### PR TITLE
Writing spec→plan→compile port (3rd instance) — v5.57.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.56.0"
+    "version": "5.57.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.56.0",
+      "version": "5.57.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.56.0",
+  "version": "5.57.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/docs/DESIGN-writing-spec-plan-compile.md
+++ b/docs/DESIGN-writing-spec-plan-compile.md
@@ -1,0 +1,368 @@
+# DESIGN: the `spec → plan → compiled run.js` pattern applied to the **writing** workflow
+
+Status: **DRAFT — assessment first, awaiting USER sign-off before any engine change.**
+Companions: `docs/DESIGN-ds-spec-plan-compile.md` (proven 1st instance, exit-code gate),
+`docs/DESIGN-dev-spec-plan-compile.md` (shipped 2nd instance, exit-code gate, v5.56.0/PR#8),
+`docs/ds-generalization-assessment.md` (the playbook — writing is the judgment-gate test).
+
+> The brief asked for an **honest assessment, not code**. This document's headline is a finding,
+> not a port plan: **writing is the farthest sibling, and most of the ds/dev headline win does not
+> apply to it because writing's execute layer is *already* a dynamic fan-out workflow.** What *does*
+> port is narrower, and it is mostly about the **spec** (the outline) and the **gate** (semantic),
+> not the runner.
+
+---
+
+## 0. TL;DR
+
+ds/dev replaced a **generic interpreter** (`{ds,dev}-implement.js`: an LLM "discovery" agent
+re-parsed `PLAN.md` once **per dependency level**, ran one level, then a heavyweight verifier) with a
+**deterministic compiler + a per-plan compiled `run.js`** that topo-sorts the whole DAG, runs it in
+one invocation, and gates each task on a real **exit code** via an independent probe.
+
+**Writing already did the part that mattered most.** `workflows/writing-draft.js` and
+`workflows/writing-review.js` are *already* ultracode workflows with a `discover → fan-out →
+verify → gate` shape that runs the **whole document in ONE invocation** with **genuine per-section
+parallelism**. There is no per-level round-trip to collapse, and **there is no task DAG** — writing
+sections are deliberately independent (each write-agent reads the prior/next *outline*, never a
+sibling *draft*). So the three ds/dev wins land as:
+
+| ds/dev win | Writing status |
+|---|---|
+| Kill ~N LLM-discovery round-trips → 1 topo-run | **Mostly N/A** — already 1 invocation, already flat-parallel; no DAG to topo-sort |
+| Kill the per-call LLM discovery re-parse | **Partial win** — one `Discover` LLM agent per invocation remains, and it *is* the writing form of the spec-drift mask (see §3) |
+| Cheap honest gate via real exit code | **Does NOT port as-is** — writing's gate is a **semantic judgment**, not an exit code (see §4) |
+
+The honest, high-value port for writing is therefore **three surgical moves**, not a run.js rewrite:
+
+1. **Compile the `Discover` phase** of both engines into a deterministic section-index parser
+   (`scripts/writing/writing_section_index.py`) — the writing analog of `ds_plan_table.py`. Both
+   audits find Discover ≈ 80–90% pure enumeration. This kills writing's discovery-LLM drift mask.
+2. **Harden the outline-spec + reconcile its guard** to that shared parser
+   (`writing-outline-executable-guard.py` importing it) — the assessment's explicit writing
+   follow-up ("harden writing-outline to pin a source per claim") and the close of audit gap **G2**.
+3. **Formalize `gateProbe(s)` as the SEMANTIC fork** returning `{ pass, evidence }` with
+   **numbered, specific evidence** — splitting it into a *deterministic floor* (bib-grep, claim-id,
+   repetition, prose-lint, de-ai, quote-resolution — mostly already the "Leg-1" gate) and an
+   *irreducible LLM-judgment authority* that **stays OUTSIDE run.js** (writing-review + source-verify).
+
+**What does NOT change:** brainstorm / lit-review / setup / outline stay conversational + human-gated;
+the **writing-review → writing-revise `/goal` loop stays OUTSIDE** any runner as the real correctness
+authority (for semantic gates it becomes *more* load-bearing, not foldable — assessment §"Semantic
+gates raise the stakes"). **We do NOT generate a per-project `.planning/run.js`** (§7, a real
+divergence from ds/dev worth recording for the eventual shared-core pass).
+
+---
+
+## 1. Audit findings (delegated wc-audits, 2026-06-26)
+
+Two parallel Mode-2 audits (per the delegation discipline). Full reports archived; key results:
+
+### 1.1 `writing-draft.js` + skill — baseline **8.5/10**
+Well-built TRANSFORM engine. Invariants are clean and largely structural. The 1.5-pt deduction is
+**determinism/honesty gaps**, the exact class the compile pass kills:
+- **G1 (biggest):** `fidelityOk` is *presented* like a mechanical check (ds deps-resolution) but is
+  **LLM-self-reported** — the verifier *asserts* "@bibkey exists in the bib" without grepping the
+  bib. Extracting `[@key]` from prose and grepping `bibPath` is exactly as compilable as ds
+  deps-resolution and currently isn't done. **Cleanest determinism win available.**
+- **G2:** `outlineGranular` has **no shared source-of-truth guard** — the verdict lives solely in the
+  Discover LLM; there is no `writing-outline-executable-guard.py`. ds's "one parser feeds both
+  compiler and guard" lesson is not yet applied to writing.
+- **G3:** coverage depth is **asserted, not counted** — `pointsExpanded` is a self-report; the
+  outline's bullet-groups are parseable and could ground it.
+- Discover verdict: **~90% compilable.** Pure enumeration (names, prev/next order, file paths,
+  `bibPath`, `sourcesPinned` regex). Thin residue = the *marginal* granularity judgment, which the
+  **already-mandatory `OUTLINE_REVIEWED.md = APPROVED` gate** mostly re-litigates — push it upstream;
+  catch only the *regression* (placeholder / bare-headings) mechanically.
+
+### 1.2 `writing-review.js` + review/revise skills — baseline **9.3/10**
+The layer **already separates the two halves the assessment predicts.** Leg-1 (`check-all.py` +
+de-ai-audit + bridge-repetition + prose-lint) is the deterministic probe floor that runs *before* the
+workflow; L1/L2/L3 are the irreducible semantic reviewers with evidence-rich payloads. Gaps:
+- **G3′:** `check_section_cites.py` is a **semantic gate disguised as deterministic** — its exit code
+  is reproducible-shaped but the per-claim SUPPORTED/UNSUPPORTED comes from an NLM/LLM call (PARTIAL/
+  UNCLEAR can flip run-to-run). Do **not** file it under deterministic probes.
+- **G4:** superseded reference docs still on disk (retire-the-orchestrator hygiene, like
+  dev-implement.js).
+- Discover verdict: **~80% compilable**, conditional on two upstream invariants being *hard*:
+  (a) `ACTIVE_WORKFLOW.md` always carries `style:`; (b) outlines carry `CLAIM-XX` tags. Today
+  `writing-claim-id-guard.py` only **warns**, never blocks — so (b) is not guaranteed.
+
+### 1.3 The load-bearing invariants any change MUST preserve
+From the audits (B-numbered there): closed section set from `outlines/*.md`; **document order, not
+lexical**; the **executable-spec bounce** (`outlineGranular=false` ⇒ never drafted, fixed upstream);
+**genuine parallel fan-out** (prev/next *outlines*, never sibling drafts); **pure-JS substrate gate**
+(critical+major block, minors advisory — the wc-asymptote lesson, `writing-review.js:254`);
+**selective re-run** (`onlyChecks`+`priorReviews`); **payload > pass/fail** (every issue carries
+`{severity, file:line, verbatim quote, detail}`); the **mechanical Verify stage drops fabricated
+quotes**; the **Iron Law of Re-Review**; the **Leg-1 mechanical hard gate runs BEFORE the workflow**;
+the **mandatory source-verify / de-AI passes OUTSIDE run.js**.
+
+---
+
+## 2. Mapping writing onto the ds "spec → plan → compiled run.js" model
+
+| ds/dev concept | Writing analog | Notes |
+|---|---|---|
+| **SPEC** (`SPEC.md`) | `PRECIS.md` (thesis, claims, scope, counterargs) | human-gated, conversational — unchanged |
+| **PLAN** (`PLAN.md` Task-Breakdown table) | `OUTLINE.md` + `outlines/*.md` (per-section, paragraph-granular, source-pinned) | **the spec to harden** (§3); the drafts already carry `implements: [CLAIM-XX]` frontmatter — a born traceability hook |
+| **compile** (`ds_plan_table.py` → `run.js` literal) | `writing_section_index.py` → a **data** artifact (section index), consumed by the *generic* engines | **divergence:** writing emits DATA, not code (§7) |
+| **run.js** (per-project compiled runner) | `writing-draft.js` / `writing-review.js` (**already generic dynamic workflows**) | already exist; we feed them a compiled index instead of an LLM `Discover` |
+| **task** | **section** | no inter-section deps → no DAG, no topo-sort, flat-parallel |
+| **`implementerPrompt(t)`** | the per-section **write-agent** prompt (writing-draft Transform) | already exists; unchanged in shape |
+| **`gateProbe(t)` → `{exit0, outputsPresent, tail}`** | **`gateProbe(s)` → `{pass, evidence}`** | **THE REAL FORK** (§4) — semantic, not exit-code; evidence must be numbered |
+| **adversarial layer OUTSIDE run.js** (full suite / test-gaps / dev-review) | **writing-review + source-verify + the `/goal` revise loop** | stays outside; **more** load-bearing for semantic gates |
+| **two-kinds-of-decision + stale-gate backstop** | **prose-only edit vs spec-changing editorial decision** (§5) | thesis reframe = gate-changing → edit outline + re-index |
+| **declared/dynamic PAUSE** | **R4 escalation / thesis-change** (§5) | the SEC-order reframe is the live writing R4 |
+
+**What a "gate" is in writing.** Two tiers, and conflating them is the trap:
+- a **deterministic floor** (necessary, not sufficient): bib `[@key]` resolves; `CLAIM-XX` present;
+  no fabricated quote (grep); no `[CITE-NEEDED]` left; repetition/prose-lint/de-ai thresholds. These
+  *can* be a probe-shaped `{pass, evidence}` — and mostly already are (Leg-1).
+- the **semantic authority** (sufficient): coverage adequacy, prose F/C grades, transition
+  SMOOTH/ABRUPT, thesis threading, claim-actually-supported-by-source. **Irreducibly LLM**, kept
+  OUTSIDE run.js, trusted only because the payload carries verbatim quotes + file:line.
+
+**What the probe is.** The deterministic floor above — *plus* a finding from the real repo: in
+`tender_offers` many footnotes cite a **dataset** (`data/processed/appraisal_petitions.parquet`:
+42.9%, n=58, $1.5B), not literature. **No exit code and no bib-grep verifies a number traces to a
+parquet cell** — that needs a reader that actually loads the data. So a writing `gateProbe` has a
+*third* dimension ds/dev never had — **empirical/dataset provenance** — which is **not** a mechanical
+probe; it routes to the semantic authority (a data-reading verifier) with numbered evidence. Recorded
+as a first-class finding, not forced into exit-code semantics.
+
+**Degraded mode when the dataset is remote (the real-repo case).** In `tender_offers` the parquet is
+*not local* (it lives in a remote rjds notebook), so true number→cell provenance can't run. The honest
+fallback is **prose-to-prose internal consistency** — does the draft's `42.9%` match `PRECIS.md`/
+`OUTLINE.md`'s `42.9%` — which catches **drift between draft and spec, NOT fabrication vs the data**.
+The `dataProvenance` evidence MUST label which mode it ran in (`provenance` vs `consistency-only`) so a
+green check never overstates what was verified. *(Parity sanity-checked one: draft "1,489 eligible"
+vs PRECIS "1,477" reconciles as 1,489 − 12 carve-out = 1,477 — consistent, not a discrepancy.)*
+
+---
+
+## 3. Move 1 + 2 — compile `Discover`, harden the outline-spec, reconcile the guard
+
+This is the genuinely-ports core and the highest-value work.
+
+**`scripts/writing/writing_section_index.py`** (single source of truth, mirrors `ds_plan_table.py`):
+- parses `OUTLINE.md` (`###` part order → document order, prev/next) + `outlines/*.md`
+  (`"<Name> (Outline).md"` → name) + `drafts/*.md` pairing (reuse `check_section_cites.section_slug()`);
+- extracts per section: `outlineFile`, `draftFile`, the **primary** claims (from the `## Claim →
+  Section Map`), the draft's `implements:` set, `prevName`/`nextName`, and **`sourcesPinned`**
+  (advisory, outline-based: a pandoc `[@key]` in the outline — a bare `CLAIM-XX` is a *claim id, not a
+  source*, so it does **not** count; this differs by design from a draft-body reading and gates
+  nothing — resolved spec, per the parity oracle's `sourcesPinned_AMBIGUITY` note);
+- **mechanical granularity floor:** `granular = (#bullet-groups ≥ N) ∧ (each group has ≥1 sub-point)`;
+  `false` only for placeholder (`TBA`, `develop this`, `X pgs`) or bare-headings — the *regression*
+  catch. The substantive "is each point real" judgment stays with the upstream outline reviewer.
+- **prefix-tolerant column/heading lookup** (dev's gotcha: `h == name or h.startswith(name+" ")`),
+  and **golden-tested against a REAL outline** (`tender_offers/outlines/`), not the template.
+
+**Both engines** (`writing-draft.js`, `writing-review.js`) drop their LLM `Discover` agent and consume
+this index (passed in `args`, or read via a tiny deterministic pre-step). This closes the drift mask:
+today the section enumeration is an LLM judgment that can silently disagree with what the guards think
+the section set is.
+
+### 3a. Real-repo parser constraints (tender-parity, pre-build read-only check)
+
+The parity partner stress-tested these assumptions against the live `tender_offers` repo *before* the
+parser is written, and found the convention the current engine assumes does **not** hold there — which
+is itself the **drift-mask thesis caught live**: `writing-draft.js`'s `Discover` prompt says *"each
+file named `<Name> (Outline).md`"*, yet the real outlines are named `<Name>.md`. The LLM `Discover`
+silently tolerates this; a strict deterministic parser would miss **every** outline. So the parser
+must be **tolerant** (the ds lesson) AND the emitter canonical (so new projects are born clean):
+
+- **Filename pairing is project-variable.** Accept both `<Name> (Outline).md` (canonical) and
+  `<Name>.md` (real `tender_offers`); pair to the draft `<Name> (Draft).md`. The `(Outline)` suffix in
+  this repo only exists in an **old `notes/` tree** — exclude it.
+- **Document order: `OUTLINE.md` exists and is canonical** (parity correction — it lives in
+  `paper/.planning/`, alongside the full state machine: `ACTIVE_WORKFLOW.md`, `PRECIS(_REVIEWED).md`,
+  `OUTLINE(_REVIEWED).md`, `DRAFT_COMPLETE`, `LEARNINGS.md`). Its `## Structure` block lists
+  `### Introduction / ### Part I / II / III / ### Conclusion` = exact document order. So the **primary
+  path is parse `OUTLINE.md ## Structure`**; the loud-fail heuristic (D-w-7) is **back-compat
+  fallback only**, not the main route.
+- **Unicode-safe slugs.** Part II is `… — The Two Offer-Period Channels` (em-dash) → `section_slug()`
+  must be unicode-safe (NFC normalize, keep word chars, don't choke on `—`).
+- **Claim-trace direction is the critical D-w-3 fork — there are THREE non-identical claim
+  representations; the canonical source is `OUTLINE.md ## Claim → Section Map`** (maps each claim to a
+  PRIMARY home + setup/echo, by Part numeral; claims are primary-homed only in Parts I/II/III, while
+  Intro/Conclusion are echo-only). The per-section outline tags and the draft `implements:`
+  frontmatter are *derived*, not the spec. **Guard semantics MUST be `draft.implements ⊇ {claims the
+  map assigns to that section}` — NOT equality, NOT `draft ⊆ outline`.** Either of the latter
+  **rejects Intro & Conclusion**, which legitimately survey all six claims (supersets). Getting this
+  wrong makes the blocking guard reject the real repo. *(Confirmed: all 5 drafts carry
+  `implements: [CLAIM-XX]`; Part I/II/III match their map, Intro/Concl are supersets.)*
+- **The deterministic bib-grep floor is EMPTY on 2 of 5 sections.** `[@key]` cites are a *minority*:
+  Intro 11 footnotes/**0** `[@key]`; Part I 18/8; Part II 14/**0**; Part III 19/**19**; Concl 4/14.
+  Intro & Part II are 100% Bluebook-*prose* footnotes → the deterministic source-fidelity probe
+  catches **zero** there; all fidelity falls to the semantic authority. **Slice implication:** Part
+  III (19/19) is the only section that exercises *both* gate tiers; Intro alone under-tests the
+  deterministic floor (it's a pure semantic-tier test). All 18 distinct `[@key]` resolve clean to
+  `sources.bib` → **G1 bib-grep is sound where keys exist.**
+- **`appraisal_petitions.parquet` is NOT local** (`data/` doesn't exist; `OUTLINE.md ## Figures &
+  Tables` points to a remote rjds notebook). So **D-w-4's data-provenance verifier cannot run here as
+  true provenance** — see the degraded-mode note in §4.
+
+**Harden the spec + guard (close G2, the assessment's writing follow-up):**
+- a new **`writing-outline-executable-guard.py`** imports `writing_section_index.py` and blocks
+  `OUTLINE_REVIEWED.md = APPROVED` unless every section parses (granular, claim-pinned, source-pinned
+  where the claim is substantive). "Compiles ⇔ passes the gate" becomes a property, not a hope.
+- **make `writing-claim-id-guard.py` blocking** (today it only warns — audit G1′), so `CLAIM-XX`
+  presence is guaranteed and `precisClaim` resolution is deterministic.
+- **born-canonical outline emitter:** `writing-outline` writes the canonical structure the parser
+  expects (mirrors ds-plan's canonical Task-Breakdown emitter), so the tolerant parser is a
+  back-compat shim, not a permanent crutch.
+
+**Close G1 inside writing-draft verify:** add a deterministic `[@key]`-against-`bibPath` grep to the
+fidelity step so `fidelityOk` is grounded, not asserted.
+
+---
+
+## 4. Move 3 — `gateProbe(s) → { pass, evidence }`: the semantic fork
+
+Reusing dev-refactor's seam naming (`gateProbe`, `implementerPrompt`), but **not** dev's exit-code
+shape. Writing's `gateProbe` is the judgment-gate abstraction the assessment names as the real fork:
+
+```
+gateProbe(section) → {
+  pass: boolean,             // necessary-not-sufficient: the deterministic FLOOR
+  evidence: {                // MUST be numbered/specific — the human's catch-channel
+    bibUnresolved: ["@foo 2019 @ Part-I:42"],     // grep [@key] vs bibPath (G1 fix, deterministic)
+    citeNeeded:    ["Part-I:88 'effect on minority holders'"],
+    fabricatedQuotes: [...], // grep verbatim quote vs draft (deterministic)
+    claimIdsMissing: [...],  // deterministic
+    repetition:    [{quote, locations}],           // bridge_repetition_check.py (deterministic)
+    proseLint:     [{path:line:col, category}],    // prose-lint.py (deterministic)
+    dataProvenance: ["42.9% @ Part-III:12 — unverified vs parquet"],  // EMPIRICAL — routes to a reader, NOT a probe
+  }
+}
+```
+
+**Why evidence must be numbered (the central lesson, *stronger* here):** an exit code can't lie; a
+"does this section cover its outline / cite only its sources" judge *can* be wrong or gamed. The muni
+8.8%-dedup and the hylo `readwiseSync` signature were caught by the deviation note + numbered
+payload, not the gate. For a semantic gate that funnel is the *only* safety net. So `evidence`
+carries the same specificity muni's row-counts and dev's AssertionError did. A `pass:true` with vague
+evidence is the failure mode wearing a judge's robe.
+
+**The authority stays outside.** `gateProbe.pass` (floor) is necessary; the **writing-review `/goal`
+loop + source-verify** is sufficient and authoritative. We do **not** let the semantic floor self-
+certify a draft complete — exactly as ds keeps `ds-validate-coverage` and dev keeps the full suite
+outside `run.js`.
+
+---
+
+## 5. Pauses & the two-kinds-of-decision (the live thesis-change test)
+
+Writing's editorial decisions map onto ds's two-kinds routing + stale-gate backstop:
+
+| ds/dev | Writing | Resume |
+|---|---|---|
+| **behavior-only** (winsor scope; gate unchanged) | **prose-only edit** (fix a sentence, tighten a bridge) | re-run the section; no spec edit |
+| **gate-changing** (grain/key/schema → edit Verify + recompile) | **spec-changing editorial decision** (recast a claim, reorder sections, **reframe the thesis**) | edit `OUTLINE.md`/`outlines/` + **re-index**; the draft re-blocks against the stale outline |
+| **dynamic R4 pause** (implementer can't auto-resolve) | **R4 restructuring** (already in writing-draft/revise) — and the **thesis-change** | **PAUSE**, surface numbered payload, human decides |
+
+**The stale-gate backstop, writing form:** a write-agent handed "the thesis changed" must NOT silently
+drop or rewrite an outline point to make coverage pass — it **re-blocks** and states the outline must
+be updated + re-indexed. A draft that quietly conforms to a changed thesis while the outline still
+encodes the old one is the writing analog of the forbidden silent dedup.
+
+**Live adversarial test (`tender_offers`, from tender-parity):** the **Apr 16 2026 SEC order**
+(13e-3 carve-out + competing-bid snap-back) undercut the original thesis and forced the v1→v2 reframe.
+A compiled run **must surface that as a PAUSE, never a silent edit.** This is writing's grain-pause
+fixture — the single strongest parity test, and it already happened in the real repo.
+
+**The stale APPROVED artifact (the writing analog of ds's stale `Verify`) — caught live.**
+`PRECIS_REVIEWED.md` (dated 2026-06-18, **pre-reframe**) certifies *"FIVE claims / FOUR substantive
+Parts,"* but the live reframed structure is **SIX claims / THREE Parts.** The `APPROVED` gate file is
+**stale and now lies about the document's shape.** This is exactly the failure the stale-gate backstop
+must catch: a spec-changing decision (the reframe) was honored in the *drafts* while an upstream
+APPROVED artifact still encodes the old shape. **The hardened guard (D-w-3) must detect this** — the
+section index built from the live `OUTLINE.md ## Claim → Section Map` (6 claims / 3 primary Parts) must
+**fail loudly against a `*_REVIEWED.md` that asserts a different count**, surfacing a PAUSE
+("re-approve PRECIS/OUTLINE — the approved review predates the reframe"), not silently trusting the
+stale `APPROVED`. A green gate over a stale approval is the semantic-gate version of passing on a
+clobbered artifact.
+
+---
+
+## 6. What stays OUTSIDE the runner (unchanged)
+
+brainstorm · lit-review · setup · outline (conversational, human-gated) · **writing-review.js's L1/L2/L3
+semantic reviewers** · **source-verify** (deep quote-in-source) · **`check_section_cites.py`** (NLM
+semantic gate — G3′: keep it a gate, not a "deterministic probe") · **de-ai-revise** · the
+**writing-review → writing-revise `/goal` loop** with substrate-gate exit + max-3 + REVIEW_STATE.md.
+
+---
+
+## 7. A real divergence to record for the shared-core pass (#9)
+
+ds/dev compile a **per-project `run.js` literal** because each project has a project-specific task DAG
+and project-specific `Verify` commands to inline. **Writing has neither** — its section structure is
+uniform and its runner (`writing-draft.js`/`writing-review.js`) is *generic*. So writing's "compile"
+output is best a **data artifact** (a section index) the generic runner consumes, **not generated
+code**. This is a genuine seam finding: the eventual `run-core.js` extraction should treat "compile"
+as *"produce the work-list,"* whose output may be **code (ds/dev) or data (writing)** — and
+`gateProbe` must be a domain function returning `{pass, evidence}` that spans **exit-code (ds/dev),
+mechanical-floor (writing deterministic), and judgment+empirical (writing semantic)** gates. Three
+instances now triangulate the core; do the extraction *after* writing, not as part of it.
+
+---
+
+## 8. Decisions for USER sign-off
+
+- **D-w-1 — Scope = the 3 surgical moves, NOT a per-project `run.js`.** Compile `Discover` +
+  harden the outline-spec/guard + formalize the semantic `gateProbe`. *(Recommended.)* The
+  alternative — forcing a ds-style generated `run.js` with a fake DAG — is the "don't rewrite where
+  the shape works" anti-goal.
+- **D-w-2 — `gateProbe` is two-tier: deterministic floor (probe-shaped) + semantic authority
+  (outside run.js).** Evidence numbered/specific. *(Recommended — the assessment's core directive
+  for judgment gates.)*
+- **D-w-3 — Harden the outline-spec: make `writing-claim-id-guard.py` BLOCKING and add
+  `writing-outline-executable-guard.py` importing the shared parser.** *(Recommended — closes G1/G2;
+  is the assessment's named writing follow-up.)* **Canonical claim source = `OUTLINE.md ## Claim →
+  Section Map`; guard semantics = `draft.implements ⊇ {claims mapped to that section}` (superset, NOT
+  equality, NOT `draft ⊆ outline`)** — see §3a; the wrong direction rejects the real repo's
+  Intro/Conclusion. The guard must ALSO **fail loudly when a `*_REVIEWED.md` asserts a claim/Part
+  count that disagrees with the live `OUTLINE.md`** (the stale-approval catch, §5). Risk: a blocking
+  guard could reject in-flight projects; mitigate with the born-canonical emitter + tolerant shim.
+- **D-w-4 — Empirical/dataset-provenance is a NEW gate dimension; route it to a data-reading verifier
+  in the semantic layer, do NOT force exit-code/probe semantics. When the dataset is remote (the real
+  `tender_offers` case), degrade to labeled prose-to-prose consistency** (draft-vs-PRECIS number
+  agreement) and never let the evidence overstate it as true provenance (§4 degraded mode). Also:
+  **fix the source-fidelity reviewer to handle `sources.bib` + dataset citations, not just
+  `sources.md`** (tender-parity tooling gap), and note the deterministic bib-grep floor is **empty on
+  prose-footnote sections** (Intro, Part II) — those are semantic-tier-only. *(Recommended.)*
+- **D-w-5 — Sequence:** (1) `writing_section_index.py` + golden test on `tender_offers/.planning`
+  (canonical `OUTLINE.md ## Structure` order + the `## Claim → Section Map`) and `outlines/`;
+  (2) reconcile both engines' Discover to it (parity: same section set, same verdicts);
+  (3) guard reconciliation + blocking claim-id (⊇ semantics + stale-approval catch);
+  (4) `gateProbe` two-tier + G1 bib-grep + labeled-degraded dataProvenance;
+  (5) **A/B on Part III FIRST** (19/19 `[@key]` — the only section exercising *both* gate tiers), then
+  the Introduction (pure semantic-tier); (6) thesis-change / stale-approval PAUSE fixture. **Each step
+  tested before the next; nothing ships until A/B parity holds.** *(Recommended — note this flips the
+  earlier "Intro first" order: Intro under-tests the deterministic floor.)*
+- **D-w-6 — Do NOT extract `run-core` in this pass.** Writing is the 3rd data point that *informs*
+  the later extraction (§7). *(Recommended, per the assessment.)*
+- **D-w-7 — Document-order source: parse `OUTLINE.md ## Structure` (primary — it exists and is
+  canonical in the real repo, §3a), with a loud-fail heuristic (Introduction → `Part N` by numeral →
+  Conclusion) as back-compat fallback ONLY.** *(Recommended — corrected from the earlier "no OUTLINE.md
+  → heuristic-primary" assumption.)* The tolerant filename pairing (`<Name>.md` ⇔ `<Name> (Draft).md`)
+  + unicode-safe slug (§3a) come along with this; the golden test runs against the real
+  `tender_offers/.planning` + `outlines/`, not the template.
+
+---
+
+## 9. Honest bottom line
+
+Writing is the farthest sibling and it shows: the ds/dev runner win is **already banked** (flat-
+parallel fan-out, one invocation), so copying the compiled-`run.js` machinery would add pause/DAG/
+recompile ceremony to a workflow that doesn't need it. The **real** writing port is **upstream of the
+runner** — make the **outline a machine-executable, guarded spec** (the assessment's follow-up),
+**compile away the one residual discovery-LLM** that masks drift, and **treat the gate as a two-tier
+semantic fork** whose authority stays outside the runner and whose evidence is numbered. That closes
+the two honesty gaps the audit found (G1 self-reported fidelity, G2 no shared parser/guard), respects
+"don't rewrite where the shape works," and gives the eventual shared-core extraction its third,
+most-divergent data point: a gate that is judgment + empirical, and a "compile" that emits data, not
+code.

--- a/docs/DESIGN-writing-spec-plan-compile.md
+++ b/docs/DESIGN-writing-spec-plan-compile.md
@@ -382,9 +382,26 @@ suites unaffected throughout.
   number as verified). Wired into the writing-draft skill Step 4a before the semantic source-verify
   (4b). 13/13 (`tests/writing_gate_probe_test.py`), incl. real Part III (all `[@key]` resolve;
   numbers flagged consistency-only).
-- ⏳ **NEXT (not built):** A/B on the real `tender_offers` — Part III first (both gate tiers), then
-  the Introduction (semantic-only) — vs the current `/writing-review`; the thesis-change / stale-
-  approval PAUSE fixture. Then ship.
+- ✅ **Gate-probe floor honesty (tender-parity A/B):** fixed legal-Bluebook-prose defects — statutory
+  false positive (`§ 78mm`→phantom) via token-boundary lookahead + citation-context guard; spelled-out
+  blind spot DISCLOSED (`spelledOutNotChecked` + numeric-only note) + magnitude-word normalization.
+  Probe return now carries the canonical `scope:{checked,notChecked}` (D1 contract). 23/23.
+- ✅ **PARITY PASSED (A/B on the real `tender_offers`, 2026-06-26).** Methodology: the confounded
+  current-vs-compiled double-run was REJECTED (L1/L2/L3 are non-deterministic — a verdict diff couldn't
+  be attributed to the compile change vs reviewer noise). Instead: section-set+order proven
+  deterministically (oracle diff=0); downstream review code is byte-identical between paths; the only
+  divergent variable is `precisClaim` form. **(A) focused `precisClaim` probe → BENIGN** (controlled
+  output — `precisClaimAdvanced` + argument grasp — identical across bare-ids vs prose-gloss despite
+  reviewer noise). **(B) end-to-end compiled `/writing-review`** ran CLEAN on the real 12k-word paper:
+  consumed `args.sectionIndex` (no LLM Discover), 5 sections, 22 agents, 0 unreliable, transitions+L3
+  ran, JS substrate gate computed the verdict (9C/57M/44m, `substratePass=false`) — a genuine,
+  project-aware review. Cross-validated (A)'s Part III outline-leaks. **Nuance (non-blocking):**
+  `precisClaimAdvanced` flips run-to-run (reviewer noise, NOT an ids-vs-gloss effect) and is NOT
+  gate-bearing → no ship impact; the optional `precisClaim` enrichment for echo-only sections is
+  DEFERRED (would only matter if that field is ever made gate-bearing — no speculative build).
+- ⏳ **SHIP (pending user go):** version bump 5.56.0 → 5.57.0 (minor; new scripts/hooks + engine
+  reconcile, fully back-compat), commit, push, PR, merge worktree. *(Watch for a 5.57.0 collision with
+  the wc-creator worktree; rebase to 5.58.0 if it merges first.)*
 
 ## 9. Honest bottom line
 

--- a/docs/DESIGN-writing-spec-plan-compile.md
+++ b/docs/DESIGN-writing-spec-plan-compile.md
@@ -354,6 +354,38 @@ instances now triangulate the core; do the extraction *after* writing, not as pa
 
 ---
 
+## 8b. Build status (2026-06-26, worktree `worktree-writing-spec-plan-compile`, NOT shipped)
+
+User signed off ("go for it" → "Full sequence incl. emitter synergy"). All steps tested; ds+dev
+suites unaffected throughout.
+
+- ✅ **Step 1 — `scripts/writing/writing_section_index.py`** (the deterministic Discover). 28/28
+  (`tests/writing_section_index_test.py`), **blind-oracle parity PASSED** vs `tender_offers`
+  (clean canonical match). Stale-approval catch fires live. Emits `precis/outline/bib` paths so the
+  index is a complete DATA artifact.
+- ✅ **Step 2 — engine reconciliation.** `writing-draft.js` + `writing-review.js` consume
+  `args.sectionIndex` (skip the LLM Discover), back-compat fallback retained. Both skills wired to
+  compile + pass the index. 13/13 (`tests/writing-engine-discover.test.mjs`: no-LLM path, granularity
+  bounce, back-compat).
+- ✅ **Step 3 — guards reconciled to the shared parser.** New
+  `hooks/writing-outline-executable-guard.py` (PreToolUse on `OUTLINE_REVIEWED.md`,
+  `validate = build_index().violations`; deny on ⊇/granularity, allow+warn on stale approval).
+  `writing-claim-id-guard.py` now BLOCKS drafts w/o a claim trace (warns on outlines — incremental).
+  12/12 (`tests/writing_guards_test.py`).
+- ✅ **Emitter synergy (born-canonical, the first instance to close the ds/dev emitter gap).**
+  `writing-setup` OUTLINE.md template now emits the canonical `## Structure` (headings = filename
+  stems) + `## Claim → Section Map`; `writing-outline` emits `implements: [CLAIM-XX]` frontmatter +
+  a pinned source per claim. Tolerant parser is now a back-compat shim, not the primary path.
+- ✅ **Step 4 — two-tier `gateProbe` deterministic floor** (`scripts/writing/writing_gate_probe.py`,
+  closes audit G1). `{pass, evidence}`: bib-grep (`[@key]` vs `sources.bib`), `[CITE-NEEDED]`, claim
+  trace; `dataProvenance` in **labeled consistency-only mode** (never overstates a remote-dataset
+  number as verified). Wired into the writing-draft skill Step 4a before the semantic source-verify
+  (4b). 13/13 (`tests/writing_gate_probe_test.py`), incl. real Part III (all `[@key]` resolve;
+  numbers flagged consistency-only).
+- ⏳ **NEXT (not built):** A/B on the real `tender_offers` — Part III first (both gate tiers), then
+  the Introduction (semantic-only) — vs the current `/writing-review`; the thesis-change / stale-
+  approval PAUSE fixture. Then ship.
+
 ## 9. Honest bottom line
 
 Writing is the farthest sibling and it shows: the ds/dev runner win is **already banked** (flat-

--- a/hooks/writing-claim-id-guard.py
+++ b/hooks/writing-claim-id-guard.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env -S uv run python3
 """
-PostToolUse hook: Check that written outline/draft files reference CLAIM-XX IDs.
+PostToolUse hook: enforce CLAIM-XX traceability on written outline/draft files.
 
-Fires after Write to outlines/ or drafts/ directories. Warns if no CLAIM-XX IDs found
-in the written content — claims must be traceable through all artifacts.
+Claims must be traceable through every artifact so the deterministic section index
+(scripts/writing/writing_section_index.py) can resolve each section's claims and run the ⊇
+gate (draft.implements ⊇ the OUTLINE.md Claim→Section Map's primary claims).
+
+Enforcement is SCOPED to avoid false positives on incremental work (the in-flight-project
+risk flagged in DESIGN D-w-3):
+  - drafts/  → BLOCK on zero CLAIM-XX. A finished prose draft with no claim trace cannot be
+    indexed and would fail the ⊇ gate anyway; drafts are not built point-by-point.
+  - outlines/ → WARN only. Outlines are written subsection-by-subsection; the COMPREHENSIVE
+    hard gate is hooks/writing-outline-executable-guard.py (PreToolUse on OUTLINE_REVIEWED.md).
+Only enforced inside a writing PROJECT (a .planning/ dir present).
 """
 import json
 import os
@@ -12,6 +21,10 @@ import sys
 from pathlib import Path
 
 CLAIM_PATTERN = re.compile(r'CLAIM-\d+')
+
+
+def _in_writing_project(p: Path) -> bool:
+    return any((parent / ".planning").is_dir() for parent in p.parents)
 
 
 def main():
@@ -52,17 +65,31 @@ def main():
     claims = CLAIM_PATTERN.findall(content)
     artifact_type = "outline" if is_outline else "draft"
 
-    if not claims:
-        print(json.dumps({
-            "result": "continue",
-            "message": (
-                f"No CLAIM-XX IDs found in {artifact_type} file: {file_path}\n"
-                f"Every {artifact_type} must reference the PRECIS claims it covers.\n"
-                f"Add 'Implements: [CLAIM-XX]' or 'Claim Supported: CLAIM-XX' lines."
-            )
-        }))
-    else:
+    if claims:
         print(json.dumps({"result": "continue"}))
+        return
+
+    remedy = (
+        f"No CLAIM-XX IDs found in {artifact_type} file: {file_path}\n"
+        f"Every {artifact_type} must reference the PRECIS claims it covers.\n"
+        f"Add 'implements: [CLAIM-XX]' frontmatter (or a 'Claim Supported: CLAIM-XX' line)."
+    )
+
+    # A finished DRAFT with no claim trace is unambiguous → BLOCK (only inside a project).
+    if is_draft and _in_writing_project(p):
+        print(json.dumps({
+            "decision": "block",
+            "reason": remedy + (
+                "\n\nThis draft cannot be indexed (its implements set is empty), so it would "
+                "fail the section-index ⊇ gate (draft.implements must ⊇ the OUTLINE.md "
+                "Claim → Section Map's primary claims for this section). Add the implements "
+                "frontmatter, then continue."
+            ),
+        }))
+        return
+
+    # Outlines (or non-project files) → warn only; the outline-executable guard hard-gates at approval.
+    print(json.dumps({"result": "continue", "message": remedy}))
 
 
 if __name__ == '__main__':

--- a/hooks/writing-outline-executable-guard.py
+++ b/hooks/writing-outline-executable-guard.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env -S uv run python3
+"""
+PreToolUse hook: block OUTLINE_REVIEWED.md = APPROVED unless the writing outline-spec is
+machine-executable — i.e. scripts/writing/writing_section_index.py parses it clean.
+
+This is the writing analog of ds/dev's *-plan-executable-guard: the SAME shared parser the
+two writing engines (writing-draft.js, writing-review.js) consume also gates approval, so
+"the index compiles" ⇔ "the outline passes the gate" — they cannot drift. The parser is the
+single source of truth for the document's section set, document order, file pairing, and the
+claim→section mapping.
+
+What it blocks on (from build_index().violations):
+  - a section with no outline file (tolerant pairing already tried '<Name>.md' + '(Outline).md')
+  - a non-granular outline (placeholder "TBA"/"develop this", or bare headings)
+  - a section whose draft.implements is MISSING a primary claim the OUTLINE.md
+    `## Claim → Section Map` assigns to it (the ⊇ gate — superset, NOT equality, so
+    Intro/Conclusion supersets are fine; a Part dropping its primary claim is not)
+
+It ALSO surfaces (non-blocking warning) staleApproval: a *_REVIEWED.md whose claim/Part count
+disagrees with the live OUTLINE.md (the stale-approved-artifact catch — e.g. a thesis reframe
+left PRECIS_REVIEWED.md asserting the old shape). That is a re-approve prompt, not a hard block,
+because the very act being gated is re-approval.
+
+CLI:  uv run python3 writing-outline-executable-guard.py /abs/project   # lint mode (exit 1 if bad)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "writing"))
+from writing_section_index import build_index  # noqa: E402
+
+
+def validate(project_or_planning: Path):
+    res = build_index(project_or_planning)
+    return res.violations, res.stale_approval
+
+
+def deny(reason: str):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+    sys.exit(0)
+
+
+def main():
+    # CLI lint mode
+    if len(sys.argv) > 1 and sys.argv[1] not in ("-",):
+        violations, stale = validate(Path(sys.argv[1]))
+        if stale:
+            print("STALE APPROVAL (re-approve PRECIS/OUTLINE):\n- " + "\n- ".join(stale))
+        if violations:
+            print("OUTLINE NOT EXECUTABLE:\n- " + "\n- ".join(violations))
+            sys.exit(1)
+        print("Outline-spec executable: every section parses, granular, and claim-pinned (⊇).")
+        sys.exit(0)
+
+    try:
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    if hook_input.get("tool_name", "") not in ("Write", "Edit"):
+        sys.exit(0)
+    file_path = hook_input.get("tool_input", {}).get("file_path", "")
+    if not file_path or not file_path.endswith("OUTLINE_REVIEWED.md"):
+        sys.exit(0)
+
+    # OUTLINE_REVIEWED.md lives in .planning/; the project root is its grandparent.
+    planning = Path(file_path).parent
+    violations, stale = validate(planning)
+
+    if violations:
+        msg = (
+            "GATE BLOCKED: the writing outline-spec is not machine-executable, so it "
+            "cannot be approved for drafting/review.\n\n"
+            "Problems (from scripts/writing/writing_section_index.py):\n- "
+            + "\n- ".join(violations) + "\n\n"
+            "Both writing engines build the section set from this index (document order "
+            "from OUTLINE.md ## Structure; the claim→section map; tolerant outline/draft "
+            "pairing). Fix the outline(s) in writing-outline — give each section a "
+            "paragraph-granular outline, pair its draft, and ensure each draft's "
+            "`implements: [CLAIM-XX]` covers the primary claims the `## Claim → Section "
+            "Map` assigns it — then re-run the outline reviewer."
+        )
+        if stale:
+            msg += "\n\nALSO (stale approval — fix while you are here):\n- " + "\n- ".join(stale)
+        deny(msg)
+
+    # Outline executable but a prior approval is stale → warn, do not block (re-approval is the fix).
+    if stale:
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": (
+                "Outline-spec is executable. NOTE — a prior review artifact is stale vs the "
+                "live OUTLINE.md (re-approve to clear):\n- " + "\n- ".join(stale)),
+        }}))
+        sys.exit(0)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/writing/writing_gate_probe.py
+++ b/scripts/writing/writing_gate_probe.py
@@ -138,10 +138,30 @@ def probe(draft_path: Path, bib_path: Path | None, precis_path: Path | None,
         }
 
     floor_fail = bool(evidence.get("bibUnresolved") or evidence.get("citeNeeded") or evidence.get("claimIdsMissing"))
+    # SCOPE (canonical gateProbe contract): a deterministic floor must DISCLOSE its boundary —
+    # a clean pass must never imply coverage it doesn't have. `checked` is what a green pass
+    # actually verifies; `notChecked` is what it CANNOT and is deferred to the semantic authority
+    # (writing-review + source-verify) — so necessary-not-sufficient says WHERE the line is.
+    scope = {
+        "checked": [
+            "bib-resolution ([@key] → sources.bib)" if bib_path and bib_path.is_file() else "bib-resolution (SKIPPED — no bib provided)",
+            "cite-needed-markers",
+            "claim-id-trace",
+        ] + (["numeric-consistency-vs-PRECIS/OUTLINE (NOT dataset provenance)"] if spec_text else []),
+        "notChecked": [
+            "quote-in-source fidelity (→ source-verify)",
+            "claim-actually-supported-by-source (→ writing-review/source-verify)",
+            "coverage / prose-quality / transitions / thesis (→ writing-review)",
+            "spelled-out quantities (numeric scan is digit-only)",
+            "dataset provenance (number→cell; dataset is remote/absent)",
+        ],
+    }
     return {
         "section": draft_path.stem,
         "pass": not floor_fail,                # necessary-not-sufficient: the semantic authority decides sufficiency
+        "artifactsPresent": draft_path.is_file(),
         "evidence": evidence,
+        "scope": scope,
         "citesChecked": len(cited),
         "claims": claims,
     }

--- a/scripts/writing/writing_gate_probe.py
+++ b/scripts/writing/writing_gate_probe.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env -S uv run python3
+"""
+The DETERMINISTIC FLOOR of writing's two-tier gateProbe (DESIGN §4).
+
+Writing's gate is a SEMANTIC judgment (coverage, prose quality, transitions, claim-actually-
+supported) and that judgment stays OUTSIDE any runner as the real authority (writing-review +
+source-verify). But part of "did this section pass" IS mechanically checkable, and an LLM that
+self-reports it can be wrong or gamed (audit G1: writing-draft's fidelityOk *asserts* "@bibkey
+exists" without grepping the bib). This script is that mechanical floor, returning
+{pass, evidence} with NUMBERED, SPECIFIC evidence — necessary, NOT sufficient.
+
+It is the writing analog of ds/dev's exit-code probe, except:
+  - it returns {pass, evidence}, not {exit0} — the gate is judgment, the floor is mechanical;
+  - evidence MUST be specific (file:line, the offending key/number) — for a semantic gate the
+    payload IS the human's catch-channel (the muni-row-count / hylo-AssertionError lesson);
+  - dataProvenance degrades to LABELED prose-vs-PRECIS consistency when the dataset is remote
+    (the tender_offers case) — it NEVER claims true number→cell provenance it cannot run.
+
+Checks (all deterministic):
+  - bibUnresolved   : [@key] cited in the draft with no entry in sources.bib  (closes G1)
+  - citeNeeded      : unresolved [CITE-NEEDED] markers left in the prose
+  - claimIdsMissing : the draft carries no implements: / CLAIM-XX trace
+  - dataProvenance  : numbers in the draft not found in PRECIS/OUTLINE (mode: consistency-only
+                      when no local dataset; labeled so a green check never overstates)
+Repetition (bridge_repetition_check.py) and prose-lint (prose-lint.py) are separate Leg-1
+scripts the skill already runs; this floor references them rather than duplicating.
+
+pass = no bibUnresolved AND no citeNeeded AND not claimIdsMissing. dataProvenance is advisory
+(consistency-only locally) and does NOT flip pass.
+
+CLI:  uv run python3 writing_gate_probe.py <draft.md> --bib <sources.bib> [--precis <PRECIS.md>]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_BIBKEY_DEF = re.compile(r"@\w+\s*\{\s*([^,\s]+)", re.M)        # @article{key,
+_CITE_IN_PROSE = re.compile(r"\[@([\w:-]+)")                     # [@key] or [@key, @key2]
+_EXTRA_CITES = re.compile(r"@([A-Za-z][\w:-]+)")                # bare @key inside a [@a; @b] group
+_CITE_NEEDED = re.compile(r"\[CITE-NEEDED[^\]]*\]", re.I)
+_CLAIM = re.compile(r"CLAIM-\d+")
+# numbers that look like reported statistics: 42.9%, $1.5B, n=58, 1,477
+_STAT = re.compile(r"(?<![\w.])(?:\$?\d[\d,]*(?:\.\d+)?\s*(?:%|B|M|bn|mn)?|n\s*=\s*\d[\d,]*)", re.I)
+
+
+def _bib_keys(bib_path: Path) -> set[str]:
+    if not bib_path or not bib_path.is_file():
+        return set()
+    return set(_BIBKEY_DEF.findall(bib_path.read_text(encoding="utf-8", errors="ignore")))
+
+
+def _draft_cites(text: str) -> set[str]:
+    keys = set()
+    # capture every @key inside bracketed pandoc groups [@a2020; @b2021, p. 3]
+    for grp in re.findall(r"\[([^\]]*@[^\]]+)\]", text):
+        keys.update(_EXTRA_CITES.findall(grp))
+    return keys
+
+
+def _line_of(text: str, needle: str) -> int:
+    idx = text.find(needle)
+    return text.count("\n", 0, idx) + 1 if idx >= 0 else 0
+
+
+def _norm_num(s: str) -> str:
+    return re.sub(r"[\s,]", "", s).lower().rstrip(".")
+
+
+def probe(draft_path: Path, bib_path: Path | None, precis_path: Path | None,
+          outline_path: Path | None = None) -> dict:
+    text = draft_path.read_text(encoding="utf-8", errors="ignore")
+    evidence: dict = {}
+
+    # 1. bibUnresolved (G1)
+    bib = _bib_keys(bib_path) if bib_path else set()
+    cited = _draft_cites(text)
+    if bib_path and bib_path.is_file():
+        unresolved = sorted(k for k in cited if k not in bib)
+        if unresolved:
+            evidence["bibUnresolved"] = [f"@{k} @ {draft_path.name}:{_line_of(text, '@' + k)}" for k in unresolved]
+    elif cited:
+        evidence["bibNote"] = [f"no bib provided; {len(cited)} [@key] cite(s) unchecked"]
+
+    # 2. citeNeeded
+    needed = _CITE_NEEDED.findall(text)
+    if needed:
+        evidence["citeNeeded"] = [f"{m} @ {draft_path.name}:{_line_of(text, m)}" for m in needed]
+
+    # 3. claimIdsMissing
+    claims = sorted(set(_CLAIM.findall(text)))
+    if not claims:
+        evidence["claimIdsMissing"] = [f"{draft_path.name}: no CLAIM-XX / implements: trace"]
+
+    # 4. dataProvenance (degraded: consistency-only vs PRECIS/OUTLINE when no local dataset)
+    spec_text = ""
+    for p in (precis_path, outline_path):
+        if p and p.is_file():
+            spec_text += "\n" + p.read_text(encoding="utf-8", errors="ignore")
+    if spec_text:
+        spec_nums = {_norm_num(m) for m in _STAT.findall(spec_text)}
+        draft_nums = [(m, _line_of(text, m)) for m in _STAT.findall(text)]
+        # only flag "rich" stats (a % / $ / n=) to avoid footnote numbers etc.
+        rich = [(m, ln) for m, ln in draft_nums if re.search(r"[%$]|n\s*=|B\b|M\b", m, re.I)]
+        unmatched = [f"{m} @ {draft_path.name}:{ln}" for m, ln in rich if _norm_num(m) not in spec_nums]
+        evidence["dataProvenance"] = {
+            "mode": "consistency-only",  # NOT true number→cell provenance (no local dataset)
+            "unmatchedVsSpec": unmatched,
+            "note": "consistency vs PRECIS/OUTLINE only — does NOT verify against the dataset; "
+                    "a remote/absent parquet means these numbers are unverifiable locally.",
+        }
+
+    floor_fail = bool(evidence.get("bibUnresolved") or evidence.get("citeNeeded") or evidence.get("claimIdsMissing"))
+    return {
+        "section": draft_path.stem,
+        "pass": not floor_fail,                # necessary-not-sufficient: the semantic authority decides sufficiency
+        "evidence": evidence,
+        "citesChecked": len(cited),
+        "claims": claims,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("draft")
+    ap.add_argument("--bib", default="")
+    ap.add_argument("--precis", default="")
+    ap.add_argument("--outline", default="")
+    a = ap.parse_args()
+    res = probe(Path(a.draft),
+                Path(a.bib) if a.bib else None,
+                Path(a.precis) if a.precis else None,
+                Path(a.outline) if a.outline else None)
+    print(json.dumps(res, indent=2, ensure_ascii=False))
+    return 0 if res["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/writing/writing_gate_probe.py
+++ b/scripts/writing/writing_gate_probe.py
@@ -43,8 +43,16 @@ _CITE_IN_PROSE = re.compile(r"\[@([\w:-]+)")                     # [@key] or [@k
 _EXTRA_CITES = re.compile(r"@([A-Za-z][\w:-]+)")                # bare @key inside a [@a; @b] group
 _CITE_NEEDED = re.compile(r"\[CITE-NEEDED[^\]]*\]", re.I)
 _CLAIM = re.compile(r"CLAIM-\d+")
-# numbers that look like reported statistics: 42.9%, $1.5B, n=58, 1,477
-_STAT = re.compile(r"(?<![\w.])(?:\$?\d[\d,]*(?:\.\d+)?\s*(?:%|B|M|bn|mn)?|n\s*=\s*\d[\d,]*)", re.I)
+# numbers that look like reported statistics: 42.9%, $1.5B, n=58, 1,477.
+# The trailing (?![A-Za-z]) stops a number being clipped out of an alphanumeric LEGAL token
+# (e.g. "§ 78mm" → no longer yields a phantom "78m"; "251(h)" → "251" only, never flagged
+# because it isn't a rich stat). See _looks_legal for the citation-context guard.
+_STAT = re.compile(r"(?<![\w.])(?:\$?\d[\d,]*(?:\.\d+)?\s*(?:%|billion|million|thousand|bn|mn|B|M)?(?![A-Za-z])|n\s*=\s*\d[\d,]*)", re.I)
+# a statutory/citation context immediately before a number → it is a legal cite, not a datum
+_LEGAL_CTX = re.compile(r"(§|U\.?S\.?C\.?|C\.?F\.?R\.?|Rule|DGCL|No\.|art\.|§§)\s*$", re.I)
+# spelled-out quantities legal prose uses ("forty-five percent", "fifty-eight petitions"); the
+# numeric _STAT is structurally blind to these — we DISCLOSE that rather than silently miss them.
+_SPELLED = re.compile(r"\b(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|hundred)[\w-]*\s+(percent|petitions?|deals?|days?|cases?|funds?)\b", re.I)
 
 
 def _bib_keys(bib_path: Path) -> set[str]:
@@ -67,7 +75,11 @@ def _line_of(text: str, needle: str) -> int:
 
 
 def _norm_num(s: str) -> str:
-    return re.sub(r"[\s,]", "", s).lower().rstrip(".")
+    s = re.sub(r"[\s,]", "", s).lower().rstrip(".")
+    # equate magnitude words with their letter suffix so "$1.5billion" == "$1.5B" == "$1.5bn"
+    for long, short in (("billion", "b"), ("million", "m"), ("thousand", "k"), ("bn", "b"), ("mn", "m")):
+        s = s.replace(long, short)
+    return s
 
 
 def probe(draft_path: Path, bib_path: Path | None, precis_path: Path | None,
@@ -102,15 +114,27 @@ def probe(draft_path: Path, bib_path: Path | None, precis_path: Path | None,
             spec_text += "\n" + p.read_text(encoding="utf-8", errors="ignore")
     if spec_text:
         spec_nums = {_norm_num(m) for m in _STAT.findall(spec_text)}
-        draft_nums = [(m, _line_of(text, m)) for m in _STAT.findall(text)]
-        # only flag "rich" stats (a % / $ / n=) to avoid footnote numbers etc.
-        rich = [(m, ln) for m, ln in draft_nums if re.search(r"[%$]|n\s*=|B\b|M\b", m, re.I)]
-        unmatched = [f"{m} @ {draft_path.name}:{ln}" for m, ln in rich if _norm_num(m) not in spec_nums]
+        rich = []
+        for m in _STAT.finditer(text):
+            tok = m.group(0)
+            # only flag "rich" stats (a % / $ / n= / B/M magnitude) — bare footnote numbers are noise
+            if not re.search(r"[%$]|n\s*=|B\b|M\b", tok, re.I):
+                continue
+            # skip statutory/citation numbers ("§ 78mm", "Rule 14e-1", "17 C.F.R. § 240") — not data
+            if _LEGAL_CTX.search(text[max(0, m.start() - 12):m.start()]):
+                continue
+            rich.append((tok, text.count("\n", 0, m.start()) + 1))
+        unmatched = [f"{tok} @ {draft_path.name}:{ln}" for tok, ln in rich if _norm_num(tok) not in spec_nums]
+        spelled = sorted({s.group(0) for s in _SPELLED.finditer(text)})
         evidence["dataProvenance"] = {
             "mode": "consistency-only",  # NOT true number→cell provenance (no local dataset)
             "unmatchedVsSpec": unmatched,
-            "note": "consistency vs PRECIS/OUTLINE only — does NOT verify against the dataset; "
-                    "a remote/absent parquet means these numbers are unverifiable locally.",
+            # BLIND-SPOT DISCLOSURE: the numeric scan cannot see spelled-out quantities legal prose
+            # uses; list them so a clean dataProvenance never implies they were checked.
+            "spelledOutNotChecked": spelled,
+            "note": "consistency vs PRECIS/OUTLINE only, NUMERIC ONLY — does NOT verify against the "
+                    "dataset, and does NOT check spelled-out quantities (see spelledOutNotChecked). "
+                    "A remote/absent dataset means these numbers are unverifiable locally.",
         }
 
     floor_fail = bool(evidence.get("bibUnresolved") or evidence.get("citeNeeded") or evidence.get("claimIdsMissing"))

--- a/scripts/writing/writing_section_index.py
+++ b/scripts/writing/writing_section_index.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env -S uv run python3
+"""
+Shared, tolerant parser for the writing workflow's section index.
+
+This is the deterministic replacement for the per-invocation LLM `Discover` agent in
+workflows/writing-draft.js and workflows/writing-review.js. The section set, document
+order, file pairing, and per-section claim assignment are all regex-parseable from the
+approved planning artifacts; the only reason an LLM was ever used is that it tolerated
+format drift a strict parser would reject (e.g. real outlines are named "<Name>.md",
+not the documented "<Name> (Outline).md" — see DESIGN §3a, the drift-mask thesis).
+
+Single source of truth for "what the document's sections are." Imported by:
+  - scripts/writing/writing_compile.py            (feeds the engines a section index)
+  - hooks/writing-outline-executable-guard.py     (validates at OUTLINE_REVIEWED approval)
+so the engines and the guard can never disagree about the section set.
+
+Canonical inputs (all under <project>/.planning unless noted):
+  - OUTLINE.md  `## Structure`  → document order (### Section headings)
+  - OUTLINE.md  `## Claim → Section Map`  → the PRIMARY claim home per section (the spec)
+  - ACTIVE_WORKFLOW.md  `style:`  → legal | econ | general
+  - <project>/outlines/<Name>.md      (tolerant: also "<Name> (Outline).md")
+  - <project>/drafts/<Name> (Draft).md  (frontmatter `implements: [CLAIM-XX, ...]`)
+
+Guard semantics (DESIGN D-w-3): draft.implements ⊇ {claims the map assigns to that
+section}. NOT equality, NOT draft ⊆ outline — Intro/Conclusion legitimately survey all
+claims (supersets) and the lead Parts carry their primary claims plus setup claims.
+
+CLI:  uv run python3 writing_section_index.py /abs/project/.planning   # pretty-print
+      (pass the project root OR its .planning dir; both work)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# A claim token anywhere: CLAIM-01, CLAIM-6 …  (canonicalised to zero-padded CLAIM-NN)
+_CLAIM_RE = re.compile(r"CLAIM-(\d+)", re.I)
+# A pandoc cite key in prose: [@foo2019], @foo2019
+_CITEKEY_RE = re.compile(r"@([A-Za-z][\w:-]+)")
+# A Part heading's roman numeral: "Part II. ..." / "Part III ..." → II / III
+_PART_ROMAN_RE = re.compile(r"^Part\s+([IVXLC]+)\b", re.I)
+# Placeholder / structureless markers that bounce an outline back to writing-outline
+_PLACEHOLDER_RE = re.compile(r"\b(TBA|TBD|develop this|to be (written|drafted)|\d+\s*pgs?)\b", re.I)
+
+
+def _canon_claim(num: str) -> str:
+    return f"CLAIM-{int(num):02d}"
+
+
+def claims_in(text: str) -> set[str]:
+    return {_canon_claim(m.group(1)) for m in _CLAIM_RE.finditer(text)}
+
+
+def section_slug(name: str) -> str:
+    """Unicode-safe slug. NFC-normalise (em-dash survives as a separator), collapse
+    whitespace+punctuation to single dashes. Mirrors check_section_cites.section_slug."""
+    s = unicodedata.normalize("NFC", name).strip()
+    s = re.sub(r"\s*\(Outline\)\s*$", "", s)
+    s = re.sub(r"\s*\(Draft\)\s*$", "", s)
+    s = re.sub(r"[^\w]+", "-", s, flags=re.UNICODE).strip("-")
+    return s
+
+
+@dataclass
+class Section:
+    name: str
+    order: int
+    outline_file: str | None        # absolute path, or None if missing
+    draft_file: str | None          # absolute path, or None if missing
+    primary_claims: list[str]       # from OUTLINE.md ## Claim → Section Map (the spec)
+    implements: list[str]           # from the draft frontmatter (derived)
+    sources_pinned: bool            # informational: does the outline pin [@key]/CLAIM-XX?
+    granular: bool                  # mechanical floor: not a placeholder/bare-headings outline
+    granularity_note: str           # why not granular, if applicable
+    prev_name: str                  # "" at the ends
+    next_name: str
+    claim_ok: bool                  # draft.implements ⊇ primary_claims (the D-w-3 gate)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name, "order": self.order,
+            "outlineFile": self.outline_file, "draftFile": self.draft_file,
+            "primaryClaims": self.primary_claims, "implements": self.implements,
+            "sourcesPinned": self.sources_pinned, "granular": self.granular,
+            "granularityNote": self.granularity_note,
+            "prevName": self.prev_name, "nextName": self.next_name,
+            "claimOk": self.claim_ok,
+        }
+
+
+@dataclass
+class IndexResult:
+    sections: list[Section] = field(default_factory=list)
+    style: str = "unspecified"
+    precis_path: str = ""            # absolute .planning/PRECIS.md, or "" if absent
+    outline_path: str = ""           # absolute .planning/OUTLINE.md
+    bib_path: str = ""               # absolute references/sources.bib (or any *.bib), or "" if none
+    violations: list[str] = field(default_factory=list)
+    stale_approval: list[str] = field(default_factory=list)  # DESIGN §5: *_REVIEWED disagrees with live
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations and bool(self.sections)
+
+    def to_dict(self) -> dict:
+        return {
+            "style": self.style, "ok": self.ok,
+            "precisPath": self.precis_path, "outlinePath": self.outline_path,
+            "bibPath": self.bib_path,
+            "violations": self.violations, "staleApproval": self.stale_approval,
+            "sections": [s.to_dict() for s in self.sections],
+        }
+
+
+def _planning_dir(arg: Path) -> Path:
+    """Accept either the project root or its .planning dir."""
+    if arg.name == ".planning":
+        return arg
+    if (arg / ".planning").is_dir():
+        return arg / ".planning"
+    return arg  # last resort: treat as the planning dir
+
+
+def _project_root(planning: Path) -> Path:
+    return planning.parent if planning.name == ".planning" else planning
+
+
+def _read(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _structure_order(outline_md: str) -> list[str]:
+    """The `## Structure` block's `### Section` headings, in document order."""
+    lines = outline_md.splitlines()
+    names, in_structure = [], False
+    for raw in lines:
+        line = raw.strip()
+        if re.match(r"^##\s+Structure\b", line, re.I):
+            in_structure = True
+            continue
+        if in_structure and re.match(r"^##\s+\S", line):  # next H2 ends the block
+            break
+        if in_structure:
+            m = re.match(r"^###\s+(.+?)\s*$", line)
+            if m:
+                names.append(m.group(1).strip())
+    return names
+
+
+def _roman_to_part(names: list[str]) -> dict[str, str]:
+    """Map a roman numeral (II) → the section name that starts with 'Part II'."""
+    out = {}
+    for n in names:
+        m = _PART_ROMAN_RE.match(n)
+        if m:
+            out[m.group(1).upper()] = n
+    return out
+
+
+def _claim_section_map(outline_md: str, roman_to_part: dict[str, str]) -> dict[str, set[str]]:
+    """Parse `## Claim → Section Map` → {section_name: {primary CLAIM-XX, ...}}.
+
+    Each row: | CLAIM-0X (...) | <PRIMARY home, e.g. II.A> | <setup/echo> |. Only the
+    PRIMARY-home column counts toward a section's required claims (the spec)."""
+    lines = outline_md.splitlines()
+    in_map = False
+    primary: dict[str, set[str]] = {}
+    for raw in lines:
+        line = raw.strip()
+        if re.match(r"^##\s+Claim\s*[→\->]+\s*Section\s+Map", line, re.I):
+            in_map = True
+            continue
+        if in_map and re.match(r"^##\s+\S", line):
+            break
+        if in_map and line.startswith("|"):
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            if len(cells) < 2:
+                continue
+            claim_cell, home_cell = cells[0], cells[1]
+            if re.match(r"^[-:\s|]+$", claim_cell) or claim_cell.lower() == "claim":
+                continue  # separator / header row
+            cset = claims_in(claim_cell)
+            if not cset:
+                continue
+            rm = re.match(r"^([IVXLC]+)\b", home_cell, re.I)
+            if rm:
+                part_name = roman_to_part.get(rm.group(1).upper())
+                if part_name:
+                    primary.setdefault(part_name, set()).update(cset)
+    return primary
+
+
+def _frontmatter(text: str) -> dict:
+    """Minimal YAML-ish frontmatter read: `implements:` (list or inline), `section:`."""
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end]
+    out: dict = {}
+    m = re.search(r"^implements:\s*\[(.*?)\]", block, re.M | re.S)
+    if m:
+        out["implements"] = sorted({_canon_claim(x) for x in _CLAIM_RE.findall(m.group(1))},
+                                   key=lambda c: int(c.split("-")[1]))
+    sm = re.search(r"^section:\s*(.+)$", block, re.M)
+    if sm:
+        out["section"] = sm.group(1).strip()
+    return out
+
+
+def _pair_files(name: str, outdir: Path, draftdir: Path) -> tuple[str | None, str | None]:
+    """Tolerant pairing: outline '<Name>.md' OR '<Name> (Outline).md'; draft
+    '<Name> (Draft).md' OR '<Name>.md'. Returns absolute paths or None."""
+    out_cands = [outdir / f"{name}.md", outdir / f"{name} (Outline).md"]
+    draft_cands = [draftdir / f"{name} (Draft).md", draftdir / f"{name}.md"]
+    outline = next((str(c.resolve()) for c in out_cands if c.is_file()), None)
+    draft = next((str(c.resolve()) for c in draft_cands if c.is_file()), None)
+    return outline, draft
+
+
+def _granularity(outline_text: str) -> tuple[bool, str]:
+    """Mechanical floor: a placeholder or a bare-headings outline bounces. The
+    substantive 'is each point real' judgment stays with the upstream outline reviewer."""
+    if not outline_text.strip():
+        return False, "outline file missing or empty"
+    if _PLACEHOLDER_RE.search(outline_text):
+        m = _PLACEHOLDER_RE.search(outline_text)
+        return False, f"placeholder marker present: '{m.group(0)}'"
+    # bullet-groups = lines starting with -, *, or a bold lead; require a handful.
+    bullets = [ln for ln in outline_text.splitlines() if re.match(r"^\s*([-*]|\d+\.)\s+\S", ln)]
+    if len(bullets) < 3:
+        return False, f"bare-headings: only {len(bullets)} bullet-level points"
+    return True, ""
+
+
+def _style(planning: Path) -> str:
+    aw = _read(planning / "ACTIVE_WORKFLOW.md")
+    m = re.search(r"^style:\s*([A-Za-z]+)", aw, re.M)
+    return m.group(1).lower() if m else "unspecified"
+
+
+def _stale_approval(planning: Path, outline_md: str, sections: list[Section]) -> list[str]:
+    """DESIGN §5: an APPROVED *_REVIEWED.md that asserts a claim/Part count disagreeing
+    with the live OUTLINE.md is a stale approval — surface, don't trust."""
+    issues = []
+    live_claims = claims_in(outline_md)
+    live_parts = sum(1 for s in sections if _PART_ROMAN_RE.match(s.name))
+    for fname in ("PRECIS_REVIEWED.md", "OUTLINE_REVIEWED.md"):
+        rv = _read(planning / fname)
+        if not rv:
+            continue
+        # spelled-out or digit counts: "five claims", "6 claims", "four Parts"
+        words = {"two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8}
+        cm = re.search(r"\b(\w+|\d+)\s+claims?\b", rv, re.I)
+        if cm:
+            tok = cm.group(1).lower()
+            n = int(tok) if tok.isdigit() else words.get(tok)
+            if n is not None and live_claims and n != len(live_claims):
+                issues.append(f"{fname} asserts {n} claims but live OUTLINE.md has {len(live_claims)} "
+                              f"({', '.join(sorted(live_claims))}) — re-approve before trusting APPROVED.")
+        pm = re.search(r"\b(\w+|\d+)\s+(substantive\s+)?Parts?\b", rv, re.I)
+        if pm:
+            tok = pm.group(1).lower()
+            n = int(tok) if tok.isdigit() else words.get(tok)
+            if n is not None and live_parts and n != live_parts:
+                issues.append(f"{fname} asserts {n} Parts but live OUTLINE.md has {live_parts} — "
+                              f"the approved review predates the current structure.")
+    return issues
+
+
+def build_index(project_or_planning: Path) -> IndexResult:
+    planning = _planning_dir(project_or_planning)
+    root = _project_root(planning)
+    res = IndexResult()
+    res.style = _style(planning)
+
+    # resolved paths (so the index is a complete data artifact the engines consume directly)
+    if (planning / "PRECIS.md").is_file():
+        res.precis_path = str((planning / "PRECIS.md").resolve())
+    if (planning / "OUTLINE.md").is_file():
+        res.outline_path = str((planning / "OUTLINE.md").resolve())
+    bib = root / "references" / "sources.bib"
+    if bib.is_file():
+        res.bib_path = str(bib.resolve())
+    else:
+        other = sorted((root / "references").glob("*.bib")) if (root / "references").is_dir() else []
+        other = other or sorted(root.glob("*.bib"))
+        if other:
+            res.bib_path = str(other[0].resolve())
+
+    outline_md = _read(planning / "OUTLINE.md")
+    if not outline_md:
+        res.violations.append("No .planning/OUTLINE.md found.")
+        return res
+
+    order = _structure_order(outline_md)
+    if not order:
+        res.violations.append("OUTLINE.md has no `## Structure` block with `### Section` headings.")
+        return res
+
+    roman = _roman_to_part(order)
+    primary_map = _claim_section_map(outline_md, roman)
+    outdir, draftdir = root / "outlines", root / "drafts"
+
+    for i, name in enumerate(order):
+        outline_file, draft_file = _pair_files(name, outdir, draftdir)
+        outline_text = _read(Path(outline_file)) if outline_file else ""
+        fm = _frontmatter(_read(Path(draft_file))) if draft_file else {}
+        implements = fm.get("implements", [])
+        primary = sorted(primary_map.get(name, set()), key=lambda c: int(c.split("-")[1]))
+        granular, note = _granularity(outline_text)
+        # sources_pinned is ADVISORY + OUTLINE-based: does the outline pin a real SOURCE
+        # (a pandoc [@key]) to its claims — the question the draft phase consumer asks
+        # ("if false, the draft agent assigns citations from the bib"). A bare CLAIM-XX is
+        # a claim id, NOT a source, so it does NOT count. This deliberately differs from a
+        # draft-body reading (does the finished prose cite) — a different, also-valid
+        # measurement we do not gate on. The field drives nothing; it never fails parity.
+        # ⚠ CAVEAT (tender-parity): on LEGAL outlines [@key] is uniformly absent — they pin
+        # sources in Bluebook PROSE (§262, "Williams Act", "See …"), so this returns false
+        # for sourced legal sections. If sourcesPinned EVER goes load-bearing it needs a
+        # Bluebook-aware signal; until then it stays advisory and non-discriminating on
+        # legal projects is acceptable.
+        sources_pinned = bool(_CITEKEY_RE.search(outline_text))
+        claim_ok = set(primary).issubset(set(implements))  # ⊇ semantics (D-w-3)
+
+        if outline_file is None:
+            res.violations.append(f"Section '{name}': no outline file in {outdir} "
+                                  f"(tried '{name}.md' and '{name} (Outline).md').")
+        if not granular:
+            res.violations.append(f"Section '{name}': not granular — {note}.")
+        if primary and not claim_ok:
+            missing = sorted(set(primary) - set(implements))
+            res.violations.append(f"Section '{name}': draft.implements missing primary claim(s) "
+                                  f"{missing} (map assigns {primary}; draft has {implements}).")
+
+        res.sections.append(Section(
+            name=name, order=i, outline_file=outline_file, draft_file=draft_file,
+            primary_claims=primary, implements=implements, sources_pinned=sources_pinned,
+            granular=granular, granularity_note=note,
+            prev_name=order[i - 1] if i > 0 else "",
+            next_name=order[i + 1] if i < len(order) - 1 else "",
+            claim_ok=claim_ok,
+        ))
+
+    res.stale_approval = _stale_approval(planning, outline_md, res.sections)
+    return res
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: writing_section_index.py /abs/project[/.planning]", file=sys.stderr)
+        return 2
+    res = build_index(Path(sys.argv[1]))
+    print(json.dumps(res.to_dict(), indent=2, ensure_ascii=False))
+    return 0 if res.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/writing-draft/SKILL.md
+++ b/skills/writing-draft/SKILL.md
@@ -242,9 +242,20 @@ It discovers the sections (deterministically when `sectionIndex` is passed), ass
 
 **The JS gate is authoritative.** Do not hand-wave it to true; fix a finding and let the next run recompute. Per-section minor prose nits are advisory here — document-quality polish is `/writing-review`'s job, not the draft gate's.
 
-### Step 4: Mandatory source-verify (the citation gate)
+### Step 4: gate the citations — deterministic floor THEN semantic source-verify (two-tier)
 
-The workflow's verify stage confirms each citation *resolves* (the source exists / the cite is well-formed). It does NOT confirm the quoted text actually appears in the source. Before declaring the draft complete, run the deep check:
+Writing's citation gate is **two-tier** (DESIGN §4). Run the deterministic floor FIRST (it cannot be gamed and is nearly free), then the semantic authority:
+
+**4a — Deterministic floor (`{pass, evidence}`, mechanical).** For each `drafts/*.md`, run the gate probe — it greps every `[@key]` against `sources.bib` (closes the old "fidelity asserted, not checked" gap), flags any `[CITE-NEEDED]` left, confirms a `CLAIM-XX` trace, and reports number-vs-PRECIS drift in **labeled `consistency-only` mode** (it does NOT claim true dataset provenance when the parquet is remote/absent):
+
+```bash
+uv run python3 ${CLAUDE_SKILL_DIR}/../../scripts/writing/writing_gate_probe.py \
+  "drafts/<Section> (Draft).md" --bib references/sources.bib --precis .planning/PRECIS.md --outline .planning/OUTLINE.md
+```
+
+`pass:false` (an unresolved `[@key]`, a leftover `[CITE-NEEDED]`, or no claim trace) → feed the named `evidence` into the Step-3 `/goal` loop and re-draft that section; do NOT proceed. `dataProvenance.unmatchedVsSpec` is **advisory** (consistency-only) — review the listed numbers, but it never blocks on its own; numbers whose only source is a remote dataset are **unverifiable locally** and must not be reported as verified.
+
+**4b — Semantic authority (the real correctness check).** The floor is necessary, not sufficient. It confirms a cite *resolves*; it does NOT confirm the quoted text appears in the source or that the source supports the claim. Run the deep check:
 
 ```
 Skill(skill="workflows:source-verify")

--- a/skills/writing-draft/SKILL.md
+++ b/skills/writing-draft/SKILL.md
@@ -203,17 +203,28 @@ Skill(skill="workflows:ai-anti-patterns")
 
 ### Step 3: Run the writing-draft workflow + drive the /goal loop
 
-Drafting is the `writing-draft` **ultracode workflow** — do NOT hand-draft sections in this session, and do NOT spawn your own per-section agents. Invoke it once over the whole document:
+Drafting is the `writing-draft` **ultracode workflow** — do NOT hand-draft sections in this session, and do NOT spawn your own per-section agents.
+
+**First COMPILE the deterministic section index** (the writing analog of ds/dev's compile step — it replaces the workflow's LLM `Discover` with a regex-parse of the approved planning artifacts, so the section set/order/file-pairing/claim-map can't drift). Run it and read the JSON:
+
+```bash
+uv run python3 ${CLAUDE_SKILL_DIR}/../../scripts/writing/writing_section_index.py "<project root>" > .planning/section-index.json
+```
+
+Read `.planning/section-index.json`. If `ok` is true, pass the parsed object as `sectionIndex` (below). If it has `violations` (e.g. a section's `draft.implements` is missing a primary claim the OUTLINE.md Claim→Section Map assigns, or `staleApproval` flags a `*_REVIEWED.md` whose claim/Part count disagrees with the live OUTLINE.md), **STOP and surface them** — these are spec-integrity failures (the writing analog of a stale gate), fixed in writing-outline/-setup, not papered over. If the script errors entirely, omit `sectionIndex` and the workflow falls back to its LLM Discover (back-compat).
+
+Then invoke it once over the whole document:
 
 ```
 Workflow(name="writing-draft", args={
   "projectDir": "<absolute path to the writing project root (cwd)>",
   "pluginRoot": "<absolute path to this plugin's workflows/ dir — resolve ${CLAUDE_SKILL_DIR}/../../workflows>",
-  "outputSubdir": "drafts"
+  "outputSubdir": "drafts",
+  "sectionIndex": <the parsed .planning/section-index.json object, or omit to use the LLM Discover>
 })
 ```
 
-It discovers the sections, asserts each outline is paragraph-structured, fans out one write-agent per section (each EXPANDS its outline → prose, cites real sources, writes bridges from the adjacent outlines), verifies coverage + citation-resolvability + transitions, and returns `{ overallPass, substratePass, verdict, scoreTable, sections, findings, underGranular, sectionsThatFailed, reviews }`. **The gate is computed in JS from raw counts — never self-report it.**
+It discovers the sections (deterministically when `sectionIndex` is passed), asserts each outline is paragraph-structured, fans out one write-agent per section (each EXPANDS its outline → prose, cites real sources, writes bridges from the adjacent outlines), verifies coverage + citation-resolvability + transitions, and returns `{ overallPass, substratePass, verdict, scoreTable, sections, findings, underGranular, sectionsThatFailed, reviews }`. **The gate is computed in JS from raw counts — never self-report it.**
 
 **Read the result and act:**
 

--- a/skills/writing-outline/SKILL.md
+++ b/skills/writing-outline/SKILL.md
@@ -15,6 +15,10 @@ hooks:
             GATE_DESCRIPTION="Precis review"
             GATE_REMEDY="Return to writing-setup and run the precis reviewer before outlining"
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/writing-outline-executable-guard.py"
   PostToolUse:
     - matcher: "Edit|Write"
       hooks:

--- a/skills/writing-outline/SKILL.md
+++ b/skills/writing-outline/SKILL.md
@@ -182,16 +182,30 @@ Create directory if needed and write the detailed outline:
 mkdir -p outlines
 ```
 
-Write to `outlines/[Section Name] (Outline).md`:
+Write to `outlines/[Section Name].md` (the **filename stem MUST equal** the `### [Section Name]` heading in `.planning/OUTLINE.md ## Structure` — the section index pairs them; a `(Outline)` suffix is tolerated but match the OUTLINE.md heading exactly):
+
+<EXTREMELY-IMPORTANT>
+**BORN-CANONICAL + SOURCE-PINNED.** Two things make this outline machine-executable (so the
+draft engine consumes it deterministically and the outline-executable guard passes):
+1. **`implements: [CLAIM-XX]` frontmatter** carrying the claims the OUTLINE.md `## Claim →
+   Section Map` primary-homes to this section (the draft's `implements:` must ⊇ these).
+2. **A real source pinned to every substantive claim** — a `[@bibkey]` resolvable in
+   `references/sources.bib`, or a specific named authority (case/statute). The assessment's
+   writing follow-up is "pin a source per claim"; do it HERE, not at draft time. An unsourced
+   point is `[CITE-NEEDED: <what>]`, never an invented cite.
+</EXTREMELY-IMPORTANT>
 
 ```markdown
+---
+implements: [CLAIM-XX, CLAIM-YY]   # the claims primary-homed to this section in OUTLINE.md
+---
 # [Section Name] - Detailed Outline
 
 ## Section Goal
 [From master OUTLINE.md - what this section accomplishes]
 
 ## Claim Supported
-[Which claim from PRECIS.md this section advances]
+[Which claim(s) from PRECIS.md this section advances — same CLAIM-XX as the frontmatter]
 
 ## Structure: [Chronological/Thematic/Problem-Solution/Comparative]
 
@@ -210,9 +224,9 @@ Write to `outlines/[Section Name] (Outline).md`:
 ### Subsection A: [Name]
 
 **Point**: [Main argument of this subsection]
-**Evidence**:
-  - [Source 1]: "[key quote or fact]"
-  - [Source 2]: "[key quote or fact]"
+**Evidence** (pin a REAL source per claim — `[@bibkey]` or a named authority):
+  - [@bibkey1]: "[key quote or fact]"
+  - [@bibkey2]: "[key quote or fact]"
 **Logic**: [How evidence supports point]
 **Transition**: [Bridge to next subsection]
 

--- a/skills/writing-review/SKILL.md
+++ b/skills/writing-review/SKILL.md
@@ -189,14 +189,23 @@ WF=$(command ls -d ~/.claude/plugins/cache/*/workflows/*/workflows/writing-revie
 [ -z "$WF" ] && WF="${CLAUDE_SKILL_DIR}/../../workflows/writing-review.js"
 ```
 
-**2. Invoke the workflow:**
+**2. COMPILE the deterministic section index** (the writing analog of ds/dev's compile step — replaces the workflow's LLM `Discover` with a regex-parse of the approved planning artifacts; the SAME parser the writing-draft skill and the outline-executable guard use, so the section set can't drift between phases):
+
+```bash
+uv run python3 ${CLAUDE_SKILL_DIR}/../../scripts/writing/writing_section_index.py "<abs project dir>" > .planning/section-index.json
+```
+
+Read `.planning/section-index.json`. If `ok`, pass the parsed object as `sectionIndex` below. If it carries `violations` / `staleApproval` (e.g. a `*_REVIEWED.md` whose claim/Part count disagrees with the live OUTLINE.md — a stale approval after a reframe), **surface them** — they are spec-integrity failures fixed upstream. On a hard error, omit `sectionIndex` (the workflow falls back to its LLM Discover).
+
+**3. Invoke the workflow:**
 
 ```
 Workflow({
   scriptPath: "<WF>",
   args: {
     projectDir: "<abs project dir>",          // holds .planning/, outlines/, drafts/, references/sources.bib
-    pluginRoot: "${CLAUDE_SKILL_DIR}/../.."    // resolves domain skill + bridge_repetition_check.py
+    pluginRoot: "${CLAUDE_SKILL_DIR}/../..",   // resolves domain skill + bridge_repetition_check.py
+    sectionIndex: <parsed .planning/section-index.json, or omit for the LLM Discover fallback>
   }
 })
 ```

--- a/skills/writing-setup/SKILL.md
+++ b/skills/writing-setup/SKILL.md
@@ -198,6 +198,26 @@ Follow the reviewer skill instructions: dispatch the subagent, handle APPROVED/I
 
 Structure the argument with sections mapped to claims from PRECIS.md.
 
+<EXTREMELY-IMPORTANT>
+### OUTLINE.md is a MACHINE-EXECUTABLE SPEC (born-canonical)
+
+`scripts/writing/writing_section_index.py` parses OUTLINE.md to build the section set the
+draft and review engines run on (and `writing-outline-executable-guard.py` gates approval on
+it). Two blocks are **load-bearing and must be emitted in this exact shape** — get them right
+here and the outline is born-canonical (the guard goes strict; nothing relies on tolerant
+regex papering over drift):
+
+1. **`## Structure`** — one `### <Section Name>` per section, IN DOCUMENT ORDER. The heading
+   text MUST equal the section's outline/draft **filename stem** (the parser pairs
+   `### Part I. Foo` ⇄ `outlines/Part I. Foo.md` ⇄ `drafts/Part I. Foo (Draft).md`). Do NOT
+   prefix with bare roman numerals like `### I. Introduction` unless the files are named that
+   way — use the real section names (`### Introduction`, `### Part I. <Name>`, `### Conclusion`).
+2. **`## Claim → Section Map`** — the CANONICAL claim→section assignment (the spec the ⊇ gate
+   reads). Each claim has ONE primary home (a section, by `Part` numeral `II.A` or section
+   name); Intro/Conclusion are echo-only. A section's draft must `implements: ⊇` the claims
+   primary-homed to it.
+</EXTREMELY-IMPORTANT>
+
 ### OUTLINE.md Template
 
 ```markdown
@@ -205,35 +225,35 @@ Structure the argument with sections mapped to claims from PRECIS.md.
 
 ## Structure
 
-### I. Introduction
+### Introduction
 - **Goal**: Hook reader, state thesis, roadmap
-- **Hook**: [from PRECIS or TBD]
 - **Thesis**: [from PRECIS]
-- **Claims preview**: [list from PRECIS]
+- **Claims preview**: CLAIM-01 → CLAIM-0N
 
-### II. [Section Name]
+### Part I. [Section Name]
 - **Goal**: [what this section accomplishes]
-- **Implements**: [CLAIM-01, CLAIM-02, etc. from PRECIS]
+- **Implements**: [CLAIM-01, CLAIM-02 — the claims primary-homed here, from the map below]
 - **Key points**:
-  - Point A (sources: ...)
-  - Point B (sources: ...)
-- **Transition to next**: [how it leads to Section III]
+  - Point A — [@bibkey or specific authority]  (pin a real source per substantive claim)
+  - Point B — [@bibkey]
+- **Transition to next**: [how it leads to the next section]
 
-### III. [Section Name]
+### Part II. [Section Name]
 - **Goal**: [what this section accomplishes]
-- **Implements**: [CLAIM-XX from PRECIS]
+- **Implements**: [CLAIM-XX]
 - **Key points**:
-  - [points with sources]
+  - [points, each with a pinned source]
 
-### IV. Counterarguments
-- **Goal**: Address objections from PRECIS
-- **Objection 1**: [from PRECIS] → Response
-- **Objection 2**: [from PRECIS] → Response
-
-### V. Conclusion
-- **Goal**: Restate thesis with earned authority
+### Conclusion
+- **Goal**: Restate thesis with earned authority; synthesize CLAIM-01 … CLAIM-0N
 - **Implications**: What follows from this argument
-- **Future questions**: What remains unresolved
+
+## Claim → Section Map
+| Claim | Primary home | Setup / echo |
+|-------|--------------|--------------|
+| CLAIM-01 ([gloss]) | Part I.A | Introduction |
+| CLAIM-02 ([gloss]) | Part II.A | Part I.B |
+| CLAIM-0N ([gloss]) | Part II.B | Conclusion |
 
 ## Key Sources
 [Deduplicated from search phase]

--- a/tests/fixtures/writing-section-index/drafts/Conclusion (Draft).md
+++ b/tests/fixtures/writing-section-index/drafts/Conclusion (Draft).md
@@ -1,0 +1,5 @@
+---
+implements: [CLAIM-01, CLAIM-02, CLAIM-03]
+---
+# Conclusion
+Prose.

--- a/tests/fixtures/writing-section-index/drafts/Introduction (Draft).md
+++ b/tests/fixtures/writing-section-index/drafts/Introduction (Draft).md
@@ -1,0 +1,6 @@
+---
+implements: [CLAIM-01, CLAIM-02, CLAIM-03]
+section: Introduction
+---
+# Introduction
+Prose.

--- a/tests/fixtures/writing-section-index/drafts/Part I. The Setup — Foundations (Draft).md
+++ b/tests/fixtures/writing-section-index/drafts/Part I. The Setup — Foundations (Draft).md
@@ -1,0 +1,5 @@
+---
+implements: [CLAIM-01, CLAIM-02]
+---
+# Part I
+Prose.

--- a/tests/fixtures/writing-section-index/drafts/Part II — The Core Channels (Draft).md
+++ b/tests/fixtures/writing-section-index/drafts/Part II — The Core Channels (Draft).md
@@ -1,0 +1,5 @@
+---
+implements: [CLAIM-02, CLAIM-03]
+---
+# Part II
+Prose.

--- a/tests/fixtures/writing-section-index/outlines/Conclusion.md
+++ b/tests/fixtures/writing-section-index/outlines/Conclusion.md
@@ -1,0 +1,4 @@
+# Conclusion — Outline
+- **Point**: synthesize.
+- **Point**: restate.
+- **Point**: close.

--- a/tests/fixtures/writing-section-index/outlines/Introduction.md
+++ b/tests/fixtures/writing-section-index/outlines/Introduction.md
@@ -1,0 +1,4 @@
+# Introduction — Outline
+- **Point**: hook [@smith2019].
+- **Point**: thesis.
+- **Point**: roadmap.

--- a/tests/fixtures/writing-section-index/outlines/Part I. The Setup — Foundations (Outline).md
+++ b/tests/fixtures/writing-section-index/outlines/Part I. The Setup — Foundations (Outline).md
@@ -1,0 +1,4 @@
+# Part I — Outline
+- **A**: first point [@smith2019].
+- **B**: second point.
+- **C**: third point.

--- a/tests/fixtures/writing-section-index/outlines/Part II — The Core Channels.md
+++ b/tests/fixtures/writing-section-index/outlines/Part II — The Core Channels.md
@@ -1,0 +1,4 @@
+# Part II — Outline
+- **A** (CLAIM-02): core result.
+- **B** (CLAIM-03): follow-on.
+- **C**: third.

--- a/tests/writing-engine-discover.test.mjs
+++ b/tests/writing-engine-discover.test.mjs
@@ -1,0 +1,103 @@
+// Driver tests for the writing engines' reconciled Discover phase.
+// Executes workflows/writing-draft.js and writing-review.js bodies with MOCKED Workflow
+// primitives, asserting: (1) when args.sectionIndex is present, NO LLM 'discover' agent
+// fires (the compiled-Discover win); (2) the deterministic index maps to the right gate
+// outcome incl. the granularity bounce; (3) absent index ⇒ the LLM Discover still runs
+// (back-compat). Run:  node tests/writing-engine-discover.test.mjs
+import { readFileSync } from 'fs'
+
+const ROOT = new URL('..', import.meta.url).pathname
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+let PASS = 0, FAIL = 0
+const ok = (n, c, x = '') => { if (c) { PASS++; console.log(`  ok  ${n}`) } else { FAIL++; console.log(`FAIL  ${n} ${x}`) } }
+
+const draftSrc = readFileSync(ROOT + 'workflows/writing-draft.js', 'utf8').replace(/^export const meta/m, 'const meta')
+const reviewSrc = readFileSync(ROOT + 'workflows/writing-review.js', 'utf8').replace(/^export const meta/m, 'const meta')
+
+async function exec(src, { args, onAgent }) {
+  const trace = { labels: [] }
+  const agent = async (prompt, opts = {}) => { const l = opts.label || ''; trace.labels.push(l); return onAgent(l, prompt, opts) }
+  const parallel = async (thunks) => Promise.all(thunks.map(t => t()))
+  const pipeline = async () => { throw new Error('pipeline unused') }
+  const log = () => {}, phase = () => {}
+  const fn = new AsyncFunction('agent', 'parallel', 'pipeline', 'log', 'phase', 'args', 'budget',
+    src + '\n;return (typeof __ret!=="undefined")?__ret:undefined')
+  // The engines `return` their result at top level; AsyncFunction makes that the resolved value.
+  const result = await fn(agent, parallel, pipeline, log, phase, args, { total: null, spent: () => 0, remaining: () => Infinity })
+  return { result, trace }
+}
+
+const SECTIONS = [
+  { name: 'Introduction', outlineFile: '/p/outlines/Introduction.md', draftFile: '/p/drafts/Introduction (Draft).md', primaryClaims: [], implements: ['CLAIM-01', 'CLAIM-02'], sourcesPinned: false, granular: true, granularityNote: '', prevName: '', nextName: 'Part I' },
+  { name: 'Part I', outlineFile: '/p/outlines/Part I.md', draftFile: '/p/drafts/Part I (Draft).md', primaryClaims: ['CLAIM-01'], implements: ['CLAIM-01'], sourcesPinned: true, granular: true, granularityNote: '', prevName: 'Introduction', nextName: 'Stub' },
+  { name: 'Stub', outlineFile: '/p/outlines/Stub.md', draftFile: '/p/drafts/Stub (Draft).md', primaryClaims: [], implements: [], sourcesPinned: false, granular: false, granularityNote: 'placeholder: TBA', prevName: 'Part I', nextName: '' },
+]
+const INDEX = { style: 'legal', precisPath: '/p/.planning/PRECIS.md', outlinePath: '/p/.planning/OUTLINE.md', bibPath: '/p/references/sources.bib', sections: SECTIONS }
+
+// ── writing-draft.js: deterministic Discover ────────────────────────────────────
+console.log('writing-draft — deterministic Discover')
+{
+  const draftAgent = (label) => {
+    if (label.startsWith('verify:')) {
+      const section = label.slice(7)
+      return { section, coverageOk: true, fidelityOk: true, transitionOk: true, findings: [], boundary: { firstSentence: 'First.', lastSentence: 'Last.' } }
+    }
+    // transform agent: label is the section name
+    return { section: label, draftFile: `/p/drafts/${label} (Draft).md`, status: 'drafted', content: 'Prose body.', pointsExpanded: 3, summary: 'advances CLAIM-01' }
+  }
+  const { result, trace } = await exec(draftSrc, { args: { projectDir: '/p', pluginRoot: '/plug/workflows', sectionIndex: INDEX }, onAgent: draftAgent })
+  ok('no LLM discover agent fired', !trace.labels.includes('discover'), JSON.stringify(trace.labels))
+  ok('2 draftable transformed (Stub bounced)', trace.labels.filter(l => l === 'Introduction' || l === 'Part I').length === 2)
+  ok('Stub never transformed', !trace.labels.includes('Stub'))
+  ok('underGranular = [Stub]', result.underGranular.length === 1 && result.underGranular[0].section === 'Stub', JSON.stringify(result.underGranular))
+  ok('overallPass false (a structureless outline present)', result.overallPass === false)
+  ok('scoreTable has all 3 rows', (result.scoreTable.match(/\n\| /g) || []).length >= 3)
+}
+
+// happy path: all granular ⇒ overallPass true
+console.log('writing-draft — all granular ⇒ pass')
+{
+  const idx2 = { ...INDEX, sections: SECTIONS.slice(0, 2).map(s => ({ ...s, nextName: s.name === 'Part I' ? '' : s.nextName })) }
+  const draftAgent = (label) => label.startsWith('verify:')
+    ? { section: label.slice(7), coverageOk: true, fidelityOk: true, transitionOk: true, findings: [], boundary: { firstSentence: 'A.', lastSentence: 'B.' } }
+    : { section: label, draftFile: `/p/drafts/${label} (Draft).md`, status: 'drafted', content: 'Body.', pointsExpanded: 3, summary: 's' }
+  const { result, trace } = await exec(draftSrc, { args: { projectDir: '/p', pluginRoot: '/plug/workflows', sectionIndex: idx2 }, onAgent: draftAgent })
+  ok('no discover agent', !trace.labels.includes('discover'))
+  ok('overallPass true', result.overallPass === true, result.verdict)
+}
+
+// back-compat: no index ⇒ LLM discover runs
+console.log('writing-draft — back-compat LLM Discover')
+{
+  const draftAgent = (label) => {
+    if (label === 'discover') return { style: 'legal', precisPath: '', outlinePath: '', domainSkillPath: '', bibPath: '', sections: [{ name: 'Introduction', outlineFile: '/p/o/Introduction.md', draftFile: '/p/d/Introduction (Draft).md', precisClaim: 'CLAIM-01', outlineGranular: true, sourcesPinned: true, granularityNote: '', prevName: '', nextName: '' }] }
+    if (label.startsWith('verify:')) return { section: label.slice(7), coverageOk: true, fidelityOk: true, transitionOk: true, findings: [], boundary: { firstSentence: 'A.', lastSentence: 'B.' } }
+    return { section: label, draftFile: '/p/d/x.md', status: 'drafted', content: 'b', pointsExpanded: 1, summary: 's' }
+  }
+  const { trace } = await exec(draftSrc, { args: { projectDir: '/p', pluginRoot: '/plug/workflows' }, onAgent: draftAgent })
+  ok('LLM discover agent fired (no index)', trace.labels.includes('discover'))
+}
+
+// ── writing-review.js: deterministic Discover ───────────────────────────────────
+console.log('writing-review — deterministic Discover')
+{
+  const reviewAgent = (label) => {
+    if (label === 'discover') throw new Error('discover should be skipped')
+    if (label.endsWith(':structure')) return { section: label.split(':')[0], check: 'structure', itemsChecked: 4, issues: [], precisClaimAdvanced: true, boundary: { firstSentence: 'A.', lastSentence: 'B.', assumesFromPrev: '', handsOffToNext: '', argumentState: '', conceptsIntroduced: [], conceptsUsed: [], coreTerms: [] }, argumentSummary: ['pt'] }
+    if (label.endsWith(':prose')) return { section: label.split(':')[0], check: 'prose', itemsChecked: 4, issues: [] }
+    if (label.endsWith(':fidelity')) return { section: label.split(':')[0], check: 'fidelity', itemsChecked: 4, issues: [] }
+    if (label.endsWith(':verify')) return { section: label.split(':')[0], quotesChecked: 0, fabricated: [] }
+    if (label === 'L2:transitions') return { transitions: [] }
+    if (label === 'L3:document') return { conceptOrderIssues: [], repetition: [], thesisIssues: [], completeness: { claimsAddressed: 'all', counterargsConfronted: 'all', scopeHonored: true, hookDelivered: true, conclusionFollows: true, issues: [] } }
+    return {}
+  }
+  const idx = { ...INDEX, sections: SECTIONS.slice(0, 2) }
+  const { result, trace } = await exec(reviewSrc, { args: { projectDir: '/p', pluginRoot: '/plug/workflows', sectionIndex: idx }, onAgent: reviewAgent })
+  ok('no LLM discover agent fired', !trace.labels.includes('discover'))
+  ok('both sections reviewed (structure agents)', trace.labels.filter(l => l.endsWith(':structure')).length === 2)
+  ok('overallPass true (clean review)', result.overallPass === true, result.verdict)
+  ok('verdict CLEAN', /CLEAN/.test(result.verdict), result.verdict)
+}
+
+console.log(`\n${PASS} passed, ${FAIL} failed`)
+process.exit(FAIL ? 1 : 0)

--- a/tests/writing_gate_probe_test.py
+++ b/tests/writing_gate_probe_test.py
@@ -67,6 +67,25 @@ with tempfile.TemporaryDirectory() as td:
     r = gp.probe(clean, None, precis)
     ok("no bib ⇒ cites unchecked note, still passes", r["pass"] is True and "bibNote" in r["evidence"])
 
+# 7. legal-prose robustness (the tender-parity A/B defects)
+with tempfile.TemporaryDirectory() as td:
+    d = Path(td)
+    bib = write(d, "sources.bib", BIB)
+    precis = write(d, "PRECIS.md", "Median deal ~$1.5B; value-at-stake ~$30.7M; 45% repeat funds.\nCLAIM-01\n")
+    # statutory citation must NOT be parsed as a datum; magnitude words must normalize
+    legal = write(d, "Legal (Draft).md",
+                  "---\nimplements: [CLAIM-01]\n---\n"
+                  "Under 15 U.S.C. § 78mm and Rule 14e-1, the median deal is $1.5 billion [@smith2019] "
+                  "and value-at-stake $30.7 million, with forty-five percent repeat funds.\n")
+    r = gp.probe(legal, bib, precis)
+    dp = r["evidence"].get("dataProvenance", {})
+    um = dp.get("unmatchedVsSpec", [])
+    ok("no statutory phantom (§ 78mm not flagged)", not any("78m" in u for u in um), str(um))
+    ok("$1.5 billion matches spec $1.5B (magnitude-word norm)", not any("1.5" in u for u in um), str(um))
+    ok("$30.7 million matches spec $30.7M", not any("30.7" in u for u in um), str(um))
+    ok("spelled-out blind spot disclosed", "forty-five percent" in dp.get("spelledOutNotChecked", []), str(dp.get("spelledOutNotChecked")))
+    ok("note discloses numeric-only + spelled-out gap", "spelled-out" in dp.get("note", "").lower())
+
 # real-repo smoke (skipped if absent)
 REAL = Path.home() / "projects" / "tender_offers" / "paper"
 d3 = REAL / "drafts" / "Part III. Objections and the Targeted Fix (Draft).md"

--- a/tests/writing_gate_probe_test.py
+++ b/tests/writing_gate_probe_test.py
@@ -86,6 +86,24 @@ with tempfile.TemporaryDirectory() as td:
     ok("spelled-out blind spot disclosed", "forty-five percent" in dp.get("spelledOutNotChecked", []), str(dp.get("spelledOutNotChecked")))
     ok("note discloses numeric-only + spelled-out gap", "spelled-out" in dp.get("note", "").lower())
 
+# 8. SCOPE contract (canonical D1 {pass, artifactsPresent, evidence, SCOPE})
+with tempfile.TemporaryDirectory() as td:
+    d = Path(td)
+    bib = write(d, "sources.bib", BIB)
+    precis = write(d, "PRECIS.md", "42.9%.\nCLAIM-01\n")
+    cl = write(d, "S (Draft).md", "---\nimplements: [CLAIM-01]\n---\nRate 42.9% [@smith2019].\n")
+    r = gp.probe(cl, bib, precis)
+    ok("return carries artifactsPresent", r.get("artifactsPresent") is True)
+    ok("return carries scope.checked + scope.notChecked",
+       isinstance(r.get("scope", {}).get("checked"), list) and isinstance(r["scope"].get("notChecked"), list))
+    ok("scope.notChecked discloses semantic deferral",
+       any("source-verify" in x for x in r["scope"]["notChecked"]))
+    ok("scope.notChecked discloses spelled-out + dataset blind spots",
+       any("spelled-out" in x for x in r["scope"]["notChecked"]) and any("dataset" in x for x in r["scope"]["notChecked"]))
+    r2 = gp.probe(cl, None, precis)
+    ok("scope reflects skipped bib when none provided",
+       any("SKIPPED" in x for x in r2["scope"]["checked"]))
+
 # real-repo smoke (skipped if absent)
 REAL = Path.home() / "projects" / "tender_offers" / "paper"
 d3 = REAL / "drafts" / "Part III. Objections and the Targeted Fix (Draft).md"

--- a/tests/writing_gate_probe_test.py
+++ b/tests/writing_gate_probe_test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S uv run python3
+"""Tests for scripts/writing/writing_gate_probe.py — the deterministic floor of the two-tier
+gateProbe. Run:  uv run python3 tests/writing_gate_probe_test.py"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "writing"))
+import writing_gate_probe as gp  # noqa: E402
+
+_p = _f = 0
+
+
+def ok(name, cond, extra=""):
+    global _p, _f
+    if cond:
+        _p += 1; print(f"  ok  {name}")
+    else:
+        _f += 1; print(f"FAIL  {name} {extra}")
+
+
+def write(d: Path, name: str, body: str) -> Path:
+    p = d / name; p.write_text(body); return p
+
+
+BIB = "@article{smith2019, title={X}}\n@book{jones2020, title={Y}}\n"
+
+with tempfile.TemporaryDirectory() as td:
+    d = Path(td)
+    bib = write(d, "sources.bib", BIB)
+    precis = write(d, "PRECIS.md", "Thesis. Key figure: 42.9% of deals; median ~$1.5B; n=58 petitions.\nCLAIM-01\n")
+
+    # 1. clean draft: resolvable cite, claim present, number matches PRECIS
+    clean = write(d, "Clean (Draft).md", "---\nimplements: [CLAIM-01]\n---\nThe rate is 42.9% [@smith2019].\n")
+    r = gp.probe(clean, bib, precis)
+    ok("clean draft passes floor", r["pass"] is True, str(r["evidence"]))
+    ok("clean: no bibUnresolved", "bibUnresolved" not in r["evidence"])
+    ok("clean: 42.9% matches PRECIS (no unmatched)", not r["evidence"].get("dataProvenance", {}).get("unmatchedVsSpec"))
+
+    # 2. unresolved cite ⇒ fail + named
+    badcite = write(d, "BadCite (Draft).md", "---\nimplements: [CLAIM-01]\n---\nClaim [@ghostref2099].\n")
+    r = gp.probe(badcite, bib, precis)
+    ok("unresolved [@key] ⇒ pass False", r["pass"] is False)
+    ok("unresolved names the key", any("ghostref2099" in e for e in r["evidence"].get("bibUnresolved", [])), str(r["evidence"]))
+
+    # 3. CITE-NEEDED left ⇒ fail
+    cn = write(d, "CiteNeeded (Draft).md", "---\nimplements: [CLAIM-01]\n---\nFoo [CITE-NEEDED: the source].\n")
+    r = gp.probe(cn, bib, precis)
+    ok("CITE-NEEDED ⇒ pass False", r["pass"] is False and r["evidence"].get("citeNeeded"))
+
+    # 4. no claim trace ⇒ fail
+    noclaim = write(d, "NoClaim (Draft).md", "Body with a cite [@smith2019] but no claim id.\n")
+    r = gp.probe(noclaim, bib, precis)
+    ok("no CLAIM-XX ⇒ pass False", r["pass"] is False and r["evidence"].get("claimIdsMissing"))
+
+    # 5. number not in PRECIS ⇒ flagged in dataProvenance (advisory) but pass stays True
+    drift = write(d, "Drift (Draft).md", "---\nimplements: [CLAIM-01]\n---\nThe rate is 99.9% [@smith2019].\n")
+    r = gp.probe(drift, bib, precis)
+    ok("drifting number flagged in dataProvenance", any("99.9%" in u for u in r["evidence"]["dataProvenance"]["unmatchedVsSpec"]))
+    ok("dataProvenance is advisory (pass stays True)", r["pass"] is True)
+    ok("dataProvenance labeled consistency-only", r["evidence"]["dataProvenance"]["mode"] == "consistency-only")
+
+    # 6. no bib provided ⇒ note, not a hard fail on cites
+    r = gp.probe(clean, None, precis)
+    ok("no bib ⇒ cites unchecked note, still passes", r["pass"] is True and "bibNote" in r["evidence"])
+
+# real-repo smoke (skipped if absent)
+REAL = Path.home() / "projects" / "tender_offers" / "paper"
+d3 = REAL / "drafts" / "Part III. Objections and the Targeted Fix (Draft).md"
+if d3.is_file():
+    r = gp.probe(d3, REAL / "references" / "sources.bib", REAL / ".planning" / "PRECIS.md")
+    ok("[real] Part III floor passes (all [@key] resolve)", r["pass"] is True, str(r["evidence"].get("bibUnresolved")))
+    ok("[real] Part III dataProvenance is consistency-only (remote parquet)",
+       r["evidence"].get("dataProvenance", {}).get("mode") == "consistency-only")
+else:
+    print("  -- real tender_offers absent; smoke skipped")
+
+print(f"\n{_p} passed, {_f} failed")
+sys.exit(1 if _f else 0)

--- a/tests/writing_guards_test.py
+++ b/tests/writing_guards_test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env -S uv run python3
+"""Tests for the writing spec-layer guards:
+  - hooks/writing-outline-executable-guard.py  (PreToolUse on OUTLINE_REVIEWED.md)
+  - hooks/writing-claim-id-guard.py            (PostToolUse on outlines/ drafts/)
+
+Run:  uv run python3 tests/writing_guards_test.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXEC_GUARD = ROOT / "hooks" / "writing-outline-executable-guard.py"
+CLAIM_GUARD = ROOT / "hooks" / "writing-claim-id-guard.py"
+FIX = ROOT / "tests" / "fixtures" / "writing-section-index"
+
+_p = _f = 0
+
+
+def ok(name, cond, extra=""):
+    global _p, _f
+    if cond:
+        _p += 1; print(f"  ok  {name}")
+    else:
+        _f += 1; print(f"FAIL  {name} {extra}")
+
+
+def run(cmd, stdin=None, env=None):
+    return subprocess.run(cmd, input=stdin, capture_output=True, text=True,
+                          env={**os.environ, **(env or {})})
+
+
+def make_project(tmp: Path, *, granular=True, claim_ok=True, stale=False):
+    (tmp / ".planning").mkdir(parents=True)
+    (tmp / "outlines").mkdir()
+    (tmp / "drafts").mkdir()
+    (tmp / ".planning" / "ACTIVE_WORKFLOW.md").write_text("---\nstyle: legal\n---\n")
+    outline_md = ("## Structure\n\n### Part I. Alpha\n- a\n- b\n- c\n\n"
+                  "## Claim → Section Map\n| Claim | Primary home | x |\n|--|--|--|\n"
+                  "| CLAIM-01 | I.A | - |\n| CLAIM-02 | I.A | - |\n")
+    (tmp / ".planning" / "OUTLINE.md").write_text(outline_md)
+    if stale:
+        (tmp / ".planning" / "PRECIS_REVIEWED.md").write_text(
+            "---\nstatus: APPROVED\n---\nReviewed: five claims across two Parts.\n")
+    (tmp / "outlines" / "Part I. Alpha.md").write_text(
+        "- TBA develop this\n" if not granular else "- **A** point [@x2020]\n- **B** point\n- **C** point\n")
+    impl = "[CLAIM-01, CLAIM-02]" if claim_ok else "[CLAIM-01]"
+    (tmp / "drafts" / "Part I. Alpha (Draft).md").write_text(f"---\nimplements: {impl}\n---\nProse.\n")
+    return tmp
+
+
+# ── outline-executable-guard: CLI lint mode ─────────────────────────────────────
+r = run(["uv", "run", "python3", str(EXEC_GUARD), str(FIX)])
+ok("exec-guard CLI: fixture is executable (exit 0)", r.returncode == 0, r.stdout + r.stderr)
+ok("exec-guard CLI: fixture surfaces stale-approval note", "STALE APPROVAL" in r.stdout)
+
+with tempfile.TemporaryDirectory() as td:
+    proj = make_project(Path(td), granular=False)
+    r = run(["uv", "run", "python3", str(EXEC_GUARD), str(proj)])
+    ok("exec-guard CLI: non-granular ⇒ exit 1", r.returncode == 1, r.stdout)
+    ok("exec-guard CLI: names the placeholder", "not granular" in r.stdout)
+
+# ── outline-executable-guard: PreToolUse deny / allow ───────────────────────────
+with tempfile.TemporaryDirectory() as td:
+    proj = make_project(Path(td), claim_ok=False)  # draft missing primary CLAIM-02
+    hook_in = json.dumps({"tool_name": "Write",
+                          "tool_input": {"file_path": str(proj / ".planning" / "OUTLINE_REVIEWED.md")}})
+    r = run(["uv", "run", "python3", str(EXEC_GUARD)], stdin=hook_in)
+    out = json.loads(r.stdout)
+    dec = out.get("hookSpecificOutput", {}).get("permissionDecision")
+    ok("exec-guard hook: ⊇ violation ⇒ deny", dec == "deny", r.stdout)
+    ok("exec-guard hook: deny names missing claim",
+       "CLAIM-02" in out["hookSpecificOutput"]["permissionDecisionReason"])
+
+with tempfile.TemporaryDirectory() as td:
+    proj = make_project(Path(td), stale=True)  # executable but stale approval
+    hook_in = json.dumps({"tool_name": "Write",
+                          "tool_input": {"file_path": str(proj / ".planning" / "OUTLINE_REVIEWED.md")}})
+    r = run(["uv", "run", "python3", str(EXEC_GUARD)], stdin=hook_in)
+    out = json.loads(r.stdout)
+    ok("exec-guard hook: executable+stale ⇒ allow (not deny)",
+       out.get("hookSpecificOutput", {}).get("permissionDecision") == "allow", r.stdout)
+    ok("exec-guard hook: allow carries stale note",
+       "stale" in out["hookSpecificOutput"]["permissionDecisionReason"].lower())
+
+# unrelated file ⇒ no-op
+r = run(["uv", "run", "python3", str(EXEC_GUARD)],
+        stdin=json.dumps({"tool_name": "Write", "tool_input": {"file_path": "/tmp/whatever.md"}}))
+ok("exec-guard hook: non-OUTLINE_REVIEWED write ⇒ no-op", r.stdout.strip() == "" and r.returncode == 0)
+
+# ── claim-id-guard: block draft / warn outline ──────────────────────────────────
+with tempfile.TemporaryDirectory() as td:
+    proj = make_project(Path(td))
+    # a draft with NO claim, inside a project ⇒ block
+    bad_draft = proj / "drafts" / "Orphan (Draft).md"
+    bad_draft.write_text("# Orphan\nProse with no claim id.\n")
+    r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
+            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(bad_draft)})})
+    out = json.loads(r.stdout)
+    ok("claim-guard: draft w/o claim in project ⇒ block", out.get("decision") == "block", r.stdout)
+
+    # an outline with NO claim ⇒ warn (continue), never block
+    bad_outline = proj / "outlines" / "Orphan.md"
+    bad_outline.write_text("- a point with no claim id\n")
+    r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
+            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(bad_outline)})})
+    out = json.loads(r.stdout)
+    ok("claim-guard: outline w/o claim ⇒ continue (warn)", out.get("result") == "continue" and "message" in out)
+
+    # a draft WITH a claim ⇒ continue, no block
+    r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
+            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(proj / "drafts" / "Part I. Alpha (Draft).md")})})
+    out = json.loads(r.stdout)
+    ok("claim-guard: draft with claim ⇒ continue", out.get("result") == "continue" and "decision" not in out)
+
+print(f"\n{_p} passed, {_f} failed")
+sys.exit(1 if _f else 0)

--- a/tests/writing_section_index_test.py
+++ b/tests/writing_section_index_test.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env -S uv run python3
+"""Tests for scripts/writing/writing_section_index.py — the deterministic section-index
+parser (the writing analog of ds_plan_table.py).
+
+Run:  uv run python3 tests/writing_section_index_test.py
+Exits 0 iff all pass. Self-contained: uses tests/fixtures/writing-section-index plus the
+real tender_offers repo when present (skipped otherwise).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "writing"))
+
+import writing_section_index as wsi  # noqa: E402
+
+FIX = ROOT / "tests" / "fixtures" / "writing-section-index"
+
+_passed = 0
+_failed = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if cond:
+        _passed += 1
+        print(f"  ok  {name}")
+    else:
+        _failed += 1
+        print(f"FAIL  {name}{(' — ' + detail) if detail else ''}")
+
+
+# ── fixture: the happy path with all the real-repo tricky cases ──────────────────
+res = wsi.build_index(FIX)
+by = {s.name: s for s in res.sections}
+
+check("style read from ACTIVE_WORKFLOW", res.style == "legal", res.style)
+check("ok=True (no blocking violations)", res.ok, str(res.violations))
+check("5? no — 4 sections discovered", len(res.sections) == 4, str(len(res.sections)))
+
+# document order from `## Structure`, not lexical
+order = [s.name for s in res.sections]
+check("document order from ## Structure",
+      order == ["Introduction", "Part I. The Setup — Foundations",
+                "Part II — The Core Channels", "Conclusion"], str(order))
+
+# prev/next threading
+check("prev/next ends are empty",
+      by["Introduction"].prev_name == "" and by["Conclusion"].next_name == "")
+check("prev/next interior",
+      by["Part II — The Core Channels"].prev_name == "Part I. The Setup — Foundations"
+      and by["Part II — The Core Channels"].next_name == "Conclusion")
+
+# tolerant filename pairing: Part I uses "(Outline)" suffix; others use bare "<Name>.md"
+check("tolerant outline pairing: bare <Name>.md",
+      by["Introduction"].outline_file is not None
+      and by["Introduction"].outline_file.endswith("Introduction.md"))
+check("tolerant outline pairing: (Outline) suffix",
+      by["Part I. The Setup — Foundations"].outline_file is not None
+      and by["Part I. The Setup — Foundations"].outline_file.endswith("(Outline).md"))
+check("draft pairing: (Draft) suffix, em-dash safe",
+      by["Part II — The Core Channels"].draft_file is not None
+      and by["Part II — The Core Channels"].draft_file.endswith("(Draft).md"))
+
+# claim → section map: PRIMARY home only
+check("primary claims from map: Part I = {01}",
+      by["Part I. The Setup — Foundations"].primary_claims == ["CLAIM-01"])
+check("primary claims from map: Part II = {02,03}",
+      by["Part II — The Core Channels"].primary_claims == ["CLAIM-02", "CLAIM-03"])
+check("primary claims: Intro/Concl echo-only = {}",
+      by["Introduction"].primary_claims == [] and by["Conclusion"].primary_claims == [])
+
+# ⊇ semantics: claimOk = draft.implements ⊇ primary (NOT equality, NOT draft ⊆ outline)
+check("claimOk True: superset (Intro surveys all, primary {})",
+      by["Introduction"].claim_ok is True)
+check("claimOk True: Part I draft {01,02} ⊇ primary {01}",
+      by["Part I. The Setup — Foundations"].claim_ok is True
+      and by["Part I. The Setup — Foundations"].implements == ["CLAIM-01", "CLAIM-02"])
+check("claimOk True: Part II exact match still ⊇",
+      by["Part II — The Core Channels"].claim_ok is True)
+
+# stale-approval: PRECIS_REVIEWED says 4 claims, live has 3 → flagged; 2 Parts matches → not flagged
+check("stale approval: claim-count mismatch surfaced",
+      any("4 claims" in m and "3" in m for m in res.stale_approval), str(res.stale_approval))
+check("stale approval: matching Part count NOT falsely flagged",
+      not any("Parts" in m for m in res.stale_approval), str(res.stale_approval))
+
+# sourcesPinned advisory + outline-based: [@key] present ⇒ true; bare CLAIM-XX does NOT count
+check("sourcesPinned true where outline has [@key]",
+      by["Part I. The Setup — Foundations"].sources_pinned is True)
+check("sourcesPinned false where outline has only CLAIM-XX, no [@key]",
+      by["Part II — The Core Channels"].sources_pinned is False)
+
+
+# ── granularity floor: placeholder + bare-headings bounce ────────────────────────
+g_ok, _ = wsi._granularity("- a\n- b\n- c\n")
+check("granular: 3 bullets passes", g_ok is True)
+g_tba, note_tba = wsi._granularity("# Sec\n- TBA — develop this section\n- b\n- c\n")
+check("granular=False on placeholder (TBA)", g_tba is False and "TBA" in note_tba.upper())
+g_bare, note_bare = wsi._granularity("# Sec\n## A\n## B\n")
+check("granular=False on bare headings", g_bare is False and "bare-headings" in note_bare)
+
+
+# ── ⊇ direction negative: draft MISSING a primary claim must fail (not pass) ──────
+with tempfile.TemporaryDirectory() as td:
+    proj = Path(td)
+    (proj / ".planning").mkdir()
+    (proj / "outlines").mkdir()
+    (proj / "drafts").mkdir()
+    (proj / ".planning" / "ACTIVE_WORKFLOW.md").write_text("---\nstyle: econ\n---\n")
+    (proj / ".planning" / "OUTLINE.md").write_text(
+        "## Structure\n\n### Part I. Alpha\n- a\n- b\n- c\n\n"
+        "## Claim → Section Map\n| Claim | Primary home | x |\n|--|--|--|\n"
+        "| CLAIM-01 | I.A | - |\n| CLAIM-02 | I.A | - |\n")
+    (proj / "outlines" / "Part I. Alpha.md").write_text("- **A** point\n- **B** point\n- **C** point\n")
+    # draft implements only 01, but map assigns {01,02} → claimOk must be False
+    (proj / "drafts" / "Part I. Alpha (Draft).md").write_text("---\nimplements: [CLAIM-01]\n---\nx\n")
+    r2 = wsi.build_index(proj)
+    s2 = r2.sections[0]
+    check("⊇ negative: missing primary claim ⇒ claimOk False",
+          s2.claim_ok is False and "CLAIM-02" in str(r2.violations))
+    check("style econ read", r2.style == "econ")
+
+
+# ── real-repo parity (skipped if absent): the golden ground truth ────────────────
+REAL = Path.home() / "projects" / "tender_offers" / "paper"
+if (REAL / ".planning" / "OUTLINE.md").is_file():
+    rr = wsi.build_index(REAL)
+    names = [s.name for s in rr.sections]
+    check("[real] 5 sections, Intro→Conclusion order",
+          names == ["Introduction", "Part I. The Law and Economics of the Tender-Offer Clock",
+                    "Part II. What the Cut Affects — The Two Offer-Period Channels",
+                    "Part III. Objections and the Targeted Fix", "Conclusion"], str(names))
+    check("[real] all claimOk under ⊇", all(s.claim_ok for s in rr.sections))
+    check("[real] stale-approval fired (5≠6 claims, 4≠3 Parts)",
+          len(rr.stale_approval) >= 2, str(rr.stale_approval))
+    check("[real] every section paired to outline+draft",
+          all(s.outline_file and s.draft_file for s in rr.sections))
+else:
+    print("  -- real tender_offers repo absent; parity check skipped")
+
+
+print(f"\n{_passed} passed, {_failed} failed")
+sys.exit(1 if _failed else 0)

--- a/workflows/writing-draft.js
+++ b/workflows/writing-draft.js
@@ -27,6 +27,11 @@ const PLUGIN = cfg.pluginRoot || ''
 const OUTDIR = cfg.outputSubdir || 'drafts'
 const ONLY = Array.isArray(cfg.onlyChecks) && cfg.onlyChecks.length ? new Set(cfg.onlyChecks.map(String)) : null
 const PRIOR = new Map((Array.isArray(cfg.priorReviews) ? cfg.priorReviews : []).map(s => [String(s.section), s]))
+// Deterministic section index from scripts/writing/writing_section_index.py — the compiled "Discover".
+// When the skill passes it, we skip the LLM Discover entirely (the writing analog of ds/dev's compile
+// step, except the output is DATA — a section index — not a generated run.js). Back-compat: absent ⇒
+// the LLM Discover still runs, so old callers and projects without a compiled index keep working.
+const SECTION_INDEX = (cfg.sectionIndex && Array.isArray(cfg.sectionIndex.sections) && cfg.sectionIndex.sections.length) ? cfg.sectionIndex : null
 
 // ── Schemas ───────────────────────────────────────────────────────────────────
 const FINDING = {
@@ -97,8 +102,33 @@ const VERIFY_SCHEMA = {
 }
 
 // ── Phase 1: Discover ─────────────────────────────────────────────────────────
+// Map the deterministic section index → the DISCOVERY_SCHEMA shape (no LLM). draftFile is
+// recomputed from OUTDIR so a pilot subdir (e.g. drafts-pilot) is honored; precisClaim comes
+// from the OUTLINE.md Claim→Section Map (primary claims), falling back to the draft's implements.
+function discFromIndex(idx) {
+  const style = idx.style && idx.style !== 'unspecified' ? idx.style : 'general'
+  return {
+    style,
+    precisPath: idx.precisPath || '',
+    outlinePath: idx.outlinePath || '',
+    domainSkillPath: PLUGIN ? `${PLUGIN}/../skills/writing-${style}/SKILL.md` : '',
+    bibPath: idx.bibPath || '',
+    sections: idx.sections.map(s => ({
+      name: String(s.name),
+      outlineFile: s.outlineFile || '',
+      draftFile: `${PROJECT}/${OUTDIR}/${s.name} (Draft).md`,
+      precisClaim: ((s.primaryClaims && s.primaryClaims.length ? s.primaryClaims : (s.implements || [])).join(', ')) || String(s.name),
+      outlineGranular: s.granular !== false,
+      sourcesPinned: !!s.sourcesPinned,
+      granularityNote: s.granularityNote || '',
+      prevName: s.prevName || '',
+      nextName: s.nextName || '',
+    })),
+  }
+}
+
 phase('Discover')
-const disc = await agent(
+const disc = SECTION_INDEX ? discFromIndex(SECTION_INDEX) : await agent(
   `Enumerate the sections the writing-draft phase must produce, reading the APPROVED outlines. Working directory: ${PROJECT}
 
 1. Set style: read ${PROJECT}/.planning/ACTIVE_WORKFLOW.md if present; if ABSENT, INFER style from the material (a law-review / legal paper → "legal"; an economics paper → "econ"; otherwise "general"). Read .planning/PRECIS.md and .planning/OUTLINE.md if present (set their absolute paths, or "" if absent). If OUTLINE.md is absent, derive document order from the outline filenames + their headings.
@@ -112,6 +142,7 @@ Use ABSOLUTE paths. Return DISCOVERY_SCHEMA.`,
   { label: 'discover', phase: 'Discover', schema: DISCOVERY_SCHEMA, model: 'sonnet' }
 )
 if (!disc.sections.length) throw new Error(`writing-draft: no section outlines found under ${PROJECT}/outlines/. Outlines must exist (and OUTLINE_REVIEWED.md be APPROVED) before drafting.`)
+if (SECTION_INDEX) log(`Discover: deterministic section index (${disc.sections.length} sections, ${disc.style}) — no LLM Discover`)
 const underGranular = disc.sections.filter(s => s.outlineGranular === false)
 const draftable = disc.sections.filter(s => s.outlineGranular !== false)
 const outlineByName = Object.fromEntries(disc.sections.map(s => [String(s.name), s]))

--- a/workflows/writing-review.js
+++ b/workflows/writing-review.js
@@ -24,6 +24,11 @@ const PROJECT = cfg.projectDir
 if (!PROJECT) throw new Error(`writing-review requires args.projectDir. Got "${typeof args}": ${JSON.stringify(args)?.slice(0, 200)}`)
 const ONLY = Array.isArray(cfg.onlyChecks) && cfg.onlyChecks.length ? new Set(cfg.onlyChecks.map(String)) : null
 const PRIOR = new Map((Array.isArray(cfg.priorReviews) ? cfg.priorReviews : []).map(s => [s.section, s]))
+const PLUGIN = cfg.pluginRoot || ''
+// Deterministic section index from scripts/writing/writing_section_index.py — the compiled "Discover".
+// Same shared parser both writing engines consume, so they cannot drift from each other or from the
+// outline-executable guard. Absent ⇒ the LLM Discover still runs (back-compat).
+const SECTION_INDEX = (cfg.sectionIndex && Array.isArray(cfg.sectionIndex.sections) && cfg.sectionIndex.sections.length) ? cfg.sectionIndex : null
 
 // ── Schemas ───────────────────────────────────────────────────────────────────
 const ISSUE = {
@@ -119,8 +124,28 @@ const DOCUMENT_SCHEMA = {
 }
 
 // ── Phase 1: Discover ─────────────────────────────────────────────────────────
+// Map the deterministic section index → the review DISCOVERY_SCHEMA shape (no LLM). draftFile is
+// the existing draft (review does not write), precisClaim from the OUTLINE.md Claim→Section Map.
+function discFromIndex(idx) {
+  const style = idx.style && idx.style !== 'unspecified' ? idx.style : 'general'
+  return {
+    style: cfg.style || style,
+    precisPath: idx.precisPath || '',
+    outlinePath: idx.outlinePath || '',
+    sourcesBib: idx.bibPath || '',
+    domainSkillPath: PLUGIN ? `${PLUGIN}/../skills/writing-${style}/SKILL.md` : '',
+    repetitionScript: PLUGIN ? `${PLUGIN}/../skills/writing-review/scripts/bridge_repetition_check.py` : '',
+    sections: idx.sections.map(s => ({
+      name: String(s.name),
+      outlineFile: s.outlineFile || '',
+      draftFile: s.draftFile || '',
+      precisClaim: ((s.primaryClaims && s.primaryClaims.length ? s.primaryClaims : (s.implements || [])).join(', ')) || (s.draftFile ? String(s.name) : 'MISSING DRAFT'),
+    })),
+  }
+}
+
 phase('Discover')
-const disc = await agent(
+const disc = SECTION_INDEX ? discFromIndex(SECTION_INDEX) : await agent(
   `Enumerate the document's sections and resolve the review inputs. Working directory: ${PROJECT}
 
 1. Determine \`style\` (legal|econ|general): read .planning/ACTIVE_WORKFLOW.md if it exists; if it does NOT exist, infer from .planning/PRECIS.md's "Domain" line — pure law → legal, pure empirical → econ, and a **hybrid/mixed domain → general** (the safe baseline). ${cfg.style ? `Caller override: use style="${cfg.style}".` : ''}
@@ -134,6 +159,7 @@ Return DISCOVERY_SCHEMA. Absolute paths.`,
 )
 if (!disc.sections.length) throw new Error('No sections discovered — check OUTLINE.md / drafts/')
 let sections = disc.sections
+if (SECTION_INDEX) log(`Discover: deterministic section index (${sections.length} sections, ${disc.style}) — no LLM Discover`)
 log(`Document: ${sections.length} sections (${disc.style}); ${ONLY ? `re-review ${ONLY.size}` : 'full review'}`)
 
 // ── Phase 2: L1 Section Review (per-section × 3 reviewers, parallel) ───────────


### PR DESCRIPTION
Ports the **spec→plan→compile** pattern to the **writing** workflow — the 3rd concrete instance after ds (PR #7) and dev (PR #8).

## The finding (why this differs from ds/dev)
Writing is the farthest sibling: its execute layer (`writing-draft.js`, `writing-review.js`) was **already** a flat-parallel fan-out (one invocation, no task DAG). So the ds/dev headline win (collapse N LLM-discovery round-trips, compile a per-project `run.js`) mostly didn't apply. The real, honest port is **3 surgical moves, upstream of the runner** — assessed in `docs/DESIGN-writing-spec-plan-compile.md` (user-signed-off before any engine change).

## What changed
1. **Deterministic Discover** — `scripts/writing/writing_section_index.py` (the writing analog of `ds_plan_table.py`): single source of truth for the section set, parsing `OUTLINE.md ## Structure` (canonical order) + `## Claim → Section Map` (the spec). **Compile output is DATA, not generated code** — the runner is generic, so the section index is a data artifact it consumes (the pass#9 code-vs-data seam, now confirmed).
2. **Both engines reconciled** to consume `args.sectionIndex` and skip the per-call LLM Discover; **back-compat fallback** to the LLM Discover retained, so old callers/uncompiled projects keep working.
3. **Guards reconciled to the shared parser** — new `hooks/writing-outline-executable-guard.py` (`validate = build_index().violations`; deny on ⊇/granularity, allow+warn on a **stale `*_REVIEWED.md`** vs live OUTLINE — the spec-layer stale-gate backstop); `writing-claim-id-guard.py` now blocks drafts with no claim trace.
4. **Born-canonical emitter** (writing-setup + writing-outline) — **first instance to close the emitter gap** ds/dev left open: tolerance eliminated, not relocated.
5. **Two-tier semantic `gateProbe`** — `scripts/writing/writing_gate_probe.py` deterministic floor returning the canonical `{pass, artifactsPresent, evidence, scope:{checked,notChecked}}` (closes audit G1 bib-grep; legal-Bluebook-prose hardened: statutory-citation guard + spelled-out blind-spot disclosure + magnitude normalization). The **semantic authority (writing-review + source-verify) stays OUTSIDE the runner** — for semantic gates the adversarial layer is the real arbiter.

## Parity (PASSED on the real `tender_offers` 12k-word paper)
- Section-set + order proven deterministically (blind-oracle diff = 0).
- Confounded current-vs-compiled double-run **rejected** (L1/L2/L3 are non-deterministic — a verdict diff would be unattributable). Single-variable design instead.
- **(A)** focused `precisClaim` probe → **benign** for the verdict.
- **(B)** compiled `/writing-review` ran **clean end-to-end** (consumed `args.sectionIndex`, no LLM Discover, JS substrate gate computed the verdict).
- Non-blocking nuance: `precisClaimAdvanced` is reviewer-noise + not gate-bearing → the `precisClaim` enrichment is deferred (no speculative build).

## Tests (all green; ds/dev unaffected)
section-index 28 · guards 12 · gate-probe 23 · engine-discover 13 · ds 28/17/15 · dev 35/32.

Worked in coordination with the **tender-parity** (real-repo parity) and **dev-refactor** / **ds-refactor** (pass#9 shared-core seam) sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)