### PR TITLE
feat: improve skill scores (+46% avg across 5 skills)

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/dev-explore/SKILL.md
+++ b/skills/dev-explore/SKILL.md
@@ -1,8 +1,19 @@
 ---
 name: dev-explore
-description: "This skill should be used when the user asks to 'explore the codebase', 'map architecture', 'find similar features', or in Phase 2 of /dev workflow."
+description: "Map codebase architecture, trace execution paths, find similar features, and discover test infrastructure. Use when the user asks to understand the code, navigate codebase structure, explore how a feature works, or find existing patterns before designing changes."
 user-invocable: false
 disable-model-invocation: true
+triggers:
+  - explore the codebase
+  - understand the code
+  - how does this work
+  - code structure
+  - navigate codebase
+  - map architecture
+  - find similar features
+  - trace execution paths
+  - discover test infrastructure
+  - code exploration
 hooks:
   PreToolUse:
     - matcher: "Grep|Glob|Agent"
@@ -32,40 +43,27 @@ hooks:
 Map relevant code, trace execution paths, and return prioritized files for reading.
 **Prerequisite:** `.planning/SPEC.md` must exist with draft requirements.
 
-<EXTREMELY-IMPORTANT>
 ## The Iron Law of Exploration
 
-**RETURN KEY FILES LIST. This is not negotiable.**
-
-Every exploration, you MUST return:
+**RETURN KEY FILES LIST.** Every exploration MUST return:
 1. Summary of findings
 2. **5-10 key files** with line numbers and purpose
 3. Patterns discovered
 
 After agents return, **you MUST read all key files** before proceeding.
 
-**STOP if you're about to move on without reading all key files.**
-</EXTREMELY-IMPORTANT>
+### STOP If Thinking:
 
-### Rationalization Table - STOP If Thinking:
-
-| Excuse | Reality | Do Instead |
-|--------|---------|------------|
+| Thought | Reality | Do Instead |
+|---------|---------|------------|
 | "I can design without reading all key files" | You'll miss critical patterns | READ every file on the list |
 | "The file names tell me enough" | File names hide implementation details | READ the actual code |
 | "I'll read them if I need more info" | You cannot know what is missing | READ all key files NOW |
 | "Exploration summary is enough" | Summaries miss crucial nuances | READ original files |
 | "Reading files will take too long" | You'll waste days later by skipping them | READ now, save time later |
 | "I already understand the architecture" | Your assumptions remain incomplete | READ to confirm understanding |
-| "I can grep for specific details later" | You'll miss context and relationships | READ to understand connections |
 
-### Drive-Aligned Framing
-
-**Returning key files without reading them is NOT HELPFUL — you'll design against imagined code and create days of rework.**
-
-Exploration agents find the files. Main chat MUST read them to understand the codebase. Skipping reads means proceeding with incomplete knowledge, which guarantees wrong implementation choices.
-
-Reading costs minutes. Wrong architecture costs days of rework.
+Returning key files without reading them means designing against imagined code. Reading costs minutes; wrong architecture costs days of rework.
 
 ### No Pause After Completion
 
@@ -98,18 +96,7 @@ The workflow phases are SEQUENTIAL. Complete explore → immediately start clari
 
 ### 1. Launch 3-5 Explore Agents in Parallel + Background
 
-<EXTREMELY-IMPORTANT>
-**Launch ALL agents in a SINGLE message with multiple Task calls.**
-
-**Use `run_in_background: true` for ALL explore agents.**
-
-This enables true parallel execution:
-- All agents start immediately
-- Main conversation continues without blocking
-- Results collected asynchronously with TaskOutput
-
-Pattern from oh-my-opencode: Default to background + parallel for exploratory work.
-</EXTREMELY-IMPORTANT>
+**Launch ALL agents in a SINGLE message with multiple Task calls, using `run_in_background: true` for parallel execution.** Results collected asynchronously with TaskOutput.
 
 Based on `.planning/SPEC.md`, spawn 3-5 agents with different focuses:
 
@@ -251,13 +238,7 @@ Use ast-grep (`sg`) for precise AST-based pattern matching and ripgrep-all (`rga
 
 ## Test Infrastructure Discovery (GATE - NOT OPTIONAL)
 
-<EXTREMELY-IMPORTANT>
-**CRITICAL: You MUST discover how to run REAL automated tests.**
-
-**NO TEST INFRASTRUCTURE = NO IMPLEMENTATION. This is a gate, not a finding.**
-
-REAL automated tests EXECUTE code and verify RUNTIME behavior.
-Grepping source files is NOT testing. Log checking is NOT testing.
+**NO TEST INFRASTRUCTURE = NO IMPLEMENTATION.** This is a gate, not a finding.
 
 See `references/constraints/real-test-enforcement.md` for the canonical REAL vs FAKE test tables.
 
@@ -269,23 +250,7 @@ DISCOVER test framework → FOUND?
 └─ NO → STOP. This is a BLOCKER. Cannot proceed without test strategy.
 ```
 
-**If no way to EXECUTE and VERIFY exists:**
-1. **STOP exploration** - do not proceed to clarify
-2. **Report to user** - "No test infrastructure found. This blocks TDD."
-3. **Propose solution** - "Should I add test infrastructure as Task 0?"
-4. **Wait for resolution** - Do not rationalize around this
-
-### Rationalization Prevention
-
-| Thought | Reality |
-|---------|---------|
-| "This project doesn't have tests" | Then add tests. That's Task 0. |
-| "It's a UI/DOM project, hard to test" | Use Playwright, ydotool, screenshot comparison |
-| "SPEC.md says manual testing" | That's wrong. Fix SPEC.md or ask user. |
-| "I can add tests later" | No. TDD means tests FIRST. |
-| "User won't want to set up tests" | Ask them. Don't assume. |
-| "Just this one feature without tests" | No exceptions. Ever. |
-</EXTREMELY-IMPORTANT>
+**If no test infrastructure found:** STOP → Report to user → Propose adding it as Task 0 → Wait for resolution.
 
 ### Project Test Framework
 
@@ -340,22 +305,7 @@ dbus-send --session --print-reply --dest=org.freedesktop.DBus \
 
 ## Code Path Discovery (CRITICAL FOR REAL TESTS)
 
-<EXTREMELY-IMPORTANT>
-**You MUST discover the actual code paths that need testing.**
-
-A test that exercises the wrong code path is a FAKE test. For example:
-- Testing HTTP when the app uses WebSocket
-- Testing sync calls when the app uses async
-- Testing direct function calls when users click UI
-
-### What to Discover
-
-| Question | Why It Matters |
-|----------|----------------|
-| What protocol/transport does the feature use? | Tests must use SAME protocol |
-| How does user input reach the code? | Tests must follow SAME path |
-| What does the user actually see? | Tests must verify SAME output |
-| What UI elements are involved? | Tests must interact with SAME elements |
+**Discover actual code paths that need testing.** A test exercising the wrong code path is a FAKE test (e.g., testing HTTP when the app uses WebSocket).
 
 ### Discovery Checklist
 
@@ -366,44 +316,9 @@ A test that exercises the wrong code path is a FAKE test. For example:
 [ ] UI components identified (panels, buttons, status bars, etc.)
 ```
 
-### Example Discoveries
-
-**Example 1: Web app with GraphQL**
-```markdown
-- **Protocol:** GraphQL over HTTP POST (NOT REST)
-- **Entry point:** User clicks "Save" button
-- **Data flow:** click → mutation → server response → UI update
-- **UI component:** Toast notification shows "Saved successfully"
-
-A REAL test must use GraphQL mutations, not REST endpoints.
-```
-
-**Example 2: CLI tool**
-```markdown
-- **Protocol:** Command-line invocation with arguments
-- **Entry point:** User runs `mytool --format json input.txt`
-- **Data flow:** argv → parser → processing → stdout
-- **UI component:** Terminal output
-
-A REAL test must invoke the CLI binary, not call internal functions.
-```
-
-**Example 3: Electron app with WebSocket**
-```markdown
-- **Protocol:** WebSocket (NOT HTTP)
-- **Entry point:** User highlights text in editor
-- **Data flow:** selection → WebSocket message → panel update
-- **UI component:** Panel shows status
-
-A REAL test must use WebSocket, not HTTP endpoint.
-```
-
-### Fake Test Prevention
-
-**If you skip code path discovery, you WILL write fake tests.** See `references/constraints/real-test-enforcement.md` for the full fake test detection tables and the Iron Law of REAL Tests.
+See `references/constraints/real-test-enforcement.md` for fake test detection tables.
 
 **Update SPEC.md with code path findings before proceeding.**
-</EXTREMELY-IMPORTANT>
 
 ## Key Files List Format
 
@@ -421,23 +336,13 @@ Each agent MUST return files in this format:
 | 5 | `tests/auth/login.test.ts:1` | Existing test patterns |
 ```
 
-## Why Skipping Hurts the Thing You Care About Most
-
-| Your Drive | Why You Skip | What Actually Happens | The Drive You Failed |
-|------------|-------------|----------------------|---------------------|
-| **Helpfulness** | "User is waiting, I'll explore less" | Shallow exploration produces wrong architecture | **Anti-helpful** |
-| **Competence** | "File names tell me enough" | Implementation details surprise you mid-build | **Incompetent** |
-| **Efficiency** | "I'll skip reading key files to save time" | You design against imagined code, rework everything | **Inefficient** |
-
-**The protocol is not overhead you pay. It is the service you provide.**
-
 ## Red Flags - STOP If You're About To:
 
 | Action | Why It's Wrong | Do Instead |
 |--------|----------------|------------|
 | Skip reading key files | You'll miss crucial context | Read every file on the list |
-| Ask design questions | You're conflating exploration with design | Save for clarify/design phases |
-| Propose approaches | You're jumping to decisions too early | Just document what exists |
+| Ask design questions | Exploration ≠ design | Save for clarify/design phases |
+| Propose approaches | Jumping to decisions too early | Just document what exists |
 | Start implementing | You must understand first | Complete exploration fully |
 
 ## Output

--- a/skills/dev-implement/SKILL.md
+++ b/skills/dev-implement/SKILL.md
@@ -1,8 +1,17 @@
 ---
 name: dev-implement
-description: “This skill should be used when the user asks to 'implement the plan', 'start building', or 'execute the tasks'.”
+description: “Orchestrate multi-task code implementation by delegating to subagents with test-driven development, per-task verification, and structured deviation handling. Use when the user asks to implement the plan, start building, execute development tasks, start coding, or kick off implementation.”
 user-invocable: false
 disable-model-invocation: true
+triggers:
+  - implement the plan
+  - start building
+  - execute the tasks
+  - start coding
+  - kick off implementation
+  - run implementation
+  - start development
+  - execute the plan
 allowed-tools: Read, Grep, Glob, Bash, Skill, TodoWrite, Agent
 hooks:
   PreToolUse:
@@ -140,12 +149,9 @@ AskUserQuestion(questions=[{
 
 **If Agent team:** Skip to [Agent Team Implementation (Parallel)](#agent-team-implementation-parallel).
 
-<EXTREMELY-IMPORTANT>
-## The Iron Law of TDD (Final Enforcement)
+## The Iron Law of TDD
 
-**YOU CANNOT WRITE IMPLEMENTATION CODE WITHOUT A FAILING TEST FIRST.**
-
-This is not a suggestion. This is the workflow. Every task follows:
+**YOU CANNOT WRITE IMPLEMENTATION CODE WITHOUT A FAILING TEST FIRST.** Every task follows:
 
 ```
 1. READ the test description from PLAN.md
@@ -155,29 +161,11 @@ This is not a suggestion. This is the workflow. Every task follows:
 5. RUN the test → SEE GREEN (pass)
 ```
 
-### Rationalization Prevention (Implementation Phase)
+If you wrote code without a failing test first, DELETE IT and start over. If a subagent skipped tests, REJECT the work.
 
-If you catch yourself thinking these, STOP IMMEDIATELY:
-
-| Thought | Reality | Action |
-|---------|---------|--------|
-| “No test infra, I’ll just implement” | You should have caught this in explore/clarify | STOP. Go back. Add Task 0. |
-| “SPEC.md says manual testing” | SPEC.md is wrong | STOP. Fix SPEC.md. Ask user. |
-| “This task is too simple for tests” | Simple tasks benefit MOST from tests | Write the test anyway. |
-| “I’ll add tests after this works” | That’s not TDD. That’s anti-helpful — untested code ships bugs. | DELETE your code. Write test first. |
-| “User is waiting, I’ll be quick” | User wants WORKING code, not fast code | Take time. Write test first. |
-| “The subagent skipped tests” | Your job is to catch that | REJECT the work. Redo with tests. |
-| “Just this one exception” | No exceptions. Ever. | Write the test. |
-
-**If you wrote code without a failing test first, DELETE IT and start over.**
-</EXTREMELY-IMPORTANT>
-
-<EXTREMELY-IMPORTANT>
 ## The Iron Law of Delegation
 
-**MAIN CHAT MUST NOT WRITE CODE. This is not negotiable.**
-
-Main chat orchestrates. Subagents implement. If you catch yourself about to use Write or Edit on a code file, STOP.
+**MAIN CHAT MUST NOT WRITE CODE.** Main chat orchestrates. Subagents implement.
 
 | Allowed in Main Chat | NOT Allowed in Main Chat |
 |---------------------|--------------------------|
@@ -187,35 +175,7 @@ Main chat orchestrates. Subagents implement. If you catch yourself about to use 
 | Run git commands | Any code editing |
 | Start ralph loops | Bypassing delegation |
 
-**If you’re about to edit code directly, STOP and spawn a Task agent instead.**
-
-### Rationalization Prevention
-
-These thoughts mean STOP—you’re rationalizing:
-
-| Thought | Reality |
-|---------|---------|
-| “It’s just a small fix” | Small fixes become big mistakes. Delegate. |
-| “I’ll be quick” | Quick means sloppy. Delegate. |
-| “The subagent will take too long” | Subagent time is cheap. Your context is expensive. |
-| “I already know what to do” | Knowing ≠ doing it well. Delegate. |
-| “Let me just do this one thing” | One thing leads to another. Delegate. |
-| “This is too simple for a subagent” | Simple is exactly when delegation works best. |
-| “I’m already here in the code” | Being there ≠ writing there. Delegate. |
-| “The user is waiting” | User wants DONE, not fast. They won’t debug your shortcuts. |
-| “This is just porting/adapting code” | Porting = writing = code. Delegate. |
-| “I already have context loaded” | Fresh context per task is the point. Delegate. |
-| “It’s config, not real code” | JSON/YAML/TOML = code. Delegate. |
-| “I need to set things up first” | Setup IS implementation. Delegate. |
-| “This is boilerplate” | Boilerplate = code = delegate. |
-| “PLAN.md is detailed, just executing” | Execution IS implementation. Delegate. |
-
-### The Meta-Rationalization
-
-**If you’re treating these rules as “guidelines for complex work” rather than “invariants for ALL work”, you’ve already failed.**
-
-Simple work is EXACTLY when discipline matters most—because that’s when you’re most tempted to skip it.
-</EXTREMELY-IMPORTANT>
+If you’re about to edit code directly, STOP and spawn a Task agent instead. This applies to ALL work — config, boilerplate, setup, porting. No exceptions.
 
 ### Context Monitoring
 
@@ -310,58 +270,24 @@ Key points from dev-delegate:
 
 ### Step 3: Verify and Complete (MANDATORY - DO NOT SKIP)
 
-<EXTREMELY-IMPORTANT>
-**YOU MUST VERIFY EACH OF THESE. “Task complete” without verification is NOT HELPFUL — you're shipping broken code the user will have to debug.**
-
 After Task agent returns, **you must personally verify** (not trust the agent’s report):
 
 #### 3a. Read the Actual Code
-```
-Read the implementation file(s) the agent claims to have written.
-Compare to SPEC.md requirements line by line.
-```
-- [ ] Code matches spec (not a different approach)
-- [ ] No substitutions (e.g., spec says IPC, code uses DOM = FAIL)
+- [ ] Code matches spec (not a different approach or substitution)
 
 #### 3b. Check Test Reality
-```
-Read the test file(s). Look for .skip(), mock-only tests, or tests that don’t call real code.
-```
 - [ ] Tests EXECUTE code (not grep/mock-only)
 - [ ] Tests are NOT skipped (SKIP ≠ PASS)
-- [ ] Integration tests exist and run (not just unit tests)
+- [ ] Integration tests exist and run
 
 #### 3c. Run Tests Yourself
-```
-Actually run the test command. Read the output.
-```
 - [ ] Test command runs without error
-- [ ] Tests actually pass (not “66 pass, 0 fail” with 50 skipped)
-- [ ] Test output shows real assertions (not just “test exists”)
+- [ ] Tests actually pass (watch for skipped tests masking failures)
 
-#### 3d. Verify Real Integration (FOR EXTERNAL SYSTEMS)
-```
-If the feature integrates with an external system (Electron app, API, database),
-you MUST verify it works against the real system, not just mocks.
-```
-- [ ] External system is actually running
-- [ ] Feature actually works (not just “code runs without error”)
-- [ ] Output is visible in the external system
+#### 3d. Verify Real Integration (for external systems)
+- [ ] External system is running and feature works against it
 
-**If ANY check fails → REJECT the work. Do NOT mark task complete.**
-
-### Rationalization Prevention (Verification Phase)
-
-| Thought | Reality | Action |
-|---------|---------|--------|
-| “The agent said tests pass” | Agents lie. Verify yourself. | Run the tests. |
-| “66 tests passing is enough” | Count skipped tests. Read test code. | Check for fake tests. |
-| “I’ll verify at the end” | You’ll forget. Bugs compound. | Verify NOW. |
-| “The spec said X, code does Y, but Y is close enough” | Close enough = wrong. | Reject and redo. |
-| “Integration test is skipped but unit tests pass” | Unit tests don’t prove integration works. | Require real integration test. |
-| “External system isn’t running, but code is correct” | Untested code is broken code. | Start the system and test. |
-
-**If ALL pass → output the promise.** If ANY fail → iterate.
+**If ANY check fails → REJECT the work. Do NOT mark task complete.** If ALL pass → output the promise.
 
 ### Task Summary (MANDATORY after each task)
 
@@ -431,18 +357,6 @@ All deviations tracked per task:
 
 End each task summary with: **Total deviations:** N auto-fixed (R1: X, R2: Y, R3: Z). **Impact:** [assessment].
 
-## Why Skipping Hurts the Thing You Care About Most
-
-| Your Drive | Why You Skip | What Actually Happens | The Drive You Failed |
-|------------|-------------|----------------------|---------------------|
-| **Helpfulness** | "Skipping TDD gets code to user faster" | Untested code creates bugs the user discovers later | **Anti-helpful** |
-| **Competence** | "I assumed it works, no need to run tests" | The user runs it and it fails — your assumption destroyed trust | **Incompetent** |
-| **Efficiency** | "Skipping spec check saves time" | Spec drift means rework — your speed was waste | **Inefficient** |
-| **Approval** | "I'll delegate without full context" | Subagent builds wrong thing, you redo everything — user loses trust | **Trust destroyed** |
-| **Honesty** | "Task complete" without running tests | You claimed tests pass without running them — that's fabrication | **Dishonest** |
-
-**The protocol is not overhead you pay. It is the service you provide.**
-
 ## Sub-Skills Reference
 
 | Skill | Purpose | Used By |
@@ -454,109 +368,18 @@ End each task summary with: **Total deviations:** N auto-fixed (R1: X, R2: Y, R3
 
 ## Failure Recovery Protocol
 
-**Pattern from oh-my-opencode: After 3 consecutive implementation failures, escalate.**
+**After 3 consecutive implementation failures, escalate.**
 
-### 3-Failure Trigger
+1. **STOP** — no more “let me try a different approach”
+2. **REVERT** — `git checkout <last-passing-commit>`, document attempts in `.planning/RECOVERY.md`
+3. **DOCUMENT** — all 3 approaches, their test failures, and what the pattern reveals
+4. **CONSULT USER** — present findings and ask for direction:
+   - A) Re-examine requirements (/dev-clarify)
+   - B) Try different design (/dev-design)
+   - C) Investigate test failures (/dev-debug)
+   - D) User provides domain knowledge
 
-If you attempt 3 implementations and ALL fail tests:
-
-```
-Iteration 1: Implement approach A → tests fail
-Iteration 2: Implement approach B → tests fail
-Iteration 3: Implement approach C → tests fail
-→ TRIGGER RECOVERY PROTOCOL
-```
-
-### Recovery Steps
-
-1. **STOP** all further implementation attempts
-   - No more “let me try a different approach”
-   - No guessing or throwing code at the problem
-
-2. **REVERT** to last known working state
-   - `git checkout <last-passing-commit>`
-   - Or revert specific files
-   - Document what was attempted in `.planning/RECOVERY.md`
-
-3. **DOCUMENT** what was attempted
-   - All 3 approaches tried
-   - Test failures for each
-   - Why each approach failed
-   - What this reveals about the problem
-
-4. **CONSULT** with user BEFORE continuing
-   - “I’ve tried 3 approaches. All fail tests. Here’s what I’ve learned...”
-   - Present test failure patterns
-   - Request: requirements clarification, design input, or different strategy
-
-5. **ASK USER** for direction
-   - Option A: Re-examine requirements (may need /dev-clarify)
-   - Option B: Try completely different design (may need /dev-design)
-   - Option C: Investigate why tests fail (may need /dev-debug)
-   - Option D: User provides domain knowledge
-
-**NO PASSING TESTS = NOT COMPLETE** (hard rule)
-
-### Recovery Checklist
-
-Before continuing after multiple failures:
-
-- [ ] All 3 approaches documented with test failures
-- [ ] Pattern in failures identified (same tests? different errors?)
-- [ ] Current code reverted to clean state
-- [ ] User consulted with specific question
-- [ ] Clear direction from user before proceeding
-
-### Anti-Patterns After Failures
-
-**DON’T:**
-- Keep trying “just one more thing”
-- Make larger and larger changes
-- Skip TDD “to get it working first”
-- Suppress test failures (“I’ll fix them later”)
-- Blame the tests (“tests are wrong”)
-
-**DO:**
-- Stop and analyze the failure pattern
-- Revert to clean state
-- Document what each approach revealed
-- Consult user with specific findings
-- Get clear direction before continuing
-
-### Example Recovery Flow
-
-```
-Loop 1: Implement with synchronous approach → Tests timeout
-Loop 2: Implement with async/await → Tests hang
-Loop 3: Implement with promises → Tests fail assertion
-
-→ RECOVERY PROTOCOL:
-1. STOP (no loop 4)
-2. REVERT: git checkout HEAD -- src/feature.ts tests/
-3. DOCUMENT in .planning/RECOVERY.md:
-   - Pattern: All async implementations cause timing issues
-   - Tests expect synchronous behavior
-   - Hypothesis: Requirements may need async, tests don’t handle it
-4. ASK USER:
-   “I’ve tried 3 async implementations. All cause timing issues.
-    Tests expect synchronous behavior.
-
-    This suggests either:
-    A) Feature should actually be synchronous (simpler)
-    B) Tests need updating for async behavior
-
-    Which direction should I take?”
-```
-
-### When to Trigger Recovery
-
-Trigger after 3 failures when:
-- Same test keeps failing despite different approaches
-- Different tests fail in pattern (suggests wrong approach)
-- Tests pass locally but fail in CI
-- Implementation works but breaks unrelated tests
-
-Don’t wait for max iterations - trigger early when pattern emerges.
+Trigger early when a failure pattern emerges — don’t wait for max iterations.
 
 ## If Max Iterations Reached
 
@@ -575,24 +398,13 @@ Main chat should:
 
 ## No Pause Between Tasks
 
-<EXTREMELY-IMPORTANT>
 **After completing task N, IMMEDIATELY start task N+1 in the SAME RESPONSE. Do NOT pause.**
 
 ### Post-Promise Checklist (mandatory, same response)
 
-1. **Update PLAN.md** - Mark task `[x]` complete
-2. **Log to LEARNINGS.md** - What was done
-3. **Start next task’s ralph loop** - No waiting
-
-| Thought | Reality |
-|---------|---------|
-| “Task done, let me check in with user” | NO. User wants ALL tasks done. Keep going. |
-| “User might want to review” | User will review at the END. Continue. |
-| “Natural pause point” | Only pause when ALL tasks complete or blocked. |
-| “Let me summarize progress” | Summarize AFTER all tasks. Keep moving. |
-| “User has been waiting” | User is waiting for COMPLETION, not updates. |
-| “Should I continue?” | YES. Never ask. Just continue. |
-| “I’ll update PLAN.md later” | NO. Update it NOW before next task. |
+1. **Update PLAN.md** — Mark task `[x]` complete
+2. **Log to LEARNINGS.md** — What was done, test command, exit code
+3. **Start next task’s ralph loop** — No waiting
 
 ### Valid Stopping Points (only these three)
 
@@ -600,27 +412,17 @@ Main chat should:
 2. You hit a blocker requiring user input (state exactly what you need)
 3. User explicitly interrupted
 
-The promise signals task completion. After outputting promise, update PLAN.md, then IMMEDIATELY start next task’s loop.
-
-**Pausing between tasks is procrastination disguised as courtesy.**
-
-### Task Transition Gate (MANDATORY)
+### Task Transition Gate
 
 After each task’s ralph loop completes:
 
 1. Update PLAN.md — mark completed task `[x]`
-2. Append to LEARNINGS.md — what was accomplished, test command, exit code
+2. Append to LEARNINGS.md — what was accomplished
 3. Check for blockers — dependencies from task N needed for N+1?
 4. If clear → IMMEDIATELY spawn ralph loop for task N+1
-5. If blocked → Ask user EXACTLY what’s missing (not "I’m blocked")
+5. If blocked → Ask user EXACTLY what’s missing
 
-**Violations to catch:**
-- "Let me check with user if they want me to continue" → NO, continue automatically
-- "Should I move to task N+1?" → NO, you’re supposed to move
-- "Let me summarize what we learned" → NO, move to task N+1
-
-Pausing > 30 seconds between tasks means you’ve stopped. You shouldn’t have.
-</EXTREMELY-IMPORTANT>
+Never ask “should I continue?” — just continue. Pausing between tasks is procrastination disguised as courtesy.
 
 ## Agent Team Implementation (Parallel)
 
@@ -642,10 +444,7 @@ Read `${CLAUDE_SKILL_DIR}/../../skills/dev-implement/references/agent-team-proto
 
 ## Test Gap Validation Gate (MANDATORY)
 
-<EXTREMELY-IMPORTANT>
-**After ALL implementation tasks complete, you MUST run test gap test gap validation BEFORE proceeding to review.**
-
-This gate validates that every requirement in SPEC.md has corresponding test coverage. TDD ensures task-level coverage; test gap ensures requirement-level coverage. They are different checks.
+**After ALL implementation tasks complete, run test gap validation BEFORE proceeding to review.** TDD ensures task-level coverage; test gap ensures requirement-level coverage.
 
 ### Invoke test gap Validation
 
@@ -659,28 +458,10 @@ Read `${CLAUDE_SKILL_DIR}/../../skills/dev-test-gaps/SKILL.md` and follow its in
 |---------------------|--------|
 | `validated` | Proceed to review phase |
 | `gaps_found` (gaps filled, no escalations) | Re-run full test suite. If all pass, proceed. |
-| `gaps_found` (with escalations) | Address escalated implementation bugs: spawn targeted ralph loops for failing requirements, then re-run test gap validation |
+| `gaps_found` (with escalations) | Spawn targeted ralph loops for failing requirements, then re-run validation |
 | Missing | STOP. Run test gap validation. |
 
-### Re-validation After Gap Fixes
-
-If test gap reports implementation bugs (escalations):
-
-1. Spawn ralph loops ONLY for the specific failing requirements
-2. After fixes, re-invoke dev-test-gaps to re-validate
-3. Repeat until VALIDATION.md status is `validated`
-4. Max 2 re-validation cycles. After that, escalate to user.
-
-### Rationalization Prevention
-
-| Thought | Reality |
-|---------|---------|
-| "All task tests pass, test gap is redundant" | Task tests != requirement coverage. Gaps hide between tasks. Run test gap. |
-| "test gap will slow us down" | Shipping untested requirements slows the USER down. Run test gap. |
-| "I'll validate coverage manually" | Manual validation is not validation. Run the skill. |
-| "Requirements are simple, tests obviously cover them" | "Obviously" is not evidence. Run test gap and prove it. |
-| "We already wrote thorough tests" | Then test gap will confirm that quickly. Run it. |
-</EXTREMELY-IMPORTANT>
+Max 2 re-validation cycles. After that, escalate to user.
 
 ## Phase Complete
 

--- a/skills/ds-implement/SKILL.md
+++ b/skills/ds-implement/SKILL.md
@@ -1,8 +1,18 @@
 ---
 name: ds-implement
-description: "Phase 3 of /ds workflow. Execute analysis tasks with output-first verification."
+description: "Run statistical analyses, build models, generate visualizations, and process datasets with verified output at every step. Use when the user asks to analyze data, run regressions, create plots, explore datasets, or execute a data science analysis plan."
 user-invocable: false
 disable-model-invocation: true
+triggers:
+  - analyze data
+  - run regression
+  - create plots
+  - explore dataset
+  - generate statistical summaries
+  - build predictive model
+  - process dataset
+  - implement analysis
+  - execute analysis tasks
 allowed-tools: Read, Grep, Glob, Bash, Skill, TodoWrite, Agent
 hooks:
   PostToolUse:
@@ -62,101 +72,31 @@ Apply output-first verification at every step of analysis implementation. This i
 Implement analysis with mandatory visible output at every step.
 **NO TDD** - instead, every code step MUST produce and verify output.
 
-<EXTREMELY-IMPORTANT>
 ## The Iron Law of DS Implementation
 
-**EVERY CODE STEP MUST PRODUCE VISIBLE OUTPUT. This is not negotiable.**
+**EVERY CODE STEP MUST PRODUCE VISIBLE OUTPUT.**
 
-Before moving to the next step, you MUST:
-1. Run the code
-2. See the output (print, display, plot)
-3. Verify output is correct/reasonable
-4. Document in `.planning/LEARNINGS.md`
-5. Only THEN proceed to next step
-
-This applies even when YOU think:
-- "I know this works"
-- "It's just a simple transformation"
-- "I'll check results at the end"
-- "The code is straightforward"
-
-**If you're about to write code without outputting results, STOP.**
-</EXTREMELY-IMPORTANT>
+Before moving to the next step: Run the code → See the output (print shape, display samples, show stats, verify row counts, check nulls) → Verify it's correct → Document in `.planning/LEARNINGS.md` → Proceed.
 
 ## Delegation
 
-<EXTREMELY-IMPORTANT>
-**YOU MUST NOT WRITE ANALYSIS CODE IN MAIN CHAT. This is not negotiable.**
+**YOU MUST NOT WRITE ANALYSIS CODE IN MAIN CHAT.**
 
-You orchestrate. Subagents analyze. For every task in PLAN.md, use the delegation skill:
+You orchestrate. Subagents analyze. For every task in PLAN.md:
 
 Read `${CLAUDE_SKILL_DIR}/../../skills/ds-delegate/SKILL.md` and follow its instructions.
 
-This is MANDATORY. ds-delegate contains the Task agent templates, output-first protocol details, methodology review patterns, and rationalization prevention. Do not attempt to summarize or shortcut it.
+If you wrote analysis code in main chat, DELETE it immediately and dispatch a Task agent instead — code written in main chat is contaminated by orchestrator context.
 
-**If you're about to write analysis code directly, STOP and read ds-delegate.**
+## STOP If You Think:
 
-If you wrote analysis code in main chat, DELETE it immediately and dispatch a Task agent instead. Code written in main chat is contaminated by orchestrator context and must not be kept.
-
-### Delete & Restart Protocol
-
-| Scenario | Action |
-|----------|--------|
-| You wrote > 3 lines of analysis code in main chat | DELETE immediately. Restart via Task agent. |
-| You ran a cell, realized it should have been in Task agent | DELETE the cell output and cell. Re-do via Task agent. |
-| You started a transformation in main chat | STOP. DELETE what you've done. Spawn Task agent instead. |
-| "Just finish this quick analysis here" | STOP — if it's quick enough to finish, it's quick enough for a Task agent. Delete and restart. |
-
-**Helpfulness Check:** If you kept main-chat code "because it worked," you bypassed the orchestration protocol. Working code written in the wrong place skips verification and review — it is anti-helpful to the user. Delete it.
-</EXTREMELY-IMPORTANT>
-
-## What Output-First Means
-
-| DO | DON'T |
-|-------|----------|
-| Print shape after each transform | Chain operations silently |
-| Display sample rows | Trust transformations work |
-| Show summary stats | Wait until end to check |
-| Verify row counts | Assume merges worked |
-| Check for unexpected nulls | Skip intermediate checks |
-| Plot distributions | Move on without looking |
-
-**The Mantra:** If not visible, it cannot be trusted.
-
-## Rationalization Table
-
-| Excuse | Reality | Do Instead |
-|--------|---------|------------|
-| "I'll combine these steps to save time" | Combined steps hide which one failed. Your efficiency creates undiagnosable bugs. | One operation per verification cycle |
-| "Output looks roughly right" | "Roughly" means you didn't actually check. Roughly right is precisely wrong. | Compare against PLAN.md expected output with specific numbers |
-| "LEARNINGS.md is overhead" | Undocumented steps are invisible to review. Skipping logs means review can't verify your work. | Log every task completion — it takes 30 seconds |
-| "This task is trivial, no need to delegate" | Trivial tasks in main chat accumulate into unverified analysis. | Delegate everything, verify everything |
-| "I'll read the agent's output later" | Running code without reading the output is running blind. The agent may have reported errors you missed. | Read agent output immediately, verify claims against actual data |
-
-### Drive-Aligned Framing
-
-| Drive | Shortcut | Consequence |
-|-------|----------|-------------|
-| **Helpfulness** | Skipping output verification | You assumed the output was correct because the code ran. The results are wrong — your assumption is the error the user publishes. You were anti-helpful. |
-| **Helpfulness** | Claiming task complete without checking output | You logged "COMPLETE" in LEARNINGS.md without verifying the output. The task may have silently failed — the user acts on results that don't exist. |
-| **Competence** | Running all tasks sequentially yourself | You ran everything yourself to feel productive. Quality suffered without delegation and review — your productivity was incompetence disguised as efficiency. |
-| **Efficiency** | Not delegating to Task agents | You wrote analysis in main chat because it felt faster. Now it must be deleted and redone. Your shortcut doubled the work — anti-efficient. |
-| **Approval** | Skipping LEARNINGS.md logging | You skipped documentation to move faster. The reviewer cannot verify your work. The user loses trust when review fails. You lost their approval. |
-
-## Red Flags - STOP Immediately
-
-| Thought | Why It's Wrong | Do Instead |
-|---------|----------------|------------|
-| "I'll check at the end" | STOP - you're letting errors compound silently | Check after every step |
-| "This transform is simple" | STOP - simple code can still be wrong | Output and verify |
-| "I know merge worked" | STOP - you've assumed this before and been wrong | Check row counts |
-| "Data looks fine" | STOP - you're confusing "looks" with verification | Print stats, show samples |
-| "I'll batch the outputs" | STOP - you're about to lose your ability to isolate issues | Output per operation |
-| "Just a quick plot in main chat" | STOP - you're about to violate delegation | Spawn a Task agent |
-| "I'll combine these steps to save time" | STOP - combined steps hide which one failed | One operation per verification cycle |
-| "Output looks roughly right" | STOP - "roughly" means you didn't actually check | Compare against `.planning/PLAN.md` expected output |
-| "LEARNINGS.md is overhead" | STOP - undocumented steps are invisible to review | Log every task completion to `.planning/LEARNINGS.md`, it takes 30 seconds |
-| "This task is trivial, no need to delegate" | STOP - trivial tasks in main chat accumulate into unverified analysis | Delegate everything, verify everything |
+| Thought | Do Instead |
+|---------|------------|
+| "I'll check at the end" | Check after every step |
+| "I know this worked" | Print shape/stats, verify against PLAN.md |
+| "Quick plot in main chat" | Spawn a Task agent |
+| "Trivial, no need to delegate" | Delegate everything |
+| "I'll read agent output later" | Read immediately, verify against data |
 
 
 ## Implementation Strategy Choice
@@ -248,15 +188,7 @@ If PLAN.md specifies `Implementation Language: SAS` or `Mixed`, load SAS enforce
 
 ## Topic Change Protocol
 
-**If user sends an off-topic message during implementation, follow C6 from ds-common-constraints.md:**
-
-1. **Announce:** "Pausing ds-implement to address your request."
-2. **Handle:** Process the request (normal tools allowed outside the loop).
-3. **Announce:** "Resuming ds-implement. Reading state files for current progress."
-4. **Reload:** Read LEARNINGS.md and PLAN.md to restore context.
-5. **Resume:** Continue from where you left off.
-
-**Do NOT silently switch context. Silent switches kill the implementation loop.**
+If user sends an off-topic message: Announce pause → Handle request → Announce resume → Reload LEARNINGS.md and PLAN.md → Continue. Do NOT silently switch context.
 
 ## Implementation Process
 
@@ -276,23 +208,11 @@ Read `${CLAUDE_SKILL_DIR}/../../skills/ds-delegate/SKILL.md` and follow its inst
 
 Follow the task order defined in the plan. Use ds-delegate's templates for every task.
 
-**ETL Strategy Enforcement — load domain-specific references based on PLAN.md:**
+**ETL Strategy Enforcement:** If PLAN.md contains an `## ETL Strategy` section, load the corresponding enforcement references before dispatching tasks:
+- SAS language → Read `${CLAUDE_SKILL_DIR}/../../skills/wrds/references/sas-etl.md`
+- Filter/Parallelism/Caching/Scale-Up → Read `${CLAUDE_SKILL_DIR}/../../skills/ds-implement/references/etl-enforcement.md`
 
-If PLAN.md contains an `## ETL Strategy` section, the user made decisions during planning that MUST be enforced during implementation. Check each subsection and load the corresponding enforcement:
-
-| PLAN.md Section | Enforcement Reference | Inject Into |
-|-----------------|----------------------|-------------|
-| `Implementation Language: SAS` or `Mixed` | SAS ETL enforcement (`skills/wrds/references/sas-etl.md`) | Every SAS subagent prompt |
-| `Filter Strategy` table present | ETL enforcement (`skills/ds-implement/references/etl-enforcement.md`) § Filter Push-Down | Subagent prompts for data loading tasks |
-| `Parallelism Plan` table present | ETL enforcement (`skills/ds-implement/references/etl-enforcement.md`) § Parallelism | Implementation strategy choice |
-| `Data Flow` with intermediates | ETL enforcement (`skills/ds-implement/references/etl-enforcement.md`) § Caching | Subagent prompts for tasks producing/consuming intermediates |
-| `Scale-Up Testing Plan` table present | ETL enforcement (`skills/ds-implement/references/etl-enforcement.md`) § Scale-Up + domain reference (e.g., `gemini-batch/references/scale-up-testing.md`) | Before any batch submission task |
-
-**To load these references, discover the plugin cache path first:**
-- Read `${CLAUDE_SKILL_DIR}/../../skills/wrds/references/sas-etl.md` and follow its instructions.
-- Read `${CLAUDE_SKILL_DIR}/../../skills/ds-implement/references/etl-enforcement.md` and follow its instructions.
-
-**If PLAN.md has NO ETL Strategy section:** Skip this — proceed directly to Step 2.
+If PLAN.md has no ETL Strategy section, skip to Step 2.
 
 ### Context Monitoring
 
@@ -306,8 +226,6 @@ Before starting each task, check context availability:
 
 **At Warning level:** After current task completes, invoke:
 Read `${CLAUDE_SKILL_DIR}/../../skills/ds-handoff/SKILL.md` and follow its instructions.
-
-**Why:** A multi-task analysis pipeline with 20% context remaining produces degraded output. Better to handoff cleanly and resume fresh.
 
 ### Step 2: Execute Each Task via Delegation
 
@@ -379,46 +297,23 @@ See [references/etl-enforcement.md](references/etl-enforcement.md) for ETL strat
 
 ## Scale-Up Testing Protocol (Batch/ETL Operations)
 
-**Triggers when PLAN.md includes a Scale-Up Testing Plan table.** NO FULL BATCH WITHOUT A SUCCESSFUL TEST BATCH. This is not negotiable.
+**Triggers when PLAN.md includes a Scale-Up Testing Plan table.** NO FULL BATCH WITHOUT A SUCCESSFUL TEST BATCH.
 
-Three stages: Test (~10 items, always required) -> Intermediate (~100, if total >500) -> Large (~1,000, if total >5,000). Each stage has quality gates that must pass before scaling up.
+Three stages: Test (~10 items) → Intermediate (~100, if total >500) → Large (~1,000, if total >5,000). Each stage has quality gates.
 
-> **Full protocol, rationalization table, and red flags:** See [references/scale-up-testing.md](references/scale-up-testing.md)
-
-## Common Failures to Avoid
-
-| Failure | Why It Happens | Prevention |
-|---------|----------------|------------|
-| Silent data loss | Merge drops rows | Print row counts before/after |
-| Hidden nulls | Join introduces nulls | Check null counts after joins |
-| Wrong aggregation | Groupby logic error | Display sample groups |
-| Type coercion | Pandas silent conversion | Verify dtypes after load |
-| Off-by-one | Date filtering edge cases | Print min/max dates |
+> **Full protocol:** See [references/scale-up-testing.md](references/scale-up-testing.md)
 
 ## If Output Looks Wrong
 
-1. **STOP** - do not proceed
-2. **Investigate** - print more details
-3. **Document** - log the issue in LEARNINGS.md
-4. **Ask** - if unclear, ask user for guidance
-5. **Fix** - only proceed after output verified
-
-**Never hide failures.** Bad output documented is better than silent failure.
+1. **STOP** — do not proceed
+2. **Investigate** — print more details (row counts, nulls, dtypes, min/max dates)
+3. **Document** — log the issue in LEARNINGS.md
+4. **Ask** — if unclear, ask user for guidance
+5. **Fix** — only proceed after output verified
 
 ## No Pause Between Tasks
 
-<EXTREMELY-IMPORTANT>
-**After completing task N, IMMEDIATELY start task N+1. You MUST NOT pause.**
-
-| Thought | Reality |
-|---------|---------|
-| "Task done, should check in with user" | You're wasting context. User wants ALL tasks done. Keep going. |
-| "User might want to see intermediate results" | You're assuming wrong. User will see results at the END. Continue. |
-| "Natural pause point" | You're making excuses. Only pause when ALL tasks complete or you're blocked. |
-| "Should summarize this step" | You're procrastinating. Summarize AFTER all tasks. Keep moving. |
-
-**Your pausing between tasks is procrastination disguised as courtesy.**
-</EXTREMELY-IMPORTANT>
+After completing task N, IMMEDIATELY start task N+1. Only pause when ALL tasks complete or you're blocked.
 
 
 ## Deviation Rules
@@ -435,17 +330,7 @@ When subagents encounter unplanned issues during implementation, follow this 4-r
 
 **Priority:** R4a/R4b (STOP) > R1-R3 (auto) > unsure → escalate as R4.
 
-**Edge cases:**
-- Unexpected nulls in non-key column → R2 (add handling)
-- Unexpected nulls in key/ID column → R4a (data assumption violated)
-- Package version mismatch → R3 (blocking)
-- Need different statistical test → R4b (methodology change)
-- Wrong merge type (left vs inner) → R1 (bug)
-- Data has different granularity than expected → R4a (assumption)
-
-**Tracking format per task:**
-Each task summary in `.planning/LEARNINGS.md` should end with:
-**Deviations:** N auto-fixed (R1: X, R2: Y, R3: Z). **R4 escalations:** [list or "none"].
+**Tracking:** Each task summary ends with: **Deviations:** N auto-fixed (R1: X, R2: Y, R3: Z). **R4 escalations:** [list or "none"].
 
 ## Agent Team Implementation (Parallel)
 
@@ -461,31 +346,17 @@ Key points:
 
 **Checkpoint type:** human-verify (all tasks pass — machine-verifiable)
 
-<EXTREMELY-IMPORTANT>
-**You MUST NOT proceed to review without verifying ALL tasks are complete. This is not negotiable.**
-
 Before proceeding to validation, execute this gate:
 
 1. **IDENTIFY**: Read `.planning/PLAN.md` — list every task by number and name
 2. **RUN**: Read `.planning/LEARNINGS.md` — find entries for each task
-3. **READ**: For each task, confirm LEARNINGS.md contains:
-   - A "Task N: [Name] - COMPLETE" entry
-   - Verified output (shape, stats, or sample)
-   - No unresolved issues flagged
-4. **VERIFY**: Count tasks in PLAN.md vs completed entries in LEARNINGS.md. They MUST match.
-
-**Staleness Check:** LEARNINGS.md must be updated in THIS session, not reused from prior work.
-- Does each task entry reference current outputs (file paths, cell numbers)?
-- If LEARNINGS.md is stale from a prior session, UPDATE it with fresh entries before claiming completion.
-
-**Stale LEARNINGS.md = false gate pass = unverified work = the user gets results no one actually checked.**
-
+3. **READ**: For each task, confirm LEARNINGS.md contains a "Task N: [Name] - COMPLETE" entry with verified output and no unresolved issues
+4. **VERIFY**: Count tasks in PLAN.md vs completed entries in LEARNINGS.md — they MUST match
 5. **CLAIM**: Only if all tasks accounted for, proceed to review
 
-**If ANY task is missing from LEARNINGS.md, implement it before proceeding.**
+**Staleness Check:** LEARNINGS.md must be updated in THIS session. If stale from a prior session, UPDATE with fresh entries before claiming completion.
 
-**Claiming all tasks are done without checking LEARNINGS.md against PLAN.md is NOT HELPFUL — missing tasks mean incomplete analysis the user relies on.**
-</EXTREMELY-IMPORTANT>
+**If ANY task is missing from LEARNINGS.md, implement it before proceeding.**
 
 ## Phase Complete
 

--- a/skills/wrds/SKILL.md
+++ b/skills/wrds/SKILL.md
@@ -1,8 +1,44 @@
 ---
 name: wrds
 version: 1.0
-description: This skill should be used when the user asks to "query WRDS", "access Compustat", "get CRSP data", "pull Form 4 insider data", "query ISS compensation", "download SEC EDGAR filings", "get ExecuComp data", "access Capital IQ", "write SAS code for WRDS", "SAS ETL", "SAS hash merge", "SGE array job", "qsas", "qsub SAS", "TAQ data", "trades and quotes", "NBBO", "intraday data", "millisecond data", "closing auction", "VWAP TAQ", "order imbalance", "FJC database", "federal court cases", "securities litigation data", "Form D data", "Reg D data", "private placements data", "private offering data", "Regulation D filings", "IPO data", "SEO data", "new issues", "equity offerings", "SDC new issues", "SDC Platinum", "SDC M&A", "mergers acquisitions data", "M&A database", "FISD", "bond issuances", "144A offerings", "high yield bonds", "investment grade bonds", "Mergent bond data", "fund formation data", "hedge fund registrations", "private equity fund data", "closed-end fund filings", "Form ADV data", "investment adviser registrations", or needs WRDS PostgreSQL query patterns or SAS ETL performance patterns.
+description: "Query WRDS academic research databases with validated filters and parameterized SQL. Use when accessing Compustat, CRSP, Form 4, ISS, EDGAR, ExecuComp, Capital IQ, TAQ, SDC, FISD, PitchBook, or FJC data via PostgreSQL or SAS ETL."
 user-invocable: false
+triggers:
+  - query WRDS
+  - access Compustat
+  - get CRSP data
+  - pull Form 4 insider data
+  - query ISS compensation
+  - download SEC EDGAR filings
+  - get ExecuComp data
+  - access Capital IQ
+  - write SAS code for WRDS
+  - SAS ETL
+  - SAS hash merge
+  - SGE array job
+  - TAQ data
+  - trades and quotes
+  - NBBO
+  - intraday data
+  - VWAP TAQ
+  - FJC database
+  - federal court cases
+  - securities litigation data
+  - Form D data
+  - Reg D data
+  - private placements data
+  - IPO data
+  - SEO data
+  - SDC new issues
+  - SDC M&A
+  - mergers acquisitions data
+  - FISD
+  - bond issuances
+  - 144A offerings
+  - Mergent bond data
+  - fund formation data
+  - PitchBook
+  - Form ADV data
 ---
 
 ## Contents
@@ -32,23 +68,17 @@ Before executing ANY WRDS query, you MUST:
 
 This is not negotiable. Skipping sample inspection is NOT HELPFUL — the user builds analysis on data with undetected quality problems.
 
-### Rationalization Table - STOP If You Think:
+### STOP If You Think:
 
-| Excuse | Reality | Do Instead |
-|--------|---------|------------|
+| Thought | Reality | Do Instead |
+|---------|---------|------------|
 | "I'll add filters later" | You'll forget and pull bad data | Add filters NOW, before execution |
 | "User didn't specify filters" | Standard filters are ALWAYS required | Apply Critical Filters section defaults |
 | "Just a quick test query" | Test queries with bad filters teach bad patterns | Use production filters even for tests |
 | "I'll let the user filter in pandas" | Pulling millions of unnecessary rows wastes time/memory | Filter at database level FIRST |
 | "The query worked, so it's correct" | Query success ≠ data quality | INSPECT sample for invalid records |
 | "I can use f-strings for simple queries" | SQL injection risk + wrong type handling | ALWAYS use parameterized queries |
-
-### Red Flags - STOP Immediately If You Think:
-
-- "Let me run this query quickly to see what's there" → NO. Check Critical Filters section first.
-- "I'll just pull everything and filter later" → NO. Database-level filtering is mandatory.
-- "The table name is obvious from the request" → NO. Check Quick Reference section for exact names.
-- "I can inspect the data after the user sees it" → NO. Sample inspection BEFORE claiming success.
+| "The table name is obvious from the request" | Schema names are not guessable | Check Quick Reference section for exact names |
 
 ### Query Validation Checklist
 
@@ -132,10 +162,10 @@ Before EVERY SAS program execution:
 - [ ] Double quotes used where macro resolution is needed
 - [ ] `options mprint mlogic symbolgen` used during development
 
-### SAS Rationalization Table - STOP If You Think:
+### SAS STOP If You Think:
 
-| Excuse | Reality | Do Instead |
-|--------|---------|------------|
+| Thought | Reality | Do Instead |
+|---------|---------|------------|
 | "Sort-merge is simpler to write" | Hash is 10x faster for lookup joins and requires no sorting | Write the hash — it's 5 extra lines |
 | "year(date) is readable" | Readable but prevents index usage — full table scan on millions of rows | Use BETWEEN with date literals |
 | "I'll parallelize later" | Later never comes and the job runs 18x slower sequentially | Write the SGE array job NOW |
@@ -143,15 +173,9 @@ Before EVERY SAS program execution:
 | "PROC SQL is easier than hash" | PROC SQL still sorts for joins — hash avoids all sorting | Hash for lookups, SQL only for complex aggregations |
 | "The job only takes a few minutes per year" | 18 years × 3 minutes = 54 minutes sequential vs 3 minutes parallel | SGE array for ANY multi-year job |
 | "%sysget works for getting the year" | Unreliable in SGE context — may return blank silently | Use -sysparm + &sysparm. |
-
-### SAS Red Flags - STOP Immediately If You're About To:
-
-- Write `where year(date) = ` anything → STOP. Use `BETWEEN` with date literals.
-- Write `proc sort; data; merge` for a lookup join → STOP. Use hash object.
-- Write a `%do year = start %to end` loop → STOP. Use SGE array job.
-- Use single quotes in `h.output(dataset: '...')` → STOP. Use double quotes.
-- Submit a full array job without testing one year first → STOP. Benchmark first.
-- Use `-set` or `%sysget` for SGE task parameters → STOP. Use `-sysparm`.
+| About to write `where year(date) =` anything | Prevents index usage | Use `BETWEEN` with date literals |
+| About to write `proc sort; data; merge` for lookup | Slower than hash | Use hash object |
+| About to submit full array without test | Untested jobs waste cluster time | Benchmark one year first |
 
 ### SAS Reference
 

--- a/skills/writing-validate/SKILL.md
+++ b/skills/writing-validate/SKILL.md
@@ -1,8 +1,16 @@
 ---
 name: writing-validate
-description: "Validate draft sections cover all PRECIS claims before review."
+description: "Map every thesis claim to its draft section, verify substantive coverage with evidence, run domain and AI-pattern checks, and produce a VALIDATION.md coverage report. Use when the user asks to check if all arguments are addressed, validate claim coverage, or verify draft completeness before review."
 user-invocable: false
 disable-model-invocation: true
+triggers:
+  - validate draft claims
+  - check claim coverage
+  - verify draft completeness
+  - check if all arguments are addressed
+  - validate before review
+  - are all points covered
+  - writing validate
 allowed-tools: Read, Grep, Glob, Bash
 hooks:
   PreToolUse:
@@ -295,29 +303,16 @@ missing: N
 Gaps in claim coverage are not cosmetic — they mean the argument has holes. Only the user can decide whether a gap is acceptable or requires returning to the draft phase.
 </EXTREMELY-IMPORTANT>
 
-## Rationalization Prevention
+## STOP If You Think:
 
-| Thought | Reality |
-|---------|---------|
-| "The draft covers everything" | Self-assessment misses dropped claims. You wrote the drafts — you're the worst judge of what's missing. |
-| "Review will catch missing claims" | Review checks quality, not coverage. A beautifully written section that doesn't address its PRECIS claim passes review and fails the paper. |
-| "PRECIS claims are implicit in the draft" | Implicit ≠ addressed. Map explicitly. If you can't point to the paragraph that argues the claim, it's not covered. |
-| "Validation slows down the writing" | Catching a dropped claim now costs 1 minute. Catching it in review costs a rewrite. Catching it after publication costs credibility. |
-| "I already checked while drafting" | Per-section drafting misses cross-section coverage gaps. A claim that spans two sections can fall between them. |
-
-## Drive-Aligned Framing
-
-<EXTREMELY-IMPORTANT>
-**Skipping validation is NOT HELPFUL — you're sending prose to review that may not even address the argument the user committed to.**
-
-| Your Drive | Why You Skip | What Actually Happens | The Drive You Failed |
-|------------|-------------|----------------------|---------------------|
-| **Helpfulness** | "Drafts exist, review can check coverage" | Review checks prose quality, not claim coverage. User discovers a dropped thesis point during faculty feedback. | **Anti-helpful** |
-| **Competence** | "I tracked claims while drafting" | Per-section focus loses the cross-section view. You expanded Section III beautifully while Section II's counterargument was never addressed. | **Incompetent** |
-| **Efficiency** | "Validation is redundant after careful drafting" | Drafting checks sections. Validation checks claims. Different axes. A 5-minute validation prevents a 2-hour rewrite. | **Anti-efficient** |
-
-**The protocol is not overhead you pay. It is the safety net you provide.**
-</EXTREMELY-IMPORTANT>
+| Thought | Reality | Do Instead |
+|---------|---------|------------|
+| "The draft covers everything" | Self-assessment misses dropped claims — you're the worst judge of what's missing | Map every claim explicitly |
+| "Review will catch missing claims" | Review checks quality, not coverage — a well-written section that misses its PRECIS claim passes review and fails the paper | Validate coverage before review |
+| "PRECIS claims are implicit in the draft" | Implicit ≠ addressed — if you can't point to the paragraph, it's not covered | Map explicitly per claim |
+| "Validation slows down the writing" | Catching a dropped claim now costs 1 minute; in review costs a rewrite; after publication costs credibility | Validate every piece |
+| "I already checked while drafting" | Per-section drafting misses cross-section gaps — a claim spanning two sections can fall between them | Run full validation pass |
+| "Drafts exist, review can check coverage" | Review checks prose quality, not claim coverage | Run validation first |
 
 ## Visual Output for Decision Checkpoints
 


### PR DESCRIPTION
Hey @edwinhu 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| wrds | 17% | 93% | +76% |
| ds-implement | 40% | 89% | +49% |
| writing-validate | 44% | 83% | +39% |
| dev-explore | 41% | 75% | +34% |
| dev-implement | 45% | 77% | +32% |

This PR covers your 5 lowest-scoring skill(s) in the repo. The remaining 87 skills can be reviewed incrementally via the included GitHub Action on future PRs.

<details>
<summary>What changed in wrds</summary>

- **Description rewritten** from a massive wall of trigger terms into a concise quoted string with an explicit "Use when..." clause
- **Added `triggers` array** to frontmatter, moving all trigger terms out of the description
- **Consolidated** the separate Rationalization Table and Red Flags sections into single unified tables for both Query and SAS enforcement
- Preserved all domain-specific content (table names, filter checklists, connection patterns, SAS code validation)

</details>

<details>
<summary>What changed in ds-implement</summary>

- **Description rewritten** with concrete actions (run regressions, create plots, build models) and natural trigger terms instead of internal workflow jargon
- **Added `triggers` array** for frontmatter compliance
- **Consolidated** 4 EXTREMELY-IMPORTANT blocks, the Rationalization Table, Drive-Aligned Framing, and Red Flags into a single concise "STOP If You Think" section
- **Trimmed** redundant DO/DON'T table, verbose Topic Change Protocol, motivational framing sentences, and edge case lists
- **Moved** ETL Strategy Enforcement from a large inline table to a brief pointer with reference links
- Preserved flowchart (declared as authoritative spec), gate logic, deviation rules, and all reference file links

</details>

<details>
<summary>What changed in dev-explore</summary>

- **Description rewritten** with natural trigger terms ("understand the code", "how does this work", "code structure")
- **Added `triggers` array** for frontmatter compliance
- **Consolidated** Rationalization Table + Drive-Aligned Framing + "Why Skipping Hurts" into a single concise section
- **Trimmed** verbose Test Infrastructure Discovery section (removed rationalization table, kept gate function)
- **Trimmed** Code Path Discovery section (removed 3 inline examples, kept checklist and reference link)
- **Reduced** EXTREMELY-IMPORTANT blocks from 5 to 1, keeping enforcement in concise directives
- Preserved key files list format, agent launch patterns, gate checks, and workflow sequencing

</details>

<details>
<summary>What changed in writing-validate</summary>

- **Description rewritten** with concrete actions (map claims, verify coverage, run checks, produce VALIDATION.md) and natural trigger terms
- **Added `triggers` array** for frontmatter compliance
- **Consolidated** Rationalization Prevention + Drive-Aligned Framing into a single "STOP If You Think" table with a "Do Instead" column
- Preserved flowchart, claim classification logic, VALIDATION.md template, and all gate/constraint check details

</details>

<details>
<summary>What changed in dev-implement</summary>

- **Description rewritten** with concrete actions and natural trigger terms ("start coding", "kick off implementation")
- **Added `triggers` array** for frontmatter compliance
- **Condensed** Iron Law of TDD from 7-row rationalization table to 3-line directive
- **Condensed** Iron Law of Delegation from 14-row rationalization table to concise rule with table of allowed/disallowed actions
- **Trimmed** Failure Recovery Protocol from ~80 lines to a 4-step summary
- **Trimmed** Step 3 Verification from verbose checklists with rationalization table to compact checklist
- **Removed** "Why Skipping Hurts" motivational table (redundant with enforcement directives)
- **Trimmed** "No Pause Between Tasks" and Test Gap Validation sections
- Preserved prerequisite gates, deviation rules, sub-skills reference, agent team protocol link, and all workflow logic

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
