### PR TITLE
feat(workshop): port spec→plan→compile pattern (4th instance) (v5.59.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.58.0"
+    "version": "5.59.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.58.0",
+      "version": "5.59.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.58.0",
+  "version": "5.59.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/docs/DESIGN-workshop-spec-plan-compile.md
+++ b/docs/DESIGN-workshop-spec-plan-compile.md
@@ -1,0 +1,628 @@
+# DESIGN: the `spec → plan → compiled run.js` pattern applied to the **workshop** workflow
+
+Status: **DRAFT — assessment first, awaiting USER sign-off before any engine change.**
+Companions: `docs/DESIGN-ds-spec-plan-compile.md` (1st instance, exit-code gate, shipped),
+`docs/DESIGN-dev-spec-plan-compile.md` (2nd instance, exit-code gate, v5.56.0/PR#8),
+`docs/DESIGN-writing-spec-plan-compile.md` (**3rd instance, judgment gate — workshop's TWIN**),
+`docs/common-infra-candidates.md` (the canonical seam list; pass #9 extraction in flight).
+
+> The brief asked for an **honest assessment, not code**. Headline finding:
+> **workshop is writing's structural twin, and is in fact MORE ready than writing was.** Its execute
+> layer (`workshop-generate.js`) is already a flat-parallel fan-out and its verify layer
+> (`workshop-verify.js`) is already a substrate-split JS gate with semantic authority outside
+> (independently confirmed: a `wc-audit` of the workshop workflow scored **9.64 / PASS, 0 critical**,
+> §9). What ports is narrow, the same shape writing took: it is about the **spec** (the slide table),
+> the **one shared parser**, and **honest fidelity/scope**, NOT a per-project `run.js`.
+
+---
+
+## 0. TL;DR
+
+ds/dev replaced a **generic interpreter** (an LLM "discovery" agent re-parsing `PLAN.md` once per
+dependency level) with a **deterministic compiler + a per-project compiled `run.js`** that topo-sorts
+a task DAG and gates each task on a real **exit code**.
+
+**Workshop already did the parts that mattered most.** `workflows/workshop-generate.js` and
+`workflows/workshop-verify.js` are *already* ultracode workflows with a `Discover → fan-out → gate`
+shape that runs the **whole deck in ONE invocation** with **genuine per-section parallelism**. There
+is **no task DAG** — workshop sections are deliberately independent (linear narrative; the only
+coupling is shared *read-only* inventory IDs, a shared resource, never producer→consumer; confirmed on
+the real 38-slide opv deck). So the three ds/dev wins land as:
+
+| ds/dev win | Workshop status |
+|---|---|
+| Kill ~N LLM-discovery round-trips → 1 topo-run | **N/A** — already 1 invocation, already flat-parallel; no DAG to topo-sort |
+| Kill the per-call LLM discovery re-parse | **The real win — DOUBLED.** `workshop-generate` AND `workshop-verify` EACH carry their own LLM `Discover` re-parsing the same OUTLINE → two drift masks, not one (§3) |
+| Cheap honest gate via real exit code | **Workshop is RICHER than writing here** — `typst compile` + `check-all.py` give genuine **exit codes** (a rich-mechanical floor), with a semantic *ceiling* (per-slide convention/notes/fidelity + visual). The substrate-split JS gate already encodes this (§4) |
+
+The honest, high-value port for workshop is **two surgical moves + one emitter move**, not a run.js
+rewrite:
+
+1. **Extract ONE shared parser** (`scripts/workshop/workshop_slide_table.py`) out of
+   `hooks/workshop-outline-executable-guard.py`'s `find_slide_table`, and point its consumers at it —
+   the guard (`validate = parse().violations`), `workshop-generate`'s Discover (**fully** replaced),
+   and the **OUTLINE-reading PART** of `workshop-verify`'s Discover (an inventory/section **side-table**
+   only — see §3a, the cardinality correction). Output = **DATA** (a slide work-list + a side-table).
+   This kills the doubled drift mask and makes "compiles ⇔ passes the gate" a property.
+2. **Ground the self-reported fidelity + disclose floor scope.** `workshop-generate`'s
+   `fidelityOk = citedInventory ⊆ allowed` trusts the section agent's **self-reported** `citedInventory`
+   — grep the fragment `.typ` files for `F/T/R/A` tokens instead (the writing-G1 fix). And give
+   `workshop-verify`'s deterministic floor a `scope:{checked, notChecked}` disclosure (doctrine #3
+   addendum) so a clean mechanical pass never implies it verified the visual/semantic ceiling.
+3. **Born-canonical emitter (same pass).** Phase 2 emits the canonical Slide Spec **table** going
+   forward; the shared parser stays **tolerant** of the real **prose** form as a back-compat shim.
+
+**What does NOT change:** gather / structure (outline) stay conversational + human-gated; the
+**workshop-verify → workshop-revise `/goal` loop stays OUTSIDE** any runner as the real correctness
+authority; the **substrate-split JS gate** (blocking = critical+major, minors advisory) is preserved
+byte-for-byte. **We do NOT generate a per-project `.planning/run.js`** (§7 — same divergence writing
+recorded; workshop is the *second* "compile = data" instance, validating that branch).
+
+---
+
+## 1. The PARITY REGRESSION constraint (top-level — drives every decision below)
+
+The parity partner (`opv-parity`) stress-tested the real, shipped, last-scored-9.5 deck at
+`~/projects/opv` (projectDir holds BOTH `.planning/` and `presentation/`; **`presentation/.planning/`
+is STALE/superseded — ignore it**). Findings that shape the design:
+
+- **The real `OUTLINE.md` is free-form PROSE, NOT a table.** It carries the same semantic fields
+  (`- Slide: "Takeaway." — bullets → [A2, R1, ...]`, sections via `=`/`==`) but as bullet lines, not
+  `|`-table rows. **Zero `|`-tables.**
+- **The strict guard `workshop-outline-executable-guard.py` FAILS (exit 1) on it** ("No executable
+  Slide Spec table found … prose … which workshop-generate cannot fan out"). Same FAIL on
+  `OUTLINE_APPROVED.md`.
+- **The OUTLINE is also INCOMPLETE relative to the built deck** (§3a): 21 OUTLINE rows vs **38**
+  `#slide[` blocks — the Appendix drifted 3 specced → 19 built (Q&A backups added directly in
+  slides.typ, never in OUTLINE).
+- **This IS the drift mask, caught live.** The LLM `Discover` in both engines silently tolerates the
+  prose form (workshop-verify already degrades: prose/absent OUTLINE → `inventoryRefs` empty → slides
+  classified `PARTIAL`). A naïve strict parser would reject **every** real slide — exactly ds's "the
+  guard rejected every real muni row" moment.
+
+**Therefore the #1 design rule:** the executable-table contract must **NOT** become a precondition for
+**VERIFY** or **REVISE** — only for net-new **GENERATE**. The deterministic parser **replaces** the
+LLM Discover where an OUTLINE parses **in either form**; where it is prose/absent, verify degrades
+**exactly as today** (`inventoryRefs` empty → `PARTIAL`). **Zero regression on existing decks.** This
+is why move (1) ships the parser **tolerant** and the emitter **canonical** in the *same* pass (the
+writing resolution: tender_offers used `<Name>.md` not the documented `<Name> (Outline).md`; tolerant
+parser + canonical emitter).
+
+**Second preserved invariant (opv-parity):** the **advisory-minor substrate split** in
+`workshop-verify.js` is an *encoded judgment* (compile/constraints/widows/overflow/fidelity/notes/visual
+crit+major BLOCK; per-slide convention/style minors are ADVISORY, non-blocking — the wc-asymptote
+"over-enforcement treadmill" lesson). The compiled parser is **upstream** of the gate; the port must
+not flatten this. Gate computation is untouched.
+
+---
+
+## 2. Mapping workshop onto the ds "spec → plan → compiled run.js" model
+
+| ds/dev concept | Workshop analog | Notes |
+|---|---|---|
+| **SPEC** (`SPEC.md`) | `SOURCES.md` (paper inventory: `F/T/R/A` IDs) | human-gated, look-at-extracted — unchanged |
+| **PLAN** (`PLAN.md` Task table) | `OUTLINE.md` **Slide Spec table** (per-slide rows) | **the spec to harden + the parser's input** (§3) |
+| **compile** (`ds_plan_table.py` → `run.js` literal) | `workshop_slide_table.py` → a **DATA** artifact (slide work-list + side-table) | **divergence:** workshop emits DATA, not code (§7) — *second* data instance after writing |
+| **run.js** (per-project compiled runner) | `workshop-generate.js` / `workshop-verify.js` (**already generic dynamic workflows**) | already exist; feed them compiled DATA instead of an LLM `Discover` |
+| **task** | **section** (a `=`/`==` run of slides; slide = sub-row) | no inter-section deps → no DAG, flat-parallel + a final **assembly barrier** (trivial 2-level, expressed directly in JS — not topo) |
+| **`implementerPrompt(t)`** | the per-**section** write-agent prompt (workshop-generate) | already exists; unchanged in shape |
+| **`gateProbe(t)`** | **two gates** (§4): generate = `{fragmentsWritten, deckCompiles}` (rich-mechanical); verify = substrate-split `{pass, evidence, scope}` | RICH-mechanical floor (real exit codes) + semantic ceiling — a **4th gate-type point** for pass #9 |
+| **adversarial layer OUTSIDE run.js** | **workshop-verify + visual-verify + the `/goal` revise loop** | stays outside; the per-slide reviewers are the writing-review L1/L2/L3 analog |
+| **two-kinds-of-decision + stale-gate backstop** | **slide-edit vs spec-changing editorial decision** (§5) | structure/proportion reframe = gate-changing → edit OUTLINE + re-index |
+| **declared/dynamic PAUSE** | **R4 (structure reorder / proportion change)** — already in workshop Phase 3/4 | unchanged |
+
+**What a "gate" is in workshop.** Two tiers, like writing — but the floor is *thicker*:
+- a **rich deterministic floor** (necessary, mostly sufficient at its layer): `typst compile` exit code,
+  `check-all.py` exit code + raw FAIL lines, `detect_widows.py` count, overflow page-count delta,
+  inventory-fidelity (`[@F/T/R/A]` grep ⊆ allowed — **once move (2) lands**). Genuine exit-code /
+  mechanical signals — *richer* than writing's grep-only floor.
+- the **semantic ceiling** (sufficient for content quality): per-slide convention/style, notes-coverage
+  adequacy, source-fidelity (claim→inventory **judgment**), and **visual-defect** scoring via
+  `look_at.py`. **Irreducibly LLM**, lives in `workshop-verify` (the verify engine = OUTSIDE the
+  execute runner), trusted only because each finding carries `{severity, file:line, verbatim quote,
+  detail}`.
+
+---
+
+## 3. Move 1 — extract the ONE shared parser (the doubled drift-mask kill)
+
+The highest-value work and the doctrine-#5 sleeper, **doubled**: the Slide Spec parser already exists
+as `find_slide_table` **inside** `hooks/workshop-outline-executable-guard.py` — but
+`workshop-generate.js` *Discover* AND `workshop-verify.js` *Discover* **each re-parse the same OUTLINE
+with an independent LLM agent**. Three readers of one spec, only one deterministic; the two LLM readers
+can silently disagree with the guard **and with each other**.
+
+**`scripts/workshop/workshop_slide_table.py`** (single source of truth, mirrors
+`writing_section_index.py`):
+- **parse BOTH forms** (tolerant — the back-compat shim the real opv deck forces):
+  - canonical **table** (`| Slide | Section | Takeaway | Bullets | Inventory | Visual | Notes |`), via
+    the existing `find_slide_table` logic lifted verbatim;
+  - real **prose** (`### Part N` / `= Section` / `== Subsection` + `- Slide: "Takeaway." — bullets →
+    [A2, R1, …]`) — extract Takeaway (quoted), Bullets (after em-dash), Inventory (`→ [...]`), Section
+    (nearest `=`/`==`).
+- emit per **slide**: `num`, `section` (the `=`+`==` grouping key), `takeaway`, `bullets`,
+  `inventory[]`, `visual`, `notes`; and per **section**: ordered slide list + `sectionOrder` (document
+  order).
+- **prefix-tolerant column lookup** (dev's gotcha: real headers carry parentheticals) and **cell
+  tolerance** (ds's gotcha: em-dash / `---` / empty ⇒ `none`).
+- **Unicode-safe slugs** (section titles carry em-dashes).
+- **byte-identical join key** (writing-refactor's gotcha a): emit each row's key (slide num + title)
+  identical to what the parser keys on AND to the slides.typ title it pairs to (the verify side-table
+  join) — zero fuzzy matching is the goal.
+- **golden-tested against the REAL opv `OUTLINE.md` (prose), NOT `custom-outline.typ`** — *the TRAP*
+  (writing-refactor's #1 gotcha): the template is already canonical so it cannot reveal the drift; only
+  the real hand-emitted deck does.
+
+### 3a. THE CARDINALITY CORRECTION — parser is the GENERATE enumerator, only a VERIFY side-table
+
+opv-parity's per-section ground truth (OUTLINE rows vs slides.typ `#slide` blocks):
+
+| Section | OUTLINE rows | slides.typ |
+|---|---|---|
+| Motivation & Background | 3 | 3 |
+| Framework / Three-Stage | 7 | 7 |
+| Re-evaluating Criticisms | 5 | 6 *(robo-voting split into 2)* |
+| Policy Proposals | 3 | 3 |
+| Appendix | 3 | **19** *(Q&A backups added in slides.typ, never in OUTLINE)* |
+| **TOTAL** | **21** | **38** |
+
+The OUTLINE (21 rows) and slides.typ (38 blocks) are **two different work-lists of different
+cardinality**. The two engines consume them differently, so the parser plays **two different roles**:
+
+- **GENERATE** (`workshop-generate`): the parser **IS the enumerator.** Its 21 OUTLINE rows == the
+  generate work-list (one fragment-agent per row). The LLM Discover is **fully replaced.** Direct
+  parity.
+- **VERIFY** (`workshop-verify`): slide enumeration **MUST stay sourced from `slides.typ` (38).** The
+  parser supplies the canonical **OUTLINE-side rows** (21: section/takeaway/bullets/inventory); the
+  **JOIN** of an OUTLINE row to a built slide stays **semantic** (§3a-join). ~18–19 body slides get
+  inventory once joined; the 17 unspecced (appendix) slides get **empty `inventoryRefs` → PARTIAL** =
+  the current degraded behavior, **zero regression.**
+
+**HARD push-back baked into the design (opv-parity):** the parser must **NEVER** become the verify
+*enumerator* — doing so would under-count this real deck by 17 slides (38→21) and **silently drop the
+entire appendix from review.** So `workshop-verify`'s Discover **splits**: (a) *enumerate slides from
+`slides.typ`* — **KEEP** (it reads the built deck, the source of truth for what is actually on screen,
+incl. the 19 drifted appendix slides); (b) *attach `inventoryRefs` from the OUTLINE rows* — the parser
+hands the LLM the **canonical candidate rows**, but the **correspondence stays semantic** (§3a-join).
+
+### 3a-join. THE JOIN IS SEMANTIC, not a string op (opv-parity, measured)
+
+opv-parity measured the OUTLINE-takeaway ↔ `slides.typ`-`===`-title correspondence on the 18 body
+slides (em-dash/quote/case normalized): **exact 6/18 (33%) · +prefix 7/18 · +token-overlap≥0.6 13/18
+(72%) · MISS 5/18** — five body takeaways are *paraphrased* in the built deck (e.g. outline "The three
+stages work together as a governance system." → deck "We decompose the proxy voting decision into a
+three-stage framework.", overlap 0.22). **A deterministic title-join caps at ~72% even with generous
+fuzzy matching and drops 5 body slides' inventory → those flip to `PARTIAL`.** The current LLM Discover
+matches these paraphrases *semantically* and attaches inventory → marks them `COVERED`.
+
+**So a pure-mechanical join is NOT zero-regression — it is a ~5-slide downgrade of the verify coverage
+map vs today.** The "degraded = same as no-OUTLINE" claim holds only for the 17 appendix slides; for the
+body, a mechanical join actively *loses* attachments the LLM recovers. **A mechanical join is a judgment
+masquerading as a string op** — the doctrine-#5 lesson *inverted* (don't put a deterministic checker
+where the task is irreducibly semantic).
+
+**This is the SAME "deterministic core + semantic authority outside" shape as the gateProbe trust-class
+(D1 / doctrine #4) — it simply recurs at the JOIN instead of the GATE** (ds-refactor / S5 owner,
+recorded canonical PR#21–22). A work-list row is therefore either **(a) mechanically-keyed** (ds parquet
+/ dev file-path → key-match — and workshop's *born-canonical* `// slide-id:` anchor, going forward) or
+**(b) candidate rows for a semantic join the LLM does OUTSIDE the parser** (legacy prose decks). The
+shared-Python-S1 parser-core follow-up therefore **must NOT bake a deterministic-key-match join
+assumption** into the core — that would be silently wrong for any drifting-identifier domain.
+
+Two generalizations this surfaced (canonical, ds-refactor):
+- **Predictive rule:** *a join turns semantic exactly when the work-list enumerates from MORE THAN ONE
+  SOURCE.* Workshop is the first multi-source instance (generate ← OUTLINE spec; verify ← built
+  `slides.typ`), so its join drifts; ds/dev are single-source (the plan), so their join is mechanical by
+  construction. The design test for any new domain is simply **"does it enumerate the work-list from
+  more than one source?"** — no need to discover the semantic join the hard way.
+- **The (a)/(b) split is not fixed — a born-canonical anchor converts (b)→(a).** The `// slide-id:`
+  stamp is **doctrine #6 ("emit the key byte-identical") applied to the JOIN KEY** (the same move
+  writing made for plan ids, now for slides). Canonical guidance: *where you want a mechanical join, add
+  a born-canonical anchor — do not teach the parser to guess.*
+
+**Contract fix (keeps semantic authority outside `run.js` — the invariant):**
+- The parser **deterministically emits the OUTLINE-side table** (21 rows) + the **canonical SOURCES
+  inventory** (the full valid-id universe). KEEP — this is the real, drift-killing win.
+- ⚠ **CORRECTED by a parity variance study (opv-parity, n=3) — do NOT feed candidates INTO the join.**
+  My first cut injected the parser's rows as a candidate MENU into the verify Discover prompt ("match
+  each built slide to the BEST candidate"). The n=3 study showed this **contaminates the semantic join**:
+  the agent greedily forces **unspecced appendix slides onto the nearest row** → false COVERED (COVERED
+  count `[25,20,38]` vs free-read's stable `[21,21,19]`; appendix over-match `[5,0,16]` vs `[0,0,0]` —
+  once **all 16** appendix tables forced COVERED). A single sample had masked it (looked like 20/21 PASS).
+  **The lesson is the §3a-join lesson one level deeper: feeding the deterministic artifact *into* the
+  semantic step biases it — the same "no deterministic thing contaminating the judgment" rule, now at the
+  PROMPT.** So:
+  - **The JOIN stays a FREE OUTLINE read — byte-identical to the current LLM Discover** (correct,
+    unbiased, returns `[]` for appendix slides with no row). The parser does **not** feed the join.
+  - **The parser's contribution to verify is a deterministic WHITELIST applied in JS, AFTER Discover,
+    OUTSIDE the agent:** drop any `inventoryRef` not in the canonical SOURCES inventory (the
+    no-hallucination guard) — it cannot bias the join because the agent never sees it. *(This is the
+    achievable determinism win for verify; the big determinism wins are GENERATE (full) + the GUARD.)*
+  - **Meta-lesson (record for pass #9):** for a **judgment-flavored** seam, **single-sample parity is
+    not sufficient — variance (n≥3) is required.** A lean single sample would have shipped a false PASS.
+- **Born-canonical escape hatch (net-new decks only):** the GENERATE emitter stamps a stable
+  slide-anchor comment (e.g. `// slide-id: M-3`) into each `#slide[` block that the OUTLINE row shares
+  → the join becomes **mechanical by construction** for decks this workflow generates. Legacy prose
+  decks (opv) still take the semantic join. This is the join-layer analog of the born-canonical emitter
+  (move 3): kill the fuzzy match going forward, tolerate it backward.
+- **The join is many-built-to-one-outline, NOT a bijection** (opv-parity: S11/S12 both ⟵ one outline
+  row; S13/S14 both ⟵ one row — a deck 1→2 split). Parser candidates are 1 row per outline entry; the
+  join must allow **N built slides → 1 outline row.** Do not model it as a bijection.
+- **The port is not strictly lossy — the parser FIXES an LLM over-attach** (opv-parity: baseline S21
+  "Key findings" over-attaches `R1–R8` (8 IDs); the outline tail is only `→ [R1, R8]`; a deterministic
+  parser reading the `→ [...]` tail emits exactly `[R1, R8]`). So the trade is precise: **the parser
+  fixes LLM over-attach; the semantic join preserves LLM paraphrase-recall.**
+
+**Golden test (b) — concrete acceptance criterion (opv-parity baseline `discover_baseline_38.json`,
+21 COVERED / 17 PARTIAL):** parser-candidates + the semantic join must reproduce **COVERED on all 21
+baseline-COVERED slides**, especially the 5 paraphrase / 1→2-split cases the LLM recovers semantically —
+**S4, S9, S14, S18, S19.** Any of those landing `PARTIAL` is a measurable regression. *(A pure-mechanical
+fuzzy-join scores only **16/21** recall on this deck — the quantified proof that the join must stay
+semantic for legacy decks.)*
+
+*(Bonus signal, future enhancement only — NOT this pass: the OUTLINE(21) ↔ slides.typ(38) drift is
+itself a coverage finding verify could surface — "deck drifted 17 slides past spec; appendix unspecced."
+Record, don't build.)*
+
+### 3b. Guard reconciliation (S6)
+
+`workshop-outline-executable-guard.py` imports the new module and sets
+`validate = parse(outline).violations`. ONE format spec; strict-at-emitter / tolerant-at-parser; the
+guard asserts only structural validity (every row complete, every inventory ID exists in `SOURCES.md`),
+never format. Because the parser is tolerant of prose, **the guard now PASSES on the real opv deck** (it
+parses) — which is what removes the parity regression §1 flagged. The guard also fails loudly on a stale
+`OUTLINE_APPROVED.md` whose slide/section count disagrees with the live `OUTLINE.md` (the stale-approval
+catch, §5).
+
+**Both engines' OUTLINE-reading drops to the shared parser** (the skill runs the parser → passes
+`args.slideIndex`; back-compat fallback to the LLM Discover only if the index is absent — writing's
+pattern), with verify keeping its independent slides.typ enumeration per §3a.
+
+---
+
+## 4. Move 2 — honest fidelity + scope-disclosure (the two-tier gate, made honest)
+
+Workshop's gate is already two-tier and substrate-split; move (2) closes the two *honesty* gaps:
+
+**4a. Ground self-reported fidelity (writing-G1, workshop form).** In `workshop-generate.js` the gate
+computes `fidelityOk = (citedInventory ⊆ allowed)` from the section agent's **self-reported**
+`citedInventory` — an LLM assertion presented as a mechanical check. Fix: after the section writes its
+fragment, **grep the fragment `.typ` for inventory tokens** (`F\d+|T\d+|R\d+|A\d+`) and compute
+`⊆ allowed` from the *file*, not the report. Exactly as compilable as ds deps-resolution; currently
+not done.
+
+**4b. Scope-disclosure on the verify floor (doctrine #3 addendum / D1 `scope`).**
+`workshop-verify.js`'s mechanical leg returns raw counts but does not say **what it could not check**.
+Per the D1 contract the gate result must carry `scope:{checked, notChecked}` so a clean mechanical pass
+never implies the visual/semantic ceiling was verified. Workshop's `checked` is genuinely **larger**
+than writing's (compile + constraints are real exit codes); `notChecked` = the per-slide semantic
+judgments + the visual leg when `look_at.py` is unresolved (already surfaced as "skipped (NOT silently
+passed)" — formalize it into `scope.notChecked`).
+
+**Formalize `gateProbe` as the seam (no behavior change to the gate):** name the deterministic floor a
+`gateProbe`-shaped `{pass, artifactsPresent, evidence, scope}` (the D1 contract), with the semantic
+authority (per-slide reviewers + visual-verify) staying the **primary arbiter OUTSIDE** the execute
+runner. There is no LLM judge *inside* the execute runner's probe to game — `workshop-generate`'s gate
+is pure mechanical (fragment written ∧ compiles).
+
+**4c. Pre-existing mechanical-floor noise (opv-parity, on the stub fixture) — preserve for parity,
+fix SEPARATELY.** The "deterministic floor is clean" assumption has two **pre-existing** holes (in the
+*current* `workshop-verify.js`, NOT introduced by the port):
+- **`check-all.py` rides cross-domain PHANTOM constraints.** On the fixture: exit=1, 6 FAIL — but only
+  **3 are real deck findings** (notes-structure, section-hierarchy, teleprompter-notes); **3 are
+  phantoms** (`post-subagent-enforcement`, `topic-change-protocol`, `writing-stop-triggers`) that scan
+  `plugin_dir/skills/writing-*/SKILL.md` in the **workflows repo itself** (proven:
+  `writing-stop-triggers.py` walks `__file__.parent.parent.parent/'skills'`) — they audit *this repo's
+  skill authoring*, not the deck, and fire **identically on every workshop project**. Plus **1 tooling
+  ERROR** (`scored-tics-patterns` has no `check` attr). **Consequence: `constraintsPassed` is ~never
+  true on any real deck → the substrate gate is effectively PERMANENTLY RED regardless of slide
+  quality.** **Empirically confirmed on clean shipped main** (opv-parity, HEAD `4723f48`, not a
+  worktree/fixture quirk): all 6 `writing-*` skills × the 3 phantom docs are missing the references
+  those constraints require, and `check-all.py` resolves `__file__.parent.parent.parent/skills` = the
+  plugin's own skills dir **regardless of the `.` path arg**, so the 3 phantoms + broken module keep
+  `exit=1` even on a hypothetically perfect deck (0 real typst findings). The domain filter exists but
+  reports "0 skipped" — it fails to scope a typst project down to `typst-*`, which is the precise fix
+  locus for D-w-8. This is a *current shipped* bug, so the port must **reproduce it byte-for-byte** and
+  the fix is filed separately (D-w-8).
+- **Overflow heuristic false-positives.** `overflow = handout_pages − slide_count` over-counts because
+  `university-theme` injects a page per `=`/`==`/title divider (fixture: handout 47 pp vs 38 `#slide`
+  → naive overflow **9**, true ≈ **0**). Same story: a *current* heuristic, preserved for parity, fixed
+  separately.
+This **reinforces the move-(2) scope-disclosure**: the floor's `scope.notChecked` must eventually
+disclose "check-all includes non-typst/meta constraints; overflow is a divider-naive page-count
+heuristic" — but that disclosure is itself a behavior change → D-w-8, not folded into the port.
+
+---
+
+## 5. Pauses & the two-kinds-of-decision
+
+| ds/dev | Workshop | Resume |
+|---|---|---|
+| **behavior-only** (gate unchanged) | **slide-content edit** (fix a bullet, tighten a takeaway) | re-run that section (`onlyChecks`); no spec edit |
+| **gate-changing** (grain/key/schema → edit Verify + recompile) | **spec-changing editorial decision** (reorder sections, change time proportions, re-scope a Part) | edit `OUTLINE.md` + **re-index**; re-approve `OUTLINE_APPROVED.md`; the section re-blocks against the stale outline |
+| **dynamic R4 pause** | **R4 structural** (already in workshop Phase 3/4 deviation tables) | **PAUSE**, surface numbered deviations, human decides |
+
+**Stale-gate backstop, workshop form:** a section write-agent handed "the structure changed" must NOT
+silently drop or re-scope a slide to make the fidelity/coverage gate pass — it must re-block and state
+the OUTLINE must be updated + re-indexed + re-approved. The hardened guard catches a stale
+`OUTLINE_APPROVED.md` whose slide/section count disagrees with the live `OUTLINE.md` (writing's
+stale-`*_REVIEWED.md` catch, slide-table form). *(A per-domain forcing fixture — a deliberate
+proportion-reorder that leaves a stale approval — is the workshop analog of ds's grain-pause; build it
+in the test step.)*
+
+---
+
+## 6. What stays OUTSIDE the runner (unchanged)
+
+gather (look-at extraction) · structure/outline (conversational, **user-approved** — the one decision
+checkpoint) · **workshop-verify.js's per-slide semantic reviewers + visual-verify** · the
+**workshop-verify → workshop-revise `/goal` loop** with substrate-gate exit + max-3-turns +
+`SLIDES_REVIEWED.md`/`VALIDATION.md` artifacts. The metadata cross-check (title/authors vs SOURCES.md)
+stays in Phase 4.
+
+---
+
+## 7. The "compile = data" divergence (record for shared-core pass #9)
+
+ds/dev compile a **per-project `run.js` literal** because each project has a project-specific task DAG
+and project-specific `Verify` commands. **Workshop has neither** — its section structure is uniform and
+its runner is *generic*. So workshop's "compile" output is a **data artifact** (a slide work-list +
+side-table) the generic runner consumes, **not generated code** — the *same* branch writing took.
+**Workshop is the SECOND data instance, validating writing's branch** (ds/dev = code, writing+workshop =
+data). And it adds a genuine **4th gate-type point** for the extraction (run-core-extract agreed this is
+worth recording):
+
+| Instance | Floor | Ceiling |
+|---|---|---|
+| ds / dev | exit-code (the gate IS the probe) | — |
+| writing | mechanical-floor (grep/bib-resolution, necessary-not-sufficient) | semantic authority OUTSIDE |
+| **workshop** | **RICH-mechanical floor (`typst compile` + `check-all.py` REAL exit codes)** | semantic ceiling (per-slide judgment + visual) OUTSIDE |
+
+The D1 `{pass, artifactsPresent, evidence, scope}` contract spans all four cleanly — workshop's
+`scope.checked` is just *larger* (more is genuinely exit-code-verified); `scope.notChecked` = the
+visual/semantic ceiling. That is the contract proving it covers the whole spectrum — exactly what the
+extraction wanted.
+
+**Run-core consumption decision:** workshop **consumes the DATA seams** of the pass-#9 core — **S1**
+(deterministic table parser + column-map, shared by compiler AND guard), **S4/S4-art** (payload +
+`artifactsPresent`), **D1** (`gateProbe` contract incl. `scope`), **S6** (guard↔parser reconciliation),
+and the **doctrine** — but **NOT S2** (the topo run-template DRIVER), because it has no DAG. Same
+consumption profile as writing → **no bespoke seams**; workshop injects rather than reinvents.
+**Two workshop-specific seam refinements for pass #9 (confirmed with run-core-extract):**
+1. S1's "produce the work-list" has **two outputs** here, not one — an *enumeration* (generate ← spec)
+   and a *candidate-row set for a SEMANTIC join* (verify ← built artifact, join stays LLM). The
+   extracted core should model "compile = produce the work-list(s)" where a domain may bind the
+   work-list to a *different* enumeration source per consumer, **and where the cross-artifact
+   correspondence may itself be irreducibly semantic** (§3a-join) — the parser owns enumeration, never a
+   drifting-identifier join.
+2. **Scope of pass #9 vs the follow-up (run-core-extract's call, agreed):** pass #9 extracts
+   `run-core.js` (the **JS S2 topo driver**, ds+dev) and lands the **D1 `{pass, artifactsPresent,
+   evidence, scope:{checked,notChecked}}` contract** as the cross-instance reference (already live/tested
+   in `writing_gate_probe.py`; ds+dev gain `scope` this pass; workshop's widow/overflow regex floor gets
+   the same blind-spot disclosure). The **shared-Python S1 parser-core extraction** (so workshop +
+   writing import ONE parser-core instead of per-domain copies) is a **separate immediate FOLLOW-UP
+   pass, co-owned by run-core-extract + writing-refactor + this workshop port** — deliberately NOT folded
+   into pass #9, to keep the proven-3-instance extraction clean. Workshop is documented as the **4th
+   instance / contract consumer**, not a pass-#9 input.
+
+*(Do the run-core extraction in pass #9 after writing's A/B parity lands; this pass mirrors writing's
+already-built shape and consumes the contracts, not the driver.)*
+
+---
+
+## 8. Decisions for USER sign-off
+
+- **D-w-1 — Scope = the 2 surgical moves + 1 emitter move, NOT a per-project `run.js`.** Extract the
+  one shared parser; ground fidelity + scope-disclosure; born-canonical emitter. *(Recommended.)*
+  Forcing a ds-style generated `run.js` with a fake DAG is the "don't rewrite where the shape works"
+  anti-goal — and the real opv deck proves there's no DAG.
+- **D-w-2 — PARITY: the executable table is required ONLY for net-new GENERATE, never for
+  VERIFY/REVISE.** The parser is tolerant of the real **prose** form; the guard PASSES on existing
+  prose decks; verify/revise degrade exactly as today on prose/absent OUTLINE. **Zero regression on the
+  shipped opv deck.** *(Recommended — the parity partner's flagged constraint.)*
+- **D-w-3 — ONE shared parser `scripts/workshop/workshop_slide_table.py`**, consumed by the guard
+  (`validate = parse().violations`); **the GENERATE Discover is fully replaced** by it (its 21 rows ARE
+  the generate work-list); **the VERIFY Discover keeps its own `slides.typ` enumeration** AND keeps the
+  **OUTLINE-row↔slide JOIN semantic** — the parser supplies canonical candidate rows, the LLM does the
+  fuzzy correspondence (§3a-join: a mechanical join measured ~72% / −5 body slides = a real regression;
+  a mechanical join is a judgment masquerading as a string op). Net-new decks get a stamped slide-anchor
+  so the join is mechanical-by-construction; legacy prose decks keep the semantic join. Golden-tested
+  against the **REAL opv prose OUTLINE**, not the template (THE TRAP), two ways: (a) 21-row generate
+  parity; (b) parser-join recall vs the LLM Discover's actual attach-to-38 baseline.
+  *(Recommended — kills the doubled drift mask on *what the rows are*, without faking a semantic join.)*
+- **D-w-4 — Honest gate: grep-grounded inventory fidelity (replace self-reported `citedInventory`) +
+  `scope:{checked,notChecked}` disclosure on the verify floor (D1).** The substrate-split
+  (crit+major block, minors advisory) is preserved byte-for-byte. *(Recommended — closes the two
+  honesty gaps; no gate-behavior change.)*
+- **D-w-5 — Born-canonical emitter (same pass):** Phase 2 emits the canonical Slide Spec **table**;
+  parser stays tolerant of prose as a back-compat shim. Ship emitter + strict guard + tolerant parser
+  **together** (else old decks break). *(Recommended — writing's confirmed sequencing.)*
+- **D-w-6 — Do NOT extract `run-core` in this pass.** Workshop is the 4th data point (2nd "compile =
+  data", new rich-floor gate-type, two-output work-list) that *informs* pass #9; consume the seams,
+  don't build the core. *(Recommended.)*
+- **D-w-7 — Sequence:** (1) `workshop_slide_table.py` + golden test on the real opv prose `OUTLINE.md`
+  (two-way parity oracle per §3a); (2) reconcile the GENERATE Discover (full) + the VERIFY OUTLINE-read
+  (side-table only) to it (opv-parity runs the deterministic Mechanical leg for byte-parity, then a
+  single-slide judgment triple via `onlyChecks:["S1"]`); (3) guard reconciliation + the stale-approval
+  catch; (4) grep-grounded fidelity + `scope` disclosure; (5) born-canonical emitter; (6)
+  structure-reorder / stale-approval PAUSE fixture. **Each step tested before the next; nothing ships
+  until two-way A/B parity holds on the real opv deck.** *(Recommended.)*
+
+  **Mechanical-leg parity is byte-for-byte, NOISE INCLUDED.** The port MUST call `check-all.py` with
+  the **identical invocation** and use the **identical overflow page-count heuristic** as current
+  `workshop-verify.js` — so the 3 phantom constraint-FAILs, the 1 tooling error, and the over-counted
+  overflow all reproduce *exactly* (parity HOLDS only because both inherit the same noise). **Any
+  cleanup of that noise is NOT part of this port** (see D-w-8) — it is a separate change with its own
+  before/after, never silently folded in (silent drift would make the A/B unreadable).
+
+  **Two-track A/B fixtures (opv-parity, ready before the parser lands):**
+  - **Track A — compile-fail short-circuit (parity-critical).** The real opv deck *as-is* does **not
+    compile** (`slidesCompiled=false` — 10 missing `assets/cpva/*.png` appendix assets, S22–S31; body
+    S1–S21 intact; the committed PDFs were built in Apr/May before the assets vanished). This exercises
+    `workshop-verify.js`'s **compile-fail early-exit** (`workshop-verify.js:167`): `overallPass=false`,
+    critical compile finding(s), **and the per-slide fan-out is SKIPPED** (no 38×3 reviewers spawned).
+    **The port MUST reproduce this short-circuit** — fan-out skipped, **zero wasted agents on an
+    uncompilable deck.** Running the fan-out anyway = a parity failure. A ready-made fixture, no
+    construction needed. **Track-A pass condition asserts the STABLE short-circuit invariants, NOT an
+    exact count** (opv-parity): `overallPass===false`; `verdict==='ISSUES FOUND'`; `findings.length>=1`
+    and every finding `area==='compile'`/`severity==='critical'`; `reviews===[]`; **no per-slide
+    reviewer agents spawned**; `slidesThatFlagged===` all enumerated IDs. Assert `summary.critical>=1`,
+    **never `==2`** — because `summary.critical = 1 + compileErrors.length` is agent-bucketed and
+    *floats* run-to-run (and disagrees with the always-1 `findings.length` — a current count bug; see
+    D-w-8). The reconciled engine preserves that bug byte-for-byte; the assertion just doesn't bind to
+    the flaky number.
+  - **Track B — full pipeline (Discover + join + per-slide).** Needs a *compiling* deck → opv-parity
+    preps a **fixture COPY** under `$CLAUDE_JOB_DIR/tmp` (never touches the real `slides.typ`) with the
+    10 missing appendix figs **stubbed with placeholder rects** (chosen over dropping S22–S31) — this
+    **preserves the 38-slide / 21-COVERED-17-PARTIAL baseline shape** so diff (b)'s acceptance criterion
+    (§3a-join) stays valid against the appendix-coverage signal.
+
+- **D-w-8 — Mechanical-floor HONESTY cleanup (SEPARATE from the port; flagged before/after).** Not part
+  of the compile-pattern port, but surfaced by it (§4c) and worth doing right after parity lands:
+  (a) **scope `check-all.py` to `typst-*` / a real domain filter** so the 3 repo-meta phantoms
+  (`post-subagent-enforcement`, `topic-change-protocol`, `writing-stop-triggers`) and the broken
+  `scored-tics-patterns` module stop riding every deck's gate — today they keep `constraintsPassed`
+  permanently false, so the substrate gate can *never* go green on slide quality alone;
+  (b) **make `overflow` divider-aware** (subtract theme-injected `=`/`==`/title pages, or move to a real
+  per-slide frame-overflow check) so it stops false-positiving on every deck with section dividers;
+  (c) **land the `scope.notChecked` disclosure** from move (2) describing what the floor does/doesn't
+  cover; (d) **fix the compile-fail count inconsistency** (`workshop-verify.js:167`): `summary.critical
+  = 1 + compileErrors.length` disagrees with the always-1 `findings.length` (real opv: critical=2,
+  findings=1) — make them agree (count = `compileErrors.length`, or emit one finding per error).
+  **Each is its own commit with a before/after on the opv fixture — NEVER folded into the port's
+  parity A/B.** *(Recommended as a fast-follow; gated behind parity so the two changes never confound.)*
+
+---
+
+## 9. wc-audit result (folded in — `workflows:wc-audit` on `workshop`, 2026-06-26)
+
+**Verdict PASS · substrate gate ✅ clean · composite 9.64 / 10 (advisory; threshold 9.5) · 0 critical ·
+portability Clean · ultracode-candidacy 0 open.** This independently confirms the headline: workshop is
+already a well-built, already-migrated workflow — there is **no architectural gap** the port must
+repair; the port is the upstream honesty/determinism work this DESIGN scopes, not a rebuild.
+
+Audit signals that **corroborate the move list** (not new criticals — the relevant low-9s):
+- **P03 (9):** `OUTLINE_APPROVED` is the one gate enforced by skill prose, not a PreToolUse hook keyed
+  to `.planning/OUTLINE_APPROVED.md`. → move (1)/(3) **hardens exactly this**: the guard becomes
+  parser-backed (`validate = parse().violations`), making the structure→generate gate a real hook
+  property.
+- **P17 (9):** the Phase-3/4 `workshop-verify` reviewers are prompt-asserted read-only (platform
+  ceiling — `agent()` has no allowed-tools hook), already documented in `workshop-verify.js`. No change;
+  noted.
+- **P18 (9):** no v1/v2/out-of-scope **scope tagging** on inventory IDs. Orthogonal to this port;
+  candidate follow-up, not in scope.
+- **Enforcement: Fact Rows "Weak" in generate; Red Flags+STOP "Weak" in structure.** Minor skill-prose
+  polish, independent of the compiled-pattern port — fold opportunistically, not gating.
+
+The candidacy scan classifies **generate as already-migrated** (the workshop-generate ultracode
+workflow) and **gather/structure as correctly single-agent** (no fan-out value) — i.e. the runner
+architecture is already the target shape. Nothing in the audit reopens the "needs a run.js" question.
+
+---
+
+## 9b. Build status (worktree `worktree-workshop-spec-plan-compile`, NOT shipped)
+
+User signed off ("ok" → D-w-1…D-w-7 approved; D-w-8 mechanical-floor cleanup = fast-follow after parity).
+
+- ✅ **Step 1 — `scripts/workshop/workshop_slide_table.py`** (the deterministic Discover, the ONE shared
+  parser). Parses BOTH forms (canonical 7-col table + legacy 4-field prose); `build_index() → SlideIndex`
+  with `.ok`/`.violations` (guard contract) + `.to_dict()` DATA work-list; prefix-tolerant columns (dev),
+  unicode-safe slug (writing), inventory over-attach FIX (`[R1-R8]` → literal `['R1','R8']`),
+  stale-approval backstop. **30/30** (`tests/workshop_slide_table_test.py`: mixed-form fixtures + the
+  REAL-opv-deck parity block — THE TRAP). On the real opv prose deck: **form=prose, 21 slides, 5
+  sections, ok=TRUE** (prose parses clean → parity-regression fixed), and the **stale-approval catch
+  fired live** (approved 18/4 vs live 21/5).
+- ✅ **Two-way A/B (opv-parity) — PASSED + 1 measured improvement.** (a) GENERATE: **exact 21/21**
+  (section/takeaway/inventory-deduped). (b) VERIFY side-table (semantic join, NOT mechanized): candidate
+  supplied for **21/21** baseline-COVERED → COVERED reproduced on all 21; inventory == baseline 20/21,
+  the 1 diff being the S21 **over-attach FIX** (parser more correct, not a regression); the 5 focus
+  paraphrase/split cases **S4/S9/S14/S18/S19 all reproduced exact**; non-bijection confirmed
+  (S11/S12→{F1,F2,R9}, S13/S14→{A3,F3,R10}). **Mechanical titleSlug ceiling = 10/38** → empirically
+  proves the legacy join cannot be mechanized (titleSlug is sound ONLY for the born-canonical anchor
+  path). prose parses clean (ok=True, violations=[]); stale-approval fired (18/4 vs 21/5).
+  *(`AB_RESULTS.md` archived in opv-parity's job dir.)*
+- ✅ **Step 2 — engine reconciliation (engines done + unit-tested; skill-wiring next).**
+  `workshop-generate.js`: `SLIDE_INDEX` gate + `discFromIndex()` **full-replaces** the LLM Discover
+  (composite-group fan-out key; the assembly agent now constructs `fileHeader` so discFromIndex is 100%
+  deterministic); LLM-Discover fallback retained. `workshop-verify.js`: KEEPS the slides.typ enumeration
+  + the **semantic** OUTLINE-row↔slide JOIN, but feeds the Discover deterministic **CANDIDATE rows** from
+  the parser (no free OUTLINE re-parse; inventory drawn ONLY from candidates). Parser also emits
+  `paperPath` (deterministic SOURCES read, bold-tolerant). **12/12** (`tests/workshop-engine-discover.test.mjs`:
+  no-LLM-discover-when-index path, per-group fan-out, verify-keeps-semantic-join-with-candidates,
+  back-compat fallback — caught + fixed an unescaped-backtick bug in the fallback prompt).
+- ✅ **Step 2b — skills wired.** All 5 engine invocations (workshop Phase 3 generate; Phase 3/4 + selective
+  verify; workshop-revise verify) now run `workshop_slide_table.py --json > .planning/slide-index.json`,
+  surface `violations`/`staleApproval` (STOP), and pass `args.slideIndex` (omit → LLM-Discover fallback).
+- ✅ **Step 3 — guard reconciled (S6).** `hooks/workshop-outline-executable-guard.py` now imports
+  `build_index` and sets `validate = build_index(outline).violations` — ONE parser shared by guard + both
+  engines ("parses ⇔ passes the guard"). The legacy **prose form now PASSES** (the parity-regression fix —
+  was a hard deny); real defects (missing inventory, dangling id) still DENY; **stale approval is
+  allow+WARN**, not a block. **6/6** (`tests/workshop_guard_test.py`, incl. the real opv deck passing the
+  guard CLI). Full regression green: parser 30/30, engine-discover 12/12, guard 6/6.
+- ✅ **Track A — PASS.** Reconciled vs current verify on the real compile-fail deck short-circuit
+  IDENTICALLY on the stable invariants (overallPass=false; verdict ISSUES; findings=1 compile/critical;
+  **reviews=[]; agent_count=2 → ZERO per-slide agents**; slidesThatFlagged=all 38; critical=2 byte-for-byte
+  on both → preserved for D-w-8). Reconciled short-circuits correctly WITH `slideIndex` present.
+- ✅ **Track B — regression FIXED + re-architected + RE-VALIDATED (n=3).** opv-parity's first n=3
+  variance study showed the candidate-MENU injection biased the verify join (appendix over-match, COVERED
+  `[25,20,38]`). **Fix:** verify's Discover reverted to the **free OUTLINE read** (byte-identical join,
+  parity-safe) + a deterministic **JS inventory WHITELIST** (drop non-SOURCES ids, applied outside the
+  agent — no join bias). Parser emits `sourcesInventory`; `paperPath` `~`-expanded. **16/16**
+  (`workshop-engine-discover.test.mjs`). **Re-run n=3 CONFIRMS:** COVERED `[21,21,21]` (tighter than
+  current's `[21,21,19]`), appendix over-match **`[0,0,0]`** (matches current). Whitelist validated as a
+  clean no-op hallucination guard on this deck (all attributed ids ∈ the 37-id `sourcesInventory`).
+  **Honest caveat:** the S21 over-attach FIX is **GENERATE-path only** (where the parser's 21 rows ARE the
+  source); VERIFY stays at parity with current (incl. current's S21 over-attach — all real ids, whitelist
+  keeps them). **Step 2 is parity-clean on the real opv deck — shippable.**
+- ✅ **Step 4 — honest gate (both gaps closed).** (4a) `workshop-generate` section agents now **ground
+  `citedInventory` in the file** (`grep -ohE '[FTRA][0-9]+' section-N.typ`) instead of memory — the JS gate's
+  `fidelityOk ⊆ allowed` check is now backed by a real file scan (writing-G1 analog). (4b)
+  `workshop-verify` returns a **`scope:{checked, notChecked}`** disclosure (D1 / doctrine #3 addendum) on
+  both the full gate and the compile-fail short-circuit — a clean pass no longer over-claims (it states the
+  constraints-phantom/permanently-red caveat, the divider-naive overflow caveat, the SEMANTIC reviewers +
+  unbiased join live OUTSIDE the floor, and the visual-skip when `look_at` is unresolved). Additive fields,
+  gate booleans unchanged → parity-safe. **20/20** (`workshop-engine-discover.test.mjs`). Full suite green:
+  parser 31/31, guard 6/6, engines 20/20.
+- ✅ **Step 5 — born-canonical emitter reconciled (doctrine #6).** Phase 2 already emits the canonical
+  7-col Slide Spec table; reconciled its framing to the shared parser (table = canonical, pins Visual+Notes
+  so generation renders rather than invents; prose = legacy back-compat shim only; new decks MUST emit the
+  table). Verified the parser parses the SKILL's **exact** template byte-for-byte (Part-prefix + `==`
+  backtick + parenthetical Visual) — the emitter↔parser drift catch is now a golden test (`test_table`).
+  *(The `// slide-id:` anchor for a mechanical verify join — §3a-join escape hatch — is intentionally
+  DEFERRED: it only helps net-new decks and would re-touch the just-validated verify join; no speculative
+  build.)*
+- ✅ **Step 6 — structure-reorder PAUSE fixture** (`test_reorder_pause_fixture`, the workshop grain-pause
+  analog): a reframe (2 Parts/2 slides → 3 Parts/4 slides) leaves a stale `OUTLINE_APPROVED.md`; the live
+  OUTLINE parses clean (the reframe is legitimate) yet `stale_approval` fires → routes to a re-approve
+  PAUSE, never silently trusting the stale APPROVED. Fires live on the real opv deck too (18/4 vs 21/5).
+- ✅ **Generate end-to-end A/B (opv-parity, optional) — PASS + 1 gate-gap FIXED.** A full reconciled-generate
+  run on a fresh opv copy: overallPass=true, 13/13 sections, deck compiles, **agent_count=14 (13 section + 1
+  assembly, NO LLM discover)**, and grep-fidelity (4a) independently confirmed **file-backed** (re-grep of each
+  fragment == reported `citedInventory`). **Gate-gap found + folded in:** the generate gate compiled ONLY
+  `slides.typ`, so section agents inventing notes macros could ship a malformed `notes.typ` that still passed.
+  **Fix (cheap, deterministic, parity-neutral):** the assembly agent now compiles `notes.typ` too;
+  `notesCompiled` gates `overallPass` (critical finding on failure); section agents are told to write plain
+  prose notes, NO invented macros. **23/23** (`workshop-engine-discover.test.mjs`: notes-fail blocks, macro
+  forbidden).
+- ✅ **ALL PORT STEPS COMPLETE.** Full suite green: **parser 37/37, guard 6/6, engines 23/23.** Step 2
+  parity-validated by opv-parity (Track A + B, n=3); generate path end-to-end validated. Uncommitted in
+  `worktree-workshop-spec-plan-compile`.
+- ⬜ **D-w-8** (separate fast-follow, gated behind parity) — mechanical-floor cleanup: scope `check-all.py`
+  to `typst-*` (kill the permanently-red phantoms), divider-aware overflow, the `critical`/`findings.length`
+  count fix. Each its own before/after commit; NOT part of this port's parity surface.
+
+## 10. Honest bottom line
+
+Workshop is writing's twin and is **further along than writing was at assessment time**: it already has
+the executable-spec guard writing had to *add*, already has the substrate-split JS gate, already keeps
+verify/revise outside the runner, has a **richer** (real-exit-code) deterministic floor, and scores
+**9.64 / PASS** on its own architecture audit. So copying the compiled-`run.js` machinery would bolt
+DAG/topo/recompile ceremony onto a workflow that — proven on a real 38-slide deck — has no DAG. The
+**real** workshop port is **upstream of the runner**: extract the **one shared parser** that three
+readers currently re-derive (a *doubled* drift mask), make **inventory fidelity grep-grounded** and the
+**floor scope-honest**, and emit a **born-canonical** slide table while keeping the parser tolerant of
+the real prose decks already in the wild — with the **cardinality correction** baked in so verify never
+under-counts a drifted deck. That respects "don't rewrite where the shape works," fixes a real parity
+regression instead of causing one, and hands the pass-#9 extraction its **fourth** data point: a gate
+that is **rich-mechanical-floor + semantic-ceiling**, and a "compile" that emits **data, not code** with
+a **two-output work-list** — the second instance confirming that branch.

--- a/hooks/workshop-outline-executable-guard.py
+++ b/hooks/workshop-outline-executable-guard.py
@@ -26,79 +26,22 @@ Standalone:  uv run python3 workshop-outline-executable-guard.py path/to/OUTLINE
 """
 
 import json
-import re
 import sys
 from pathlib import Path
 
-REQUIRED = ("slide", "section", "takeaway", "bullets", "inventory", "visual", "notes")
-
-
-def find_slide_table(text: str):
-    lines = text.splitlines()
-    i = 0
-    while i < len(lines):
-        line = lines[i].strip()
-        if line.startswith("|") and "|" in line[1:]:
-            header = [c.strip().lower() for c in line.strip("|").split("|")]
-            sep = lines[i + 1].strip() if i + 1 < len(lines) else ""
-            is_sep = bool(re.match(r"^\|?[\s:|-]+\|[\s:|-]+\|?$", sep)) and "-" in sep
-            if is_sep and {"slide", "section", "takeaway", "inventory"}.issubset(set(header)):
-                rows = []
-                j = i + 2
-                while j < len(lines) and lines[j].strip().startswith("|"):
-                    rows.append([c.strip() for c in lines[j].strip().strip("|").split("|")])
-                    j += 1
-                return header, rows
-        i += 1
-    return None, None
-
-
-def col(header, cells, name):
-    try:
-        return cells[header.index(name)].strip().strip("`").strip()
-    except (ValueError, IndexError):
-        return ""
+# S6 reconciliation (DESIGN §3b): the guard and BOTH engines share ONE parser. "Parses ⇔ passes the
+# guard" is a property, not a hope. The parser is TOLERANT of the legacy PROSE form (so an existing
+# prose deck like opv is no longer denied — the parity-regression fix, D-w-2), CANONICAL going forward.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "workshop"))
+from workshop_slide_table import build_index  # noqa: E402
 
 
 def validate(outline_path: Path):
-    if not outline_path.is_file():
-        return [f"OUTLINE.md not found at {outline_path}"]
-    header, rows = find_slide_table(outline_path.read_text())
-    if header is None:
-        return ["No executable Slide Spec table found (need a markdown table with columns "
-                "Slide | Section | Takeaway | Bullets | Inventory | Visual | Notes). The outline "
-                "appears to list slides as `- Slide: title — source → IDs` prose, which "
-                "workshop-generate cannot fan out into per-slide fragment generation."]
-    missing = [c for c in REQUIRED if c not in header]
-    if missing:
-        return [f"Slide Spec table is missing required column(s): {', '.join(missing)}."]
-    violations = []
-    seen = set()
-    for cells in rows:
-        slide = col(header, cells, "slide")
-        m = re.match(r"^(\d+)\.", slide)
-        if not m:
-            violations.append(f"Slide row '{slide[:40]}' has no leading 'N.' number.")
-            continue
-        n = int(m.group(1))
-        if n in seen:
-            violations.append(f"Slide {n}: duplicate slide number.")
-        seen.add(n)
-        for name, label in (("section", "Section"), ("takeaway", "Takeaway"),
-                            ("bullets", "Bullets"), ("inventory", "Inventory"),
-                            ("visual", "Visual"), ("notes", "Notes")):
-            val = col(header, cells, name)
-            if not val or val.upper() == "N/A":
-                # Visual may legitimately be "none"; everything else must be substantive.
-                if name == "visual" and val.lower() == "none":
-                    continue
-                violations.append(f"Slide {n}: {label} is empty/N/A — required for an executable slide spec.")
-        inv = col(header, cells, "inventory")
-        if inv and not re.search(r"[FTRA]\d", inv):
-            violations.append(f"Slide {n}: Inventory '{inv}' has no F/T/R/A id — every slide must cite ≥1 SOURCES.md inventory item.")
-    if not seen:
-        violations.append("Slide Spec table has no slide rows.")
-    return violations
+    """Structural violations only (S6: the guard asserts validity, never format). Returns
+    build_index().violations — the SAME parse the engines consume. A prose OR table outline that
+    parses to a complete, inventory-pinned work-list passes; only real defects (missing inventory,
+    dangling F/T/R/A id, malformed/duplicate row, empty spec) block."""
+    return build_index(outline_path).violations
 
 
 def deny(reason: str):
@@ -109,10 +52,12 @@ def deny(reason: str):
 
 def main():
     if len(sys.argv) > 1 and sys.argv[1] not in ("-",):
-        v = validate(Path(sys.argv[1]))
-        if v:
-            print("OUTLINE NOT EXECUTABLE:\n- " + "\n- ".join(v)); sys.exit(1)
-        print("OUTLINE executable: Slide Spec table is complete."); sys.exit(0)
+        idx = build_index(Path(sys.argv[1]))
+        if idx.violations:
+            print("OUTLINE NOT EXECUTABLE:\n- " + "\n- ".join(idx.violations)); sys.exit(1)
+        if idx.stale_approval:
+            print("OUTLINE executable (WARN — stale approval):\n- " + "\n- ".join(idx.stale_approval)); sys.exit(0)
+        print(f"OUTLINE executable ({idx.form} form, {len(idx.slides)} slides)."); sys.exit(0)
     try:
         hook_input = json.load(sys.stdin)
     except Exception:
@@ -123,14 +68,20 @@ def main():
     if not fp or not fp.endswith("OUTLINE_APPROVED.md"):
         sys.exit(0)
     outline = Path(fp).parent / "OUTLINE.md"
-    v = validate(outline)
-    if v:
+    idx = build_index(outline)
+    if idx.violations:
         deny("GATE BLOCKED: OUTLINE.md is not machine-executable, so it cannot be approved "
              "for slide generation.\n\n"
-             f"`{outline}` problems:\n- " + "\n- ".join(v) + "\n\n"
-             "workshop-generate fans out one fragment-agent per Slide Spec row. Fix the table "
-             "(Slide | Section | Takeaway | Bullets | Inventory | Visual | Notes), then re-approve. "
-             "Do NOT list slides as `- Slide: title` prose.")
+             f"`{outline}` problems:\n- " + "\n- ".join(idx.violations) + "\n\n"
+             "workshop-generate fans out one fragment-agent per slide. Every slide needs a takeaway and "
+             "≥1 F/T/R/A inventory id (a table row OR a `- Slide: \"...\" → [IDs]` prose line). Fix, then re-approve.")
+    # Stale approval (the live OUTLINE drifted from a prior APPROVED count) is allow+WARN, not a block:
+    # the structure may legitimately have changed — surface it so the user re-confirms, don't hard-deny.
+    if idx.stale_approval:
+        print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse",
+              "permissionDecision": "allow",
+              "permissionDecisionReason": "STALE APPROVAL (allowing — re-confirm the structure change):\n- "
+              + "\n- ".join(idx.stale_approval)}}))
     sys.exit(0)
 
 

--- a/scripts/workshop/workshop_slide_table.py
+++ b/scripts/workshop/workshop_slide_table.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env -S uv run python3
+"""
+workshop_slide_table.py — THE single deterministic parser for the workshop Slide Spec.
+
+This is the workshop analog of `scripts/writing/writing_section_index.py` and
+`scripts/dev/dev_plan_table.py`: ONE module that parses the OUTLINE.md slide spec into a
+DATA work-list, shared by (a) the guard (`workshop-outline-executable-guard.py`,
+`validate = build_index().violations`) and (b) the GENERATE engine (`workshop-generate.js`
+consumes the work-list via args instead of an LLM Discover). It kills the doubled
+LLM-Discover drift mask (DESIGN §3) and makes "parses ⇔ passes the guard" a property.
+
+TWO INPUT FORMS (tolerant-at-parser, canonical-at-emitter — DESIGN §3, D-w-5):
+  • CANONICAL TABLE (born-canonical, going forward): a markdown table with columns
+    Slide | Section | Takeaway | Bullets | Inventory | Visual | Notes — 7 fields/row.
+  • LEGACY PROSE (real shipped decks, e.g. opv): `### Part N` / `= Section` / `== Subsection`
+    headings + `- Slide: "Takeaway." — bullets → [A2, R1, ...]` bullet lines. This is a
+    4-FIELD SUBSET (takeaway, bullets, inventory, + section/subsection via headings); it has
+    NO explicit Visual/Notes columns and NO slide numbers (numbers assigned by document order).
+
+WORK-LIST ROLE DIFFERS BY CONSUMER (DESIGN §3a, the cardinality correction):
+  • GENERATE: this work-list IS the enumerator (one fragment-agent per slide row).
+  • VERIFY: slide enumeration STAYS sourced from slides.typ; this work-list is only the
+    OUTLINE-side {section, inventory} candidate set for a SEMANTIC join (DESIGN §3a-join).
+    The parser owns ENUMERATION, never the drifting-identifier JOIN.
+
+CLI:  uv run python3 workshop_slide_table.py <OUTLINE.md | project-root | .planning> [--json]
+"""
+
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Canonical table columns (born-canonical emitter writes all 7).
+REQUIRED_COLS = ("slide", "section", "takeaway", "bullets", "inventory", "visual", "notes")
+# An F/T/R/A inventory id token (R1, T12, A3, F4). Range "R1-R8" yields the literal endpoints
+# [R1, R8] (NOT expanded) — this is the deliberate over-attach FIX vs the LLM Discover (DESIGN §3a-join).
+_INV_TOK_RE = re.compile(r"[FTRA]\d+")
+# A prose slide line: `- Slide: "Takeaway." — bullets → [A2, R1]`  (em-dash or hyphen separators tolerated).
+_PROSE_SLIDE_RE = re.compile(r'^\s*-\s*Slide:\s*(?P<rest>.+)$')
+# Pull the bracketed inventory tail `→ [ ... ]` (arrow optional; last bracket on the line).
+_INV_TAIL_RE = re.compile(r'(?:→|->)?\s*\[(?P<ids>[^\]]*)\]\s*$')
+
+
+def section_slug(name: str) -> str:
+    """Unicode-safe slug (NFC; em-dash/colon survive as separators). Mirrors
+    writing_section_index.section_slug — used to key OUTLINE rows for the verify side-table join."""
+    s = unicodedata.normalize("NFC", name).strip()
+    s = re.sub(r"[^\w]+", "-", s, flags=re.UNICODE).strip("-")
+    return s
+
+
+@dataclass
+class Slide:
+    num: int                    # document-order number (assigned for prose; parsed for table)
+    part: str                   # `### Part N: ...` header text ("" if none)
+    section: str                # the `=` heading (the coarse fan-out / cardinality key)
+    subsection: str             # the `==` heading ("" if none)
+    group: str                  # composite fan-out key: "<section> / <subsection>"
+    takeaway: str               # the slide's takeaway sentence (quoted in prose; Takeaway col in table)
+    bullets: str                # body content (";"- or prose-separated)
+    inventory: list[str]        # F/T/R/A ids (literal tokens; ranges kept as endpoints)
+    visual: str                 # table-only ("" in prose form)
+    notes: str                  # table-only ("" in prose form)
+    title_slug: str             # section_slug(takeaway) — the join key candidate for verify
+
+    def to_dict(self) -> dict:
+        return {
+            "num": self.num, "part": self.part, "section": self.section,
+            "subsection": self.subsection, "group": self.group, "takeaway": self.takeaway,
+            "bullets": self.bullets, "inventory": self.inventory, "visual": self.visual,
+            "notes": self.notes, "titleSlug": self.title_slug,
+        }
+
+
+@dataclass
+class SlideIndex:
+    slides: list[Slide] = field(default_factory=list)
+    form: str = "none"               # "table" | "prose" | "none"
+    section_order: list[str] = field(default_factory=list)   # distinct `=` sections, in order
+    group_order: list[str] = field(default_factory=list)     # distinct fan-out groups, in order
+    outline_path: str = ""
+    sources_path: str = ""
+    paper_path: str = ""             # the source paper, from SOURCES.md "## Source Paper / - Path:"
+    sources_inventory: list[str] = field(default_factory=list)  # ALL F/T/R/A ids in SOURCES.md (the canonical universe; verify's whitelist)
+    violations: list[str] = field(default_factory=list)
+    stale_approval: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations and bool(self.slides)
+
+    def to_dict(self) -> dict:
+        return {
+            "form": self.form, "ok": self.ok,
+            "outlinePath": self.outline_path, "sourcesPath": self.sources_path,
+            "paperPath": self.paper_path, "sourcesInventory": self.sources_inventory,
+            "sectionOrder": self.section_order, "groupOrder": self.group_order,
+            "violations": self.violations, "staleApproval": self.stale_approval,
+            "slides": [s.to_dict() for s in self.slides],
+        }
+
+
+# ── inventory tokens ──────────────────────────────────────────────────────────
+def _inv_tokens(cell: str) -> list[str]:
+    """Literal F/T/R/A tokens in order, de-duped. '[R1-R8]' → ['R1','R8'] (endpoints, not expanded)."""
+    out, seen = [], set()
+    for m in _INV_TOK_RE.finditer(cell or ""):
+        tok = m.group(0)
+        if tok not in seen:
+            seen.add(tok); out.append(tok)
+    return out
+
+
+# ── table form (canonical) ─────────────────────────────────────────────────────
+def _split_row(line: str) -> list[str]:
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def find_slide_table(text: str):
+    """(header_lower, rows) for the table whose header carries slide+section+takeaway+inventory;
+    (None, None) if absent. Same detection as the legacy guard's find_slide_table."""
+    lines = text.splitlines()
+    for i, raw in enumerate(lines):
+        line = raw.strip()
+        if not (line.startswith("|") and "|" in line[1:]):
+            continue
+        header = [c.strip().lower() for c in line.strip("|").split("|")]
+        sep = lines[i + 1].strip() if i + 1 < len(lines) else ""
+        is_sep = bool(re.match(r"^\|?[\s:|-]+\|[\s:|-]+\|?$", sep)) and "-" in sep
+        if is_sep and {"slide", "section", "takeaway", "inventory"}.issubset(set(header)):
+            rows, j = [], i + 2
+            while j < len(lines) and lines[j].strip().startswith("|"):
+                rows.append(_split_row(lines[j])); j += 1
+            return header, rows
+    return None, None
+
+
+def _col_index(header, name) -> int:
+    """Prefix-tolerant column lookup (dev's gotcha: 'Visual (figure/diagram)' satisfies 'visual')."""
+    for i, h in enumerate(header):
+        if h == name or h.startswith(name + " ") or h.startswith(name + "("):
+            return i
+    return -1
+
+
+def _cell(header, cells, name) -> str:
+    i = _col_index(header, name)
+    try:
+        return cells[i].strip().strip("`").strip() if i >= 0 else ""
+    except IndexError:
+        return ""
+
+
+def _parse_table(text: str, idx: SlideIndex) -> None:
+    header, rows = find_slide_table(text)
+    if header is None:
+        return
+    idx.form = "table"
+    missing = [c for c in REQUIRED_COLS if _col_index(header, c) < 0]
+    if missing:
+        idx.violations.append(f"Slide Spec table missing required column(s): {', '.join(missing)}.")
+    seen = set()
+    for cells in rows:
+        slide = _cell(header, cells, "slide")
+        m = re.match(r"^\s*\**\s*(\d+)\.", slide)
+        if not m:
+            idx.violations.append(f"Slide row '{slide[:40]}' has no leading 'N.' number.")
+            continue
+        n = int(m.group(1))
+        if n in seen:
+            idx.violations.append(f"Slide {n}: duplicate slide number.")
+        seen.add(n)
+        # The table's Section cell may carry both `=` Part and `==` subsection, with the
+        # separator backtick-wrapped per the SKILL format ("Part 1: Motivation `==` The Rise").
+        # Normalise backticks → spaces, then split on the `==` boundary.
+        section = _cell(header, cells, "section").replace("`", " ")
+        sec, _, sub = section.partition("==")
+        sec = sec.replace("=", "").strip() or section.replace("=", "").strip()
+        sub = sub.strip()
+        takeaway = _cell(header, cells, "takeaway")
+        visual = _cell(header, cells, "visual")
+        notes = _cell(header, cells, "notes")
+        inv_cell = _cell(header, cells, "inventory")
+        for label, val in (("Takeaway", takeaway), ("Bullets", _cell(header, cells, "bullets")),
+                           ("Inventory", inv_cell), ("Notes", notes)):
+            if not val or val.upper() == "N/A":
+                idx.violations.append(f"Slide {n}: {label} is empty/N/A — required for an executable slide spec.")
+        if not visual or visual.upper() == "N/A":
+            idx.violations.append(f"Slide {n}: Visual is empty/N/A — use 'none' if intentional.")
+        inv = _inv_tokens(inv_cell)
+        if inv_cell and not inv:
+            idx.violations.append(f"Slide {n}: Inventory '{inv_cell[:30]}' has no F/T/R/A id.")
+        group = f"{sec} / {sub}" if sub else sec
+        idx.slides.append(Slide(
+            num=n, part="", section=sec, subsection=sub, group=group, takeaway=takeaway,
+            bullets=_cell(header, cells, "bullets"), inventory=inv, visual=visual, notes=notes,
+            title_slug=section_slug(takeaway)))
+    if not seen:
+        idx.violations.append("Slide Spec table has no slide rows.")
+
+
+# ── prose form (legacy, real shipped decks) ────────────────────────────────────
+def _parse_prose(text: str, idx: SlideIndex) -> None:
+    idx.form = "prose"
+    part = section = subsection = ""
+    n = 0
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        s = line.strip()
+        if s.startswith("### "):
+            part = s[4:].strip(); continue
+        if s.startswith("== "):
+            subsection = s[3:].strip(); continue
+        if s.startswith("= "):
+            section = s[2:].strip(); subsection = ""; continue
+        pm = _PROSE_SLIDE_RE.match(line)
+        if not pm:
+            continue
+        rest = pm.group("rest").strip()
+        # inventory tail
+        inv_cell = ""
+        tail = _INV_TAIL_RE.search(rest)
+        if tail:
+            inv_cell = tail.group("ids")
+            rest = rest[:tail.start()].rstrip()
+        # takeaway = leading DOUBLE-quoted span; bullets = remainder after the em-dash/hyphen
+        # separator. Closing delimiter is double-quote ONLY — a straight/curly apostrophe inside
+        # the takeaway (e.g. "...didn't...", "...'do funds follow ISS?'...") must NOT close it.
+        takeaway, bullets = rest, ""
+        qm = re.match(r'^["“](?P<t>.+?)["”](?P<after>.*)$', rest)
+        if qm:
+            takeaway = qm.group("t").strip()
+            after = qm.group("after").strip()
+            after = re.sub(r'^\s*[—–-]\s*', "", after)   # strip the leading separator
+            bullets = after.strip()
+        n += 1
+        group = f"{section} / {subsection}" if subsection else section
+        inv = _inv_tokens(inv_cell)
+        idx.slides.append(Slide(
+            num=n, part=part, section=section, subsection=subsection, group=group,
+            takeaway=takeaway, bullets=bullets, inventory=inv, visual="", notes="",
+            title_slug=section_slug(takeaway)))
+        # Prose-form violations (4-field subset — Visual/Notes NOT required here, back-compat):
+        if not takeaway:
+            idx.violations.append(f"Slide {n}: no takeaway sentence parsed from prose row.")
+        if not inv:
+            idx.violations.append(f"Slide {n} (\"{takeaway[:30]}\"): no F/T/R/A inventory id — every slide must cite ≥1.")
+
+
+# ── stale-approval backstop (DESIGN §5) ────────────────────────────────────────
+def _stale_approval(planning: Path, idx: SlideIndex) -> None:
+    approved = planning / "OUTLINE_APPROVED.md"
+    if not approved.is_file():
+        return
+    txt = approved.read_text(encoding="utf-8", errors="ignore")
+    for key, live in (("slide_count", len(idx.slides)),
+                      ("section_count", len(idx.section_order))):
+        m = re.search(rf"^{key}:\s*(\d+)", txt, re.M)
+        if m and int(m.group(1)) != live:
+            idx.stale_approval.append(
+                f"OUTLINE_APPROVED.md {key}={m.group(1)} but live OUTLINE.md has {live} — "
+                f"the approval predates a structure change; re-approve before generating.")
+
+
+# ── public API ──────────────────────────────────────────────────────────────────
+def build_index(arg) -> SlideIndex:
+    """Parse OUTLINE.md (table OR prose) into a SlideIndex work-list. `arg` may be the
+    OUTLINE.md path, the project root, or its .planning dir. The guard consumes `.violations`."""
+    p = Path(arg)
+    if p.is_file() and p.name.endswith(".md"):
+        outline = p
+    else:
+        planning = p / ".planning" if (p / ".planning").is_dir() else (p if p.name == ".planning" else p)
+        outline = planning / "OUTLINE.md"
+    idx = SlideIndex(outline_path=str(outline))
+    if not outline.is_file():
+        idx.violations.append(f"OUTLINE.md not found at {outline}")
+        return idx
+    planning = outline.parent
+    sources = planning / "SOURCES.md"
+    idx.sources_path = str(sources) if sources.is_file() else ""
+    if idx.sources_path:
+        src = sources.read_text(encoding="utf-8", errors="ignore")
+        # first "- Path:" line (tolerate bold markers: "- **Path:**"); it is the primary paper.
+        # expanduser() the leading ~ — the path is injected verbatim into agent Read() prompts, and a
+        # subagent's Read("~/...") does NOT tilde-expand → file-not-found (opv-parity). Emit it expanded.
+        pm = re.search(r"^\s*-\s*\*{0,2}Path:?\*{0,2}\s*(?P<p>.+?)\s*$", src, re.M)
+        if pm:
+            raw = pm.group("p").strip()
+            idx.paper_path = str(Path(raw).expanduser()) if raw.startswith("~") else raw
+    text = outline.read_text(encoding="utf-8", errors="ignore")
+
+    if find_slide_table(text)[0] is not None:
+        _parse_table(text, idx)
+    else:
+        _parse_prose(text, idx)
+        if not idx.slides:
+            idx.violations.append(
+                "No executable Slide Spec found: neither a markdown table "
+                "(Slide|Section|Takeaway|Bullets|Inventory|Visual|Notes) nor `- Slide: \"...\" → [IDs]` "
+                "prose rows. workshop-generate cannot fan out.")
+
+    # distinct section / group order (document order)
+    for sl in idx.slides:
+        if sl.section and sl.section not in idx.section_order:
+            idx.section_order.append(sl.section)
+        if sl.group and sl.group not in idx.group_order:
+            idx.group_order.append(sl.group)
+
+    # dangling inventory ref check + the canonical ID universe (verify's whitelist; only if SOURCES present)
+    if idx.sources_path:
+        src = sources.read_text(encoding="utf-8", errors="ignore")
+        known = set(_INV_TOK_RE.findall(src))
+        idx.sources_inventory = sorted(known, key=lambda t: (t[0], int(t[1:])))
+        for sl in idx.slides:
+            for tok in sl.inventory:
+                if tok not in known:
+                    idx.violations.append(f"Slide {sl.num}: inventory id {tok} not found in SOURCES.md.")
+
+    _stale_approval(planning, idx)
+    return idx
+
+
+def main() -> None:
+    args = [a for a in sys.argv[1:] if a != "--json"]
+    as_json = "--json" in sys.argv
+    target = args[0] if args else "."
+    idx = build_index(target)
+    if as_json:
+        print(json.dumps(idx.to_dict(), indent=2, ensure_ascii=False))
+        sys.exit(0 if idx.ok else 1)
+    print(f"form={idx.form}  slides={len(idx.slides)}  sections={len(idx.section_order)}  "
+          f"groups={len(idx.group_order)}  ok={idx.ok}")
+    if idx.violations:
+        print("VIOLATIONS:\n- " + "\n- ".join(idx.violations))
+    if idx.stale_approval:
+        print("STALE APPROVAL:\n- " + "\n- ".join(idx.stale_approval))
+    sys.exit(0 if idx.ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/workshop-revise/SKILL.md
+++ b/skills/workshop-revise/SKILL.md
@@ -207,11 +207,15 @@ Unplanned issues surface mid-revision. Apply the same 4-rule system as the works
 For content or structural changes (NOT simple formatting fixes), the edited deck is reviewed by the **`workshop-verify` ultracode workflow** — the same per-slide fan-out + JS gate the workshop skill uses — scoped to the slides you touched:
 
 1. **Compile** so `slides.pdf` reflects the edits: `cd [presentation directory] && typst compile slides.typ && typst compile notes.typ`
-2. **Invoke selectively** (review only the changed slides; carry the rest forward):
+2. **Invoke selectively** (review only the changed slides; carry the rest forward). Pass `slideIndex` =
+   the parsed `.planning/slide-index.json` (recompile via `scripts/workshop/workshop_slide_table.py "<project>" --json`
+   if the OUTLINE changed) — the deterministic OUTLINE side-table; the workflow still enumerates the built
+   `slides.typ` and joins inventory semantically (DESIGN §3a-join). Omit to fall back to the LLM Discover.
    ```
    Workflow(name="workshop-verify", args={
      "projectDir": "[absolute project root]",
      "pluginRoot": "${CLAUDE_SKILL_DIR}/../..",
+     "slideIndex": <parsed .planning/slide-index.json, or omit>,
      "onlyChecks": [<IDs of the slides you edited, e.g. "S4", "S5">]
    })
    ```

--- a/skills/workshop/SKILL.md
+++ b/skills/workshop/SKILL.md
@@ -394,6 +394,15 @@ Sources gathered and verified. Paper metadata extracted from source document.
    - **Notes** — the speaker-notes talking points + a `~N min` timing target.
    ```
 
+   **This table IS the canonical, born-canonical form** (doctrine #6). The ONE shared parser
+   `scripts/workshop/workshop_slide_table.py` reads it directly (the guard, `workshop-generate`, and
+   `workshop-verify`'s side-table all consume *the same* parse — "parses ⇔ passes the guard"). Emit the
+   table, not prose: the table pins **Visual + Notes per slide** (7 fields), so generation renders them
+   rather than *inventing* them. The parser also tolerates a legacy 4-field prose form
+   (`- Slide: "Takeaway." — bullets → [IDs]`) **only** as a back-compat shim for decks built before this
+   spec — new decks MUST emit the table so nothing is inferred. (After writing OUTLINE.md, the index is
+   compiled by Phase 3 step 0; a row missing a takeaway or an F/T/R/A id is a `violations` STOP.)
+
 5. **Independent OUTLINE.md review (read-only subagent) — before showing the user.** Don't make the user catch structural gaps. Dispatch ONE fresh read-only subagent (Read/Grep only) to check OUTLINE.md against its spec:
    ```
    Task(subagent_type="Explore", prompt="READ-ONLY review. Do NOT edit any file.
@@ -611,9 +620,17 @@ After completing Phase 3, report: **Total deviations:** N auto-fixed (R1: X, R2:
 Generation is the **`workshop-generate` ultracode workflow** — do NOT hand-write slides.typ in this session. It reads the approved Slide Spec table, groups slides by **Section**, and fans out one agent per section (each writes that subsection's whole run of `#slide[]` blocks + notes to a section fragment file, from the pinned rows, citing only the allowed inventory ids — section is the coherent unit, keeping intra-section flow), then an assembly agent concatenates the section files under their headers into slides.typ + notes.typ and compiles the deck.
 
 ```
+0. COMPILE THE SLIDE INDEX (the deterministic Discover — replaces the engine's LLM Discover, DESIGN §3):
+   uv run python3 ${CLAUDE_SKILL_DIR}/../../scripts/workshop/workshop_slide_table.py "<project root>" --json > .planning/slide-index.json
+   Read it. If `ok` is true → pass the parsed object as `slideIndex` (below). If it carries `violations`
+   (a slide missing inventory, a dangling F/T/R/A id, a malformed row) or `staleApproval` (OUTLINE_APPROVED.md's
+   slide/section count disagrees with the live OUTLINE.md — a stale approval after a structure change),
+   **STOP and surface them** — these are spec-integrity failures fixed in Phase 2 (re-edit OUTLINE + re-approve),
+   NOT papered over. If the script errors entirely, omit `slideIndex` and the workflow falls back to its LLM Discover.
 1. Workflow(name="workshop-generate", args={
      "projectDir": "<absolute presentation project root (cwd)>",
-     "pluginRoot": "<resolve ${CLAUDE_SKILL_DIR}/../../workflows>"
+     "pluginRoot": "<resolve ${CLAUDE_SKILL_DIR}/../../workflows>",
+     "slideIndex": <the parsed .planning/slide-index.json object, or omit to use the LLM Discover>
    })
    → returns { overallPass, slides, compiled, findings, slidesThatFailed, assembledPaths }.
 2. Read the gate:
@@ -654,11 +671,15 @@ If convention violations persist after 3 fix-and-recheck cycles, escalate to use
    cd [presentation directory] && typst compile slides.typ && typst compile notes.typ
    ```
 
-2. **Invoke the workflow** (read-only; never drafts, never fixes):
+2. **Invoke the workflow** (read-only; never drafts, never fixes). Pass `slideIndex` = the parsed
+   `.planning/slide-index.json` (reuse Phase 3 step 0's, or recompile with `workshop_slide_table.py`).
+   In VERIFY this is the OUTLINE **side-table** only — the workflow still enumerates the built `slides.typ`
+   and joins inventory to slides SEMANTICALLY (DESIGN §3a-join); omit it to fall back to the LLM Discover.
    ```
    Workflow(name="workshop-verify", args={
      "projectDir": "[absolute project root]",
-     "pluginRoot": "${CLAUDE_SKILL_DIR}/../.."
+     "pluginRoot": "${CLAUDE_SKILL_DIR}/../..",
+     "slideIndex": <parsed .planning/slide-index.json, or omit for the LLM Discover fallback>
    })
    ```
    It returns `{ overallPass, verdict, scoreTable, findings, reviews, slidesThatFlagged, inventoryCoverage }`.
@@ -673,6 +694,7 @@ If convention violations persist after 3 fix-and-recheck cycles, escalate to use
    ```
    Workflow(name="workshop-verify", args={
      "projectDir": "[abs]", "pluginRoot": "${CLAUDE_SKILL_DIR}/../..",
+     "slideIndex": <parsed .planning/slide-index.json, or omit>,
      "onlyChecks": [<slidesThatFlagged from the prior run>],
      "priorReviews": [<reviews from the prior run>]
    })
@@ -759,11 +781,14 @@ Do not declare the presentation ready, do not present to the user, do not skip t
 
 ### Steps
 
-1. **Final full verification gate** — re-invoke the workflow over the whole deck (no `onlyChecks`):
+1. **Final full verification gate** — re-invoke the workflow over the whole deck (no `onlyChecks`). Pass
+   `slideIndex` = the parsed `.planning/slide-index.json` (recompile with `workshop_slide_table.py` if the
+   OUTLINE changed); omit to fall back to the LLM Discover:
    ```
    Workflow(name="workshop-verify", args={
      "projectDir": "[absolute project root]",
-     "pluginRoot": "${CLAUDE_SKILL_DIR}/../.."
+     "pluginRoot": "${CLAUDE_SKILL_DIR}/../..",
+     "slideIndex": <parsed .planning/slide-index.json, or omit>
    })
    ```
    - If `overallPass` is false → drive the `/goal workshop-verify returns overallPass=true. Stop after 3 turns.` loop (fix `findings` via subagent → recompile → re-invoke). The JS gate is authoritative.

--- a/tests/workshop-engine-discover.test.mjs
+++ b/tests/workshop-engine-discover.test.mjs
@@ -1,0 +1,166 @@
+// Driver tests for the workshop engines' reconciled Discover phase (DESIGN Step 2).
+// Executes workflows/workshop-generate.js and workshop-verify.js bodies with MOCKED Workflow
+// primitives, asserting:
+//   (1) GENERATE: args.slideIndex present ⇒ NO LLM 'discover' agent fires (full-replace win);
+//       the deterministic index groups slides correctly; absent index ⇒ the LLM Discover runs.
+//   (2) VERIFY: args.slideIndex present ⇒ the 'discover' agent STILL fires (enumeration + the
+//       OUTLINE-row↔slide JOIN are irreducibly semantic, §3a-join) BUT its prompt carries the
+//       deterministic CANDIDATE rows (no free OUTLINE re-parse); absent ⇒ prompt says read OUTLINE.md.
+// Run:  node tests/workshop-engine-discover.test.mjs
+import { readFileSync } from 'fs'
+
+const ROOT = new URL('..', import.meta.url).pathname
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+let PASS = 0, FAIL = 0
+const ok = (n, c, x = '') => { if (c) { PASS++ } else { FAIL++; console.log(`FAIL  ${n} ${x}`) } }
+
+const genSrc = readFileSync(ROOT + 'workflows/workshop-generate.js', 'utf8').replace(/^export const meta/m, 'const meta')
+const verSrc = readFileSync(ROOT + 'workflows/workshop-verify.js', 'utf8').replace(/^export const meta/m, 'const meta')
+
+async function exec(src, { args, onAgent }) {
+  const trace = { labels: [], prompts: {} }
+  const agent = async (prompt, opts = {}) => {
+    const l = opts.label || ''
+    trace.labels.push(l); trace.prompts[l] = prompt
+    return onAgent(l, prompt, opts)
+  }
+  const parallel = async (thunks) => Promise.all(thunks.map(t => t()))
+  const pipeline = async () => { throw new Error('pipeline unused') }
+  const log = () => {}, phase = () => {}
+  const fn = new AsyncFunction('agent', 'parallel', 'pipeline', 'log', 'phase', 'args', 'budget', src)
+  const result = await fn(agent, parallel, pipeline, log, phase, args,
+    { total: null, spent: () => 0, remaining: () => Infinity })
+  return { result, trace }
+}
+
+// Minimal real-shaped slide index (3 slides over 2 composite groups), mirrors the parser output.
+const INDEX = {
+  form: 'prose', ok: true, outlinePath: '/p/.planning/OUTLINE.md', sourcesPath: '/p/.planning/SOURCES.md',
+  paperPath: '/papers/x.pdf', sourcesInventory: ['A1', 'R1', 'T1'], sectionOrder: ['Motivation', 'Appendix'],
+  groupOrder: ['Motivation / Intro', 'Appendix / Data'],
+  slides: [
+    { num: 1, section: 'Motivation', subsection: 'Intro', group: 'Motivation / Intro', takeaway: 'A.', bullets: 'b1', inventory: ['A1'], visual: '', notes: '', titleSlug: 'A' },
+    { num: 2, section: 'Motivation', subsection: 'Intro', group: 'Motivation / Intro', takeaway: 'B.', bullets: 'b2', inventory: ['R1'], visual: 'F1', notes: '', titleSlug: 'B' },
+    { num: 3, section: 'Appendix', subsection: 'Data', group: 'Appendix / Data', takeaway: 'C.', bullets: 'b3', inventory: ['T1'], visual: '', notes: '', titleSlug: 'C' },
+  ],
+}
+
+// ── GENERATE ────────────────────────────────────────────────────────────────────
+{
+  // index present: section agents echo back the slideNums the prompt requested; assemble compiles.
+  const onAgent = (label, prompt) => {
+    if (label === 'discover') throw new Error('LLM discover fired despite slideIndex')
+    if (label.startsWith('section:')) {
+      const m = prompt.match(/numbers ([\d, ]+)\)/)
+      const nums = m ? m[1].split(',').map(s => s.trim()) : []
+      const id = label.split(':')[1]
+      return { section: id, status: 'drafted', slidesPath: `/f/section-${id}.typ`, notesPath: `/f/notes-${id}.typ`, slideNums: nums, citedInventory: [], summary: 'ok' }
+    }
+    if (label === 'assemble') return { slidesWritten: true, notesWritten: true, compiled: true, compileError: '', notesCompiled: true, notesCompileError: '', slidesPdf: '/p/slides.pdf' }
+    return {}
+  }
+  const { result, trace } = await exec(genSrc, { args: { projectDir: '/p', slideIndex: INDEX }, onAgent })
+  ok('gen: no LLM discover when index present', !trace.labels.includes('discover'))
+  ok('gen: one section agent per composite group (2)', trace.labels.filter(l => l.startsWith('section:')).length === 2)
+  ok('gen: assemble ran', trace.labels.includes('assemble'))
+  ok('gen: overallPass true (all groups drafted + compiles)', result.overallPass === true, JSON.stringify(result?.verdict))
+  ok('gen: assemble prompt constructs header (fileHeader empty → instruction)',
+     /CONSTRUCT a compilable slides.typ preamble/.test(trace.prompts['assemble'] || ''))
+  // a section prompt carries the pinned takeaway + inventory from the index (not invented)
+  const secP = trace.prompts['section:0'] || ''
+  ok('gen: section prompt pins takeaway A + inventory A1', /takeaway="A\."/.test(secP) && /inventory=\[A1\]/.test(secP))
+  ok('gen: section prompt forbids invented note macros', /NO custom note macros|do NOT invent/.test(secP))
+}
+{
+  // notes.typ compile-FAIL must BLOCK overallPass (opv-parity gate-gap fix: notes are gated, not slides-only).
+  const onAgent = (label, prompt) => {
+    if (label === 'discover') throw new Error('LLM discover fired despite slideIndex')
+    if (label.startsWith('section:')) {
+      const m = prompt.match(/numbers ([\d, ]+)\)/); const nums = m ? m[1].split(',').map(s => s.trim()) : []
+      return { section: label.split(':')[1], status: 'drafted', slidesPath: '/f.typ', notesPath: '/n.typ', slideNums: nums, citedInventory: [], summary: 'ok' }
+    }
+    if (label === 'assemble') return { slidesWritten: true, notesWritten: true, compiled: true, compileError: '', notesCompiled: false, notesCompileError: 'unknown macro #slide-notes', slidesPdf: '/p/slides.pdf' }
+    return {}
+  }
+  const { result } = await exec(genSrc, { args: { projectDir: '/p', slideIndex: INDEX }, onAgent })
+  ok('gen: notes compile-fail BLOCKS overallPass', result.overallPass === false)
+  ok('gen: notes compile-fail emits a critical finding', (result.findings || []).some(f => /notes\.typ did not compile/.test(f.detail)))
+}
+{
+  // index ABSENT: the LLM discover MUST run (back-compat). Mock returns a discovery object.
+  const onAgent = (label) => {
+    if (label === 'discover') return { outlineReadable: true, sourcesPath: '/p/.planning/SOURCES.md', paperPath: '', slidesPath: '/p/presentation/slides.typ', notesPath: '/p/presentation/notes.typ', fileHeader: '#import "x"', fragmentsDir: '/p/.planning/slide-fragments', sectionOrder: ['G1'], slides: [{ num: '1', section: 'G1', takeaway: 'A.', bullets: 'b', inventory: ['A1'], visual: 'none', notes: 'n' }] }
+    if (label.startsWith('section:')) return { section: '0', status: 'drafted', slidesPath: '/f/s0.typ', notesPath: '/f/n0.typ', slideNums: ['1'], citedInventory: ['A1'], summary: 'ok' }
+    if (label === 'assemble') return { slidesWritten: true, notesWritten: true, compiled: true, compileError: '', notesCompiled: true, notesCompileError: '', slidesPdf: '/p/slides.pdf' }
+    return {}
+  }
+  const { trace } = await exec(genSrc, { args: { projectDir: '/p' }, onAgent })
+  ok('gen: LLM discover runs when index ABSENT (back-compat)', trace.labels.includes('discover'))
+}
+
+// ── VERIFY ────────────────────────────────────────────────────────────────────
+// The Discover agent attributes A1 (valid) + Z9 (NOT in SOURCES → must be whitelisted out) to S1,
+// and forces F7 onto an appendix slide (also out-of-whitelist here) — exercises the JS guard.
+function makeVerifyMock(extraSlides = []) {
+  return (label, prompt) => {
+    if (label === 'discover') return {
+      presentationDir: '/p/presentation', slidesPath: '/p/presentation/slides.typ', notesPath: '/p/presentation/notes.typ',
+      sourcesPath: '/p/.planning/SOURCES.md', checkAllPath: '/c/check-all.py', detectWidowsPath: '', lookAtPath: '',
+      slides: [{ id: 'S1', title: 'A built title', inventoryRefs: ['A1', 'Z9'] }, ...extraSlides], diagrams: [],
+    }
+    if (label === 'mechanical') return { slidesCompiled: false, notesCompiled: true, compileErrors: ['boom'], constraintsPassed: false, constraintFailures: [], widows: 0, overflow: 0 }
+    return {}
+  }
+}
+{
+  // index present: discover STILL fires (join is semantic) but the prompt is UNBIASED (no candidate menu)
+  // — the parity variance-study fix. The whitelist is applied in JS afterward, not in the prompt.
+  const { result, trace } = await exec(verSrc, { args: { projectDir: '/p', slideIndex: INDEX }, onAgent: makeVerifyMock() })
+  ok('verify: discover STILL runs with index (join is semantic)', trace.labels.includes('discover'))
+  const dp = trace.prompts['discover'] || ''
+  ok('verify: discover prompt does NOT inject a candidate menu (no over-match bias)', !/outlineRow|CANDIDATE OUTLINE ROW/.test(dp))
+  ok('verify: discover prompt is free OUTLINE read (parity with current)', /read \.planning\/OUTLINE\.md/.test(dp))
+  ok('verify: discover prompt reinforces []-is-common for appendix', /\[\] is the correct and common answer|do not force a match/.test(dp))
+  // JS whitelist dropped the out-of-SOURCES id Z9, kept A1 (short-circuits on compile-fail, but the
+  // filter ran before Mechanical; assert via the returned findings carrying the surviving ref set is
+  // indirect — instead assert the short-circuit still happened and no crash).
+  ok('verify: still short-circuits on compile-fail with index', result.overallPass === false)
+}
+{
+  // index absent: discover prompt is the same free read (back-compat — byte-identical join).
+  const { trace } = await exec(verSrc, { args: { projectDir: '/p' }, onAgent: makeVerifyMock() })
+  const dp = trace.prompts['discover'] || ''
+  ok('verify: free OUTLINE read when no index (back-compat)', /read \.planning\/OUTLINE\.md/.test(dp))
+  ok('verify: no candidate menu ever (index or not)', !/outlineRow|CANDIDATE OUTLINE ROW/.test(dp))
+}
+{
+  // COMPILING path: assert the JS whitelist drops Z9 (not in sourcesInventory) but keeps A1, visible in coverageMap.
+  const onAgent = (label) => {
+    if (label === 'discover') return {
+      presentationDir: '/p/presentation', slidesPath: '/p/presentation/slides.typ', notesPath: '/p/presentation/notes.typ',
+      sourcesPath: '/p/.planning/SOURCES.md', checkAllPath: '/c/check-all.py', detectWidowsPath: '', lookAtPath: '',
+      slides: [{ id: 'S1', title: 'A built title', inventoryRefs: ['A1', 'Z9'] }], diagrams: [],
+    }
+    if (label === 'mechanical') return { slidesCompiled: true, notesCompiled: true, compileErrors: [], constraintsPassed: true, constraintFailures: [], widows: 0, overflow: 0 }
+    if (label === 'S1:convention') return { slide: 'S1', check: 'convention', itemsChecked: 5, findings: [] }
+    if (label === 'S1:notes') return { slide: 'S1', check: 'notes', itemsChecked: 1, notesSectionFound: true, findings: [] }
+    if (label === 'S1:fidelity') return { slide: 'S1', check: 'fidelity', claimsChecked: 1, claimsGrounded: 1, findings: [] }
+    return {}
+  }
+  const { result } = await exec(verSrc, { args: { projectDir: '/p', slideIndex: INDEX }, onAgent })
+  const cov = (result.coverageMap || []).find(c => c.slide === 'S1')
+  ok('verify whitelist: out-of-SOURCES id Z9 dropped from coverageMap', cov && !cov.inventoryRefs.includes('Z9'), JSON.stringify(cov))
+  ok('verify whitelist: valid id A1 kept', cov && cov.inventoryRefs.includes('A1'), JSON.stringify(cov))
+  // D1 scope disclosure (move 2 / §4b): a clean pass discloses checked vs notChecked.
+  ok('verify scope: checked lists typst compile', (result.scope?.checked || []).some(s => /typst compile/.test(s)), JSON.stringify(result.scope))
+  ok('verify scope: notChecked discloses the SEMANTIC reviewers are outside the floor', (result.scope?.notChecked || []).some(s => /SEMANTIC/.test(s)))
+  ok('verify scope: notChecked discloses constraints caveat (phantom/permanently-red)', (result.scope?.checked || []).some(s => /permanently red|phantom/.test(s)))
+}
+{
+  // compile-fail short-circuit also carries scope (honest about what it skipped).
+  const { result } = await exec(verSrc, { args: { projectDir: '/p', slideIndex: INDEX }, onAgent: makeVerifyMock() })
+  ok('verify scope: short-circuit discloses downstream SKIPPED', (result.scope?.notChecked || []).some(s => /SKIPPED|short-circuit/.test(s)), JSON.stringify(result.scope))
+}
+
+console.log(`\n${PASS}/${PASS + FAIL} passed` + (FAIL ? `  (${FAIL} FAILED)` : ''))
+process.exit(FAIL ? 1 : 0)

--- a/tests/workshop_guard_test.py
+++ b/tests/workshop_guard_test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env -S uv run python3
+"""
+Tests for the reconciled hooks/workshop-outline-executable-guard.py (DESIGN Step 3, S6).
+Asserts the guard now shares the ONE parser (validate = build_index().violations), so:
+  • the legacy PROSE form PASSES (the parity-regression fix — was a hard deny before);
+  • real defects (missing inventory) still DENY;
+  • stale approval is allow+WARN, not a block;
+  • the real opv prose deck passes the guard (no deny).
+Run:  uv run python3 tests/workshop_guard_test.py
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+GUARD = ROOT / "hooks" / "workshop-outline-executable-guard.py"
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond, extra=""):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        print(f"  ✗ {name} {extra}")
+
+
+def run_hook(file_path: str):
+    """Simulate the PreToolUse hook on a Write to OUTLINE_APPROVED.md; return parsed JSON or {}."""
+    payload = {"tool_name": "Write", "tool_input": {"file_path": file_path}}
+    r = subprocess.run([sys.executable, str(GUARD)], input=json.dumps(payload),
+                       capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout) if r.stdout.strip() else {}
+    except json.JSONDecodeError:
+        return {"_raw": r.stdout}
+
+
+def decision(out):
+    return (out.get("hookSpecificOutput") or {}).get("permissionDecision", "allow")
+
+
+PROSE = """## Presentation Outline
+### Part 1
+= Motivation
+== Intro
+- Slide: "A real takeaway." — bullets → [A1]
+"""
+PROSE_NO_INV = """## Presentation Outline
+= Motivation
+== Intro
+- Slide: "A title with no inventory."
+"""
+
+
+def test_prose_passes():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        d.mkdir(parents=True)
+        (d / "OUTLINE.md").write_text(PROSE)
+        out = run_hook(str(d / "OUTLINE_APPROVED.md"))
+        check("prose form is ALLOWED (parity-regression fix — no hard deny)", decision(out) != "deny", out)
+
+
+def test_missing_inventory_denies():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        d.mkdir(parents=True)
+        (d / "OUTLINE.md").write_text(PROSE_NO_INV)
+        out = run_hook(str(d / "OUTLINE_APPROVED.md"))
+        check("missing-inventory slide DENIES", decision(out) == "deny", out)
+
+
+def test_stale_approval_warns_not_blocks():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        d.mkdir(parents=True)
+        (d / "OUTLINE.md").write_text(PROSE)  # 1 slide, 1 section
+        (d / "OUTLINE_APPROVED.md").write_text("---\nslide_count: 5\nsection_count: 3\n---\n")
+        out = run_hook(str(d / "OUTLINE_APPROVED.md"))
+        check("stale approval is allow (not deny)", decision(out) == "allow", out)
+        check("stale approval surfaces a warning",
+              "STALE APPROVAL" in ((out.get("hookSpecificOutput") or {}).get("permissionDecisionReason", "")), out)
+
+
+def test_cli_real_opv():
+    opv = Path.home() / "projects" / "opv" / ".planning" / "OUTLINE.md"
+    if not opv.is_file():
+        print("  (skip real-opv guard CLI — opv OUTLINE absent)")
+        return
+    r = subprocess.run([sys.executable, str(GUARD), str(opv)], capture_output=True, text=True)
+    check("real opv prose deck passes the guard CLI (exit 0 — parity-regression fix)", r.returncode == 0, r.stdout + r.stderr)
+    # opv has a stale OUTLINE_APPROVED (18/4 vs live 21/5), so the CLI reports the stale-approval WARN
+    # (still exit 0). Either the form line or the stale-approval WARN is an acceptable "executable" report.
+    check("guard reports executable (form line or stale-approval warn)",
+          "executable" in r.stdout.lower(), r.stdout)
+
+
+def main():
+    for t in (test_prose_passes, test_missing_inventory_denies,
+              test_stale_approval_warns_not_blocks, test_cli_real_opv):
+        t()
+    total = PASS + FAIL
+    print(f"\n{PASS}/{total} passed" + ("" if FAIL == 0 else f"  ({FAIL} FAILED)"))
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workshop_slide_table_test.py
+++ b/tests/workshop_slide_table_test.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env -S uv run python3
+"""
+Golden tests for scripts/workshop/workshop_slide_table.py — the ONE shared Slide Spec parser.
+
+Mirrors tests/writing_section_index_test.py: a MIXED-FORM fixture block (canonical table +
+legacy prose, proving tolerant-at-parser) plus a REAL-REPO parity block at the tail
+(build_index on the live ~/projects/opv deck, the blind-oracle target — DESIGN §3 "THE TRAP":
+golden-test the strict parser against a REAL hand-emitted deck, never the canonical template).
+
+Run:  uv run python3 tests/workshop_slide_table_test.py
+"""
+
+import sys
+import tempfile
+import unicodedata
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts" / "workshop"))
+import workshop_slide_table as W  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        print(f"  ✗ {name}")
+
+
+def write(d: Path, name: str, text: str) -> Path:
+    p = d / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+# ── 1. CANONICAL TABLE form (the EXACT born-canonical emitter format from workshop/SKILL.md Phase 2) ──
+# This fixture mirrors the SKILL template byte-for-byte (incl. the "Part N:" section prefix + the
+# `==` backtick separator + a parenthetical Visual) so a drift between the emitter and the parser
+# (doctrine #6: born-canonical emitter ↔ tolerant parser) is caught here.
+TABLE = """## Presentation Outline
+
+Total time: 20 minutes
+
+## Slide Spec (MANDATORY EXECUTABLE TABLE)
+
+| Slide | Section | Takeaway | Bullets | Inventory | Visual | Notes |
+|-------|---------|----------|---------|-----------|--------|-------|
+| 1. Title | Part 1: Motivation `==` The Rise of Proxy Advisors | Proxy advisors emerged to fill a monitoring gap. | ERISA; capacity; ISS arose | A1, R1 | none | Open with the puzzle ~2 min |
+| 2. Mechanism | Part 1: Motivation `==` The Rise of Proxy Advisors | One recommendation moves many votes. | robo share; concentration | F1, R2 | F1 (influence chart) | Walk the figure ~3 min |
+"""
+
+
+def test_table():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        write(d, "OUTLINE.md", TABLE)
+        idx = W.build_index(d.parent)
+        check("table: form=table", idx.form == "table")
+        check("table: 2 slides", len(idx.slides) == 2)
+        check("table: ok (no SOURCES → no dangling check)", idx.ok)
+        s1 = idx.slides[0]
+        check("table: takeaway parsed", s1.takeaway == "Proxy advisors emerged to fill a monitoring gap.")
+        check("table: inventory tokens", s1.inventory == ["A1", "R1"])
+        check("table: visual carried (none)", s1.visual == "none")
+        check("table: parenthetical visual carried", idx.slides[1].visual == "F1 (influence chart)")
+        check("table: notes carried (pinned, not inferred)", s1.notes.startswith("Open with the puzzle"))
+        check("table: section split off `==` with Part prefix",
+              s1.section == "Part 1: Motivation" and s1.subsection == "The Rise of Proxy Advisors")
+
+
+# ── 2. LEGACY PROSE form (the real opv shape) ───────────────────────────────────
+PROSE = """## Presentation Outline
+
+### Part 1: Setup (~3 minutes, 3 slides)
+= Motivation & Background
+
+== About the Speaker
+- Slide: "This is a paper I didn't plan to write." — SEC experience → [A1, A2]
+
+== The Debate
+- Slide: "The real question is not 'do funds follow ISS?' but 'are they judging?'" — roadmap → [A3]
+
+### Appendix (Q&A backup)
+= Appendix
+
+== Data
+- Slide: "Key findings from the data." — Summary of R1-R8 → [R1-R8]
+"""
+
+
+def test_prose():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        write(d, "OUTLINE.md", PROSE)
+        idx = W.build_index(d.parent)
+        check("prose: form=prose", idx.form == "prose")
+        check("prose: 3 slides", len(idx.slides) == 3)
+        check("prose: ok (4-field subset, Visual/Notes NOT required)", idx.ok)
+        check("prose: Visual empty (not a violation)", idx.slides[0].visual == "")
+        check("prose: apostrophe survives in takeaway",
+              idx.slides[0].takeaway == "This is a paper I didn't plan to write.")
+        check("prose: inner single-quotes survive",
+              "'do funds follow ISS?'" in idx.slides[1].takeaway)
+        check("prose: over-attach FIX — [R1-R8] → endpoints, not expanded",
+              idx.slides[2].inventory == ["R1", "R8"])
+        check("prose: sections in document order",
+              idx.section_order == ["Motivation & Background", "Appendix"])
+
+
+# ── 3. Violations: title-only garbage (no inventory) blocks ──────────────────────
+TITLE_ONLY = """## Presentation Outline
+= Motivation
+== Intro
+- Slide: "Some title with no sources."
+"""
+
+
+def test_title_only_blocks():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        write(d, "OUTLINE.md", TITLE_ONLY)
+        idx = W.build_index(d.parent)
+        check("title-only: NOT ok (missing inventory is a violation)", not idx.ok)
+        check("title-only: violation names the missing inventory",
+              any("inventory id" in v.lower() for v in idx.violations))
+
+
+# ── 4. Dangling inventory ref vs SOURCES.md ──────────────────────────────────────
+def test_dangling_ref():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        write(d, "OUTLINE.md", PROSE)
+        write(d, "SOURCES.md", "### Figures\n- **F1:** x\n### Results\n- **R1:** y\n### Args\n- **A1:** z\n- **A2:** w\n- **A3:** q\n")
+        idx = W.build_index(d.parent)
+        # R8, T?, F? absent → dangling
+        check("dangling: detected (R8 not in SOURCES)",
+              any("R8" in v and "not found" in v for v in idx.violations))
+
+
+# ── 5. Stale-approval backstop (DESIGN §5) ───────────────────────────────────────
+def test_stale_approval():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        write(d, "OUTLINE.md", PROSE)  # 3 slides, 2 sections
+        write(d, "OUTLINE_APPROVED.md", "---\nstatus: APPROVED\nslide_count: 9\nsection_count: 4\n---\n")
+        idx = W.build_index(d.parent)
+        check("stale: slide_count mismatch flagged",
+              any("slide_count=9" in s and "has 3" in s for s in idx.stale_approval))
+        check("stale: section_count mismatch flagged",
+              any("section_count=4" in s and "has 2" in s for s in idx.stale_approval))
+
+
+# ── 6. Unicode-safe slug (em-dash sections) ──────────────────────────────────────
+def test_slug_unicode():
+    s = W.section_slug("Part II — The Two Offer-Period Channels")
+    check("slug: unicode-safe (em-dash → dash, no crash)", "—" not in s and s == unicodedata.normalize("NFC", s))
+    check("slug: collapses to word-dashes", "Part-II" in s and "Channels" in s)
+
+
+# ── 7. REAL-REPO PARITY (THE TRAP — golden against the live opv deck, not the template) ──
+def test_real_opv():
+    opv = Path.home() / "projects" / "opv" / ".planning" / "OUTLINE.md"
+    if not opv.is_file():
+        print("  (skip real-opv parity — ~/projects/opv/.planning/OUTLINE.md absent)")
+        return
+    idx = W.build_index(opv)
+    check("opv: form=prose (real deck is prose, NOT a table)", idx.form == "prose")
+    check("opv: 21 slides (opv-parity ground truth)", len(idx.slides) == 21)
+    check("opv: 5 sections (= headings)", len(idx.section_order) == 5)
+    check("opv: ok — the prose deck PARSES CLEAN (parity-regression fix)", idx.ok)
+    check("opv: every slide has ≥1 inventory id", all(s.inventory for s in idx.slides))
+    check("opv: every slide has a takeaway", all(s.takeaway for s in idx.slides))
+    # the over-attach fix on the real S21 "Key findings" row
+    kf = [s for s in idx.slides if "Key findings" in s.takeaway]
+    check("opv: S21 over-attach FIX — [R1-R8] → ['R1','R8']", bool(kf) and kf[0].inventory == ["R1", "R8"])
+    # paperPath expanded (no leading ~ — a subagent Read("~/...") would not tilde-expand)
+    check("opv: paperPath is expanded absolute (no leading ~)",
+          idx.paper_path.startswith("/") and not idx.paper_path.startswith("~"))
+
+
+# ── 8. STRUCTURE-REORDER PAUSE FIXTURE (DESIGN §5 / Step 6 — workshop's grain-pause analog) ──
+# A spec-changing editorial decision (reorder/re-scope) was honored in the live OUTLINE while the
+# upstream OUTLINE_APPROVED.md still encodes the OLD shape. The deterministic backstop must catch the
+# stale approval and route to a PAUSE (re-approve), never silently trust the stale APPROVED.
+def test_reorder_pause_fixture():
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td) / ".planning"
+        # v1 was approved at 2 Parts / 2 slides; the live OUTLINE was then reorganised to 3 Parts / 4 slides.
+        reorganised = """## Presentation Outline
+= Part A
+== Intro
+- Slide: "A." — b → [A1]
+= Part B
+== Mid
+- Slide: "B." — b → [R1]
+= Part C
+== New section added in the reframe
+- Slide: "C." — b → [T1]
+- Slide: "D." — b → [A1]
+"""
+        write(d, "OUTLINE.md", reorganised)
+        write(d, "OUTLINE_APPROVED.md", "---\nstatus: APPROVED\nslide_count: 2\nsection_count: 2\n---\n")
+        idx = W.build_index(d.parent)
+        check("reorder: live OUTLINE parses (4 slides / 3 sections)",
+              len(idx.slides) == 4 and len(idx.section_order) == 3)
+        check("reorder: NOT a hard violation (the reframe itself is legitimate)", not idx.violations)
+        check("reorder: stale approval CAUGHT (slide_count 2 vs live 4)",
+              any("slide_count=2" in s and "has 4" in s for s in idx.stale_approval))
+        check("reorder: stale approval CAUGHT (section_count 2 vs live 3)",
+              any("section_count=2" in s and "has 3" in s for s in idx.stale_approval))
+        # ok stays True (parses) but stale_approval is non-empty → the skill/guard routes to a re-approve PAUSE.
+        check("reorder: ok=True (parses) yet stale_approval flags the re-approve PAUSE", idx.ok and bool(idx.stale_approval))
+
+
+def main():
+    for t in (test_table, test_prose, test_title_only_blocks, test_dangling_ref,
+              test_stale_approval, test_slug_unicode, test_reorder_pause_fixture, test_real_opv):
+        t()
+    total = PASS + FAIL
+    print(f"\n{PASS}/{total} passed" + ("" if FAIL == 0 else f"  ({FAIL} FAILED)"))
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/workshop-generate.js
+++ b/workflows/workshop-generate.js
@@ -18,6 +18,13 @@ if (!PROJECT) throw new Error(`workshop-generate requires args.projectDir. Got "
 const PLUGIN = cfg.pluginRoot || ''
 const ONLY = Array.isArray(cfg.onlyChecks) && cfg.onlyChecks.length ? new Set(cfg.onlyChecks.map(String)) : null
 const PRIOR = new Map((Array.isArray(cfg.priorReviews) ? cfg.priorReviews : []).map(s => [String(s.section), s]))
+// Deterministic slide index from scripts/workshop/workshop_slide_table.py — the compiled "Discover".
+// When the skill passes it (cfg.slideIndex), we skip the LLM Discover entirely (the ds/dev/writing
+// compile move): the parser's work-list IS the generate enumerator (DESIGN §3a — GENERATE consumes the
+// parser fully). Absent/empty → the LLM Discover still runs (back-compat for old callers / non-standard
+// projects). The fileHeader (theme preamble) is NOT a work-list concern → the assembly agent constructs
+// it from templates + SOURCES.md, so discFromIndex stays 100% deterministic (no LLM).
+const SLIDE_INDEX = (cfg.slideIndex && Array.isArray(cfg.slideIndex.slides) && cfg.slideIndex.slides.length) ? cfg.slideIndex : null
 
 const SLIDE = {
   type: 'object', additionalProperties: false,
@@ -54,19 +61,49 @@ const SECTION_SCHEMA = {
   },
 }
 const ASSEMBLE_SCHEMA = {
-  type: 'object', additionalProperties: false, required: ['slidesWritten', 'notesWritten', 'compiled', 'compileError', 'slidesPdf'],
+  type: 'object', additionalProperties: false, required: ['slidesWritten', 'notesWritten', 'compiled', 'compileError', 'notesCompiled', 'notesCompileError', 'slidesPdf'],
   properties: {
     slidesWritten: { type: 'boolean' }, notesWritten: { type: 'boolean' },
-    compiled: { type: 'boolean' }, compileError: { type: 'string' }, slidesPdf: { type: 'string' },
+    compiled: { type: 'boolean' }, compileError: { type: 'string' },
+    notesCompiled: { type: 'boolean', description: 'notes.typ compiled cleanly (a first-class teleprompter deliverable — gated, not slides-only)' },
+    notesCompileError: { type: 'string' },
+    slidesPdf: { type: 'string' },
   },
 }
 
 // ── Phase 1: Discover ─────────────────────────────────────────────────────────
+// Map the deterministic slide index → the DISCOVERY_SCHEMA shape (no LLM). The parser's COMPOSITE
+// group ("<= section> / <== subsection>") is the fan-out key (mirrors the LLM Discover's "= Part + ==
+// subsection" grouping); fileHeader is left "" for the assembly agent to construct. Prose-form rows
+// carry no Visual/Notes — default Visual to "none" and let the section agent infer notes from bullets +
+// the paper (the same inference the LLM Discover path produces from a prose outline).
+function discFromIndex(idx) {
+  return {
+    outlineReadable: true,
+    sourcesPath: idx.sourcesPath || `${PROJECT}/.planning/SOURCES.md`,
+    paperPath: idx.paperPath || '',
+    slidesPath: `${PROJECT}/presentation/slides.typ`,
+    notesPath: `${PROJECT}/presentation/notes.typ`,
+    fileHeader: '',                                  // assembly agent constructs it (DESIGN §3a)
+    fragmentsDir: `${PROJECT}/.planning/slide-fragments`,
+    sectionOrder: idx.groupOrder,                    // composite fan-out keys, document order
+    slides: idx.slides.map(s => ({
+      num: String(s.num),
+      section: s.group,                              // the composite grouping key
+      takeaway: s.takeaway,
+      bullets: s.bullets || '',
+      inventory: Array.isArray(s.inventory) ? s.inventory : [],
+      visual: (s.visual && s.visual.trim()) || 'none',
+      notes: s.notes || '',
+    })),
+  }
+}
+
 phase('Discover')
-const disc = await agent(
+const disc = SLIDE_INDEX ? discFromIndex(SLIDE_INDEX) : await agent(
   `Read the approved workshop Slide Spec and prepare for SECTION-level generation. Working directory: ${PROJECT}
 
-1. Read ${PROJECT}/.planning/OUTLINE.md. If it has no Slide Spec table (columns Slide | Section | Takeaway | Bullets | Inventory | Visual | Notes), set outlineReadable=false. For each row extract a slide: num, section (the `=` Part + `==` subsection text — the grouping key), takeaway, bullets, inventory, visual, notes.
+1. Read ${PROJECT}/.planning/OUTLINE.md. If it has no Slide Spec table (columns Slide | Section | Takeaway | Bullets | Inventory | Visual | Notes), set outlineReadable=false. For each row extract a slide: num, section (the \`=\` Part + \`==\` subsection text — the grouping key), takeaway, bullets, inventory, visual, notes.
 2. sourcesPath = ${PROJECT}/.planning/SOURCES.md ; paperPath = the source-paper path from SOURCES.md (or "").
 3. slidesPath = ${PROJECT}/presentation/slides.typ ; notesPath = ${PROJECT}/presentation/notes.typ (adjust if the project uses a different presentation dir).
 4. fileHeader = the slides.typ preamble (import theme + #show + config-info incl qr:none) — read presentation/templates/ + any existing header, or reconstruct from SOURCES.md metadata. Must be a compilable preamble.
@@ -77,6 +114,7 @@ Return DISCOVERY_SCHEMA with absolute paths.`,
   { label: 'discover', phase: 'Discover', schema: DISCOVERY_SCHEMA, model: 'sonnet' }
 )
 if (!disc.outlineReadable) throw new Error(`workshop-generate: ${PROJECT}/.planning/OUTLINE.md has no Slide Spec table. Phase 2 + workshop-outline-executable-guard must produce one first.`)
+if (SLIDE_INDEX) log(`Discover: deterministic slide index (${disc.slides.length} slides, ${disc.sectionOrder.length} groups) — no LLM Discover`)
 
 // Group slides by Section, in sectionOrder. Section id = its index in sectionOrder (stable for onlyChecks).
 const sectionList = disc.sectionOrder.map((key, idx) => ({
@@ -104,8 +142,9 @@ Typst conventions: each slide is \`=== <takeaway sentence>\` then \`#slide[ ... 
 
 WRITE two files (mkdir -p ${disc.fragmentsDir} first):
 - ${disc.fragmentsDir}/section-${sec.id}.typ — ALL this section's \`=== ...\` + \`#slide[...]\` blocks, in order (NO file header, NO \`==\` heading).
-- ${disc.fragmentsDir}/notes-section-${sec.id}.typ — flowing speaker-notes for this section (one block per slide, with timing from each slide's Notes).
-Return SECTION_SCHEMA: slidesPath, notesPath, slideNums (must equal ${JSON.stringify(sec.slides.map(s => s.num))}), citedInventory (⊆ the allowed set), summary.`,
+- ${disc.fragmentsDir}/notes-section-${sec.id}.typ — flowing speaker-notes for this section (one block per slide, with timing from each slide's Notes). Write PLAIN Typst prose + bullets ONLY — NO custom note macros (do NOT invent \`#slide-notes\`/\`#speaker-note\`/etc.; assembly adds the \`= Section\` heading + the standard notes preamble, and the gate now COMPILES notes.typ, so an invented macro breaks the build).
+GROUND citedInventory IN THE FILE (not memory): after writing, run \`grep -ohE '[FTRA][0-9]+' ${disc.fragmentsDir}/section-${sec.id}.typ | sort -u\` and set citedInventory to EXACTLY that grep output — the actual inventory ids present in the fragment you wrote. (The gate checks this ⊆ the allowed set; a memory-reported list that disagrees with the file is the fidelity bug this step closes.)
+Return SECTION_SCHEMA: slidesPath, notesPath, slideNums (must equal ${JSON.stringify(sec.slides.map(s => s.num))}), citedInventory (the grep result, ⊆ the allowed set), summary.`,
     { label: `section:${sec.id}`, phase: 'Sections', schema: SECTION_SCHEMA })
 }))).filter(Boolean)
 const secById = Object.fromEntries(liveSecs.map(s => [String(s.section), s]))
@@ -118,11 +157,13 @@ let asm = null
 if (haveAll) {
   const order = sectionList.map(s => ({ id: s.id, key: s.key,
     slidesFile: `${disc.fragmentsDir}/section-${s.id}.typ`, notesFile: `${disc.fragmentsDir}/notes-section-${s.id}.typ` }))
+  const headerInstruction = disc.fileHeader
+    ? `FILE HEADER (write to the top of slides.typ verbatim):\n${disc.fileHeader}`
+    : `FILE HEADER: none was pre-resolved — CONSTRUCT a compilable slides.typ preamble yourself: \`#import "templates/theme.typ": *\`, the \`#show: university-theme.with(...)\` block with \`config-info(...)\` populated from ${disc.sourcesPath} metadata (title/subtitle/authors/affiliations) and **\`qr: none\` (REQUIRED — the theme expects this field)**, the standard \`#show\`/\`#set\` rules, then \`#title-slide()\`. Read presentation/templates/ + any existing presentation/slides.typ preamble first; reuse it if present.`
   asm = await agent(
     `You are the workshop deck assembler. Build slides.typ + notes.typ by CONCATENATING the per-section fragment files (already written) under their Section headers, then COMPILE. Do NOT rewrite content — only concatenate, emit the \`=\`/\`==\` heading once per section, and fix compile-blocking syntax.
 
-FILE HEADER (write to the top of slides.typ verbatim):
-${disc.fileHeader}
+${headerInstruction}
 
 SECTION ORDER (each slidesFile/notesFile exists; cat them in this order; emit each section's \`=\` Part / \`==\` subsection heading once before its slides):
 ${JSON.stringify(order)}
@@ -130,7 +171,7 @@ ${JSON.stringify(order)}
 Steps (use Bash to cat the files — do NOT paste content from memory):
 1. Write ${disc.slidesPath}: the header, then for each section in order emit its heading + \`cat\` its slidesFile.
 2. Write ${disc.notesPath}: the notes preamble, then per section a \`= Section\` heading + \`cat\` its notesFile.
-3. Compile: \`tinymist compile ${disc.slidesPath}\` (or \`typst compile\`) from ${PROJECT}; fix ONLY compile-blocking syntax and recompile.
+3. Compile: \`tinymist compile ${disc.slidesPath}\` (or \`typst compile\`) AND the notes deck \`tinymist compile ${disc.notesPath}\` (notes are a first-class deliverable, gated — NOT slides-only), from ${PROJECT}; fix ONLY compile-blocking syntax and recompile each. Set compiled/compileError for slides and notesCompiled/notesCompileError for notes. Do NOT invent note macros (e.g. #slide-notes/#speaker-note) to force notes to compile — notes use plain \`=\`/\`==\` headings + prose; an undefined-macro reference is a fragment bug to surface in notesCompileError, not to paper over with a defensive alias.
 Return ASSEMBLE_SCHEMA.`,
     { label: 'assemble', phase: 'Assemble', schema: ASSEMBLE_SCHEMA })
 }
@@ -153,18 +194,21 @@ for (const sec of sectionList) {
   if (f && !fidelityOk) findings.push({ severity: 'major', section: sec.id, detail: `Section "${sec.key}": cited inventory outside its slides' allowed ids` })
 }
 const compiled = !!asm && asm.compiled === true
-if (haveAll && !compiled) findings.push({ severity: 'critical', section: 'deck', detail: `Deck did not compile: ${(asm?.compileError || 'unknown').slice(0, 300)}` })
+const notesCompiled = !!asm && asm.notesCompiled === true
+if (haveAll && !compiled) findings.push({ severity: 'critical', section: 'deck', detail: `slides.typ did not compile: ${(asm?.compileError || 'unknown').slice(0, 300)}` })
+// notes.typ is a first-class teleprompter deliverable — gate it, don't ship malformed notes (opv-parity).
+if (haveAll && compiled && !notesCompiled) findings.push({ severity: 'critical', section: 'deck', detail: `notes.typ did not compile: ${(asm?.notesCompileError || 'unknown').slice(0, 300)}` })
 if (!haveAll) findings.push({ severity: 'critical', section: 'deck', detail: 'Not all sections have fragments — assembly skipped' })
 findings.sort((a, b) => ({ critical: 0, major: 1, minor: 2 }[a.severity] - { critical: 0, major: 1, minor: 2 }[b.severity]))
 
 const allDrafted = rows.length > 0 && rows.every(r => r.drafted && r.completeSlides && r.fidelityOk)
-const overallPass = allDrafted && compiled
+const overallPass = allDrafted && compiled && notesCompiled
 const verdict = overallPass ? 'GENERATED (compiles)' : 'GAPS'
 const scoreTable = [
   '| Section | Slides | Fragment | Complete | Inventory-fidelity |',
   '|---------|--------|----------|----------|--------------------|',
   ...rows.map(r => `| ${r.key.slice(0, 28)} | ${r.slideCount} | ${r.drafted ? '✅' : '❌'} | ${r.completeSlides ? '✅' : '❌'} | ${r.fidelityOk ? '✅' : '❌'} |`),
-  `| **Deck** | compile | ${compiled ? '✅' : '❌'} | | ${overallPass ? '✅ GENERATED' : '❌ GAPS'} |`,
+  `| **Deck** | slides / notes compile | ${compiled ? '✅' : '❌'} / ${notesCompiled ? '✅' : '❌'} | | ${overallPass ? '✅ GENERATED' : '❌ GAPS'} |`,
 ].join('\n')
 
 log(overallPass
@@ -172,7 +216,7 @@ log(overallPass
   : `❌ workshop-generate: ${findings.length} finding(s); fix + re-invoke onlyChecks=sectionsThatFailed`)
 
 return {
-  overallPass, verdict, compiled, scoreTable,
+  overallPass, verdict, compiled, notesCompiled, scoreTable,
   sections: rows,
   findings,
   sectionsThatFailed: rows.filter(r => !r.drafted || !r.completeSlides || !r.fidelityOk).map(r => r.section),

--- a/workflows/workshop-verify.js
+++ b/workflows/workshop-verify.js
@@ -35,6 +35,18 @@ if (!PROJECT) throw new Error(`workshop-verify requires args.projectDir. Got "${
 const PLUGIN = cfg.pluginRoot || ''
 const ONLY = Array.isArray(cfg.onlyChecks) && cfg.onlyChecks.length ? new Set(cfg.onlyChecks.map(String)) : null
 const PRIOR = new Map((Array.isArray(cfg.priorReviews) ? cfg.priorReviews : []).map(s => [String(s.slide), s]))
+// Deterministic side-table from scripts/workshop/workshop_slide_table.py (cfg.slideIndex).
+// DESIGN §3a/§3a-join — verify is the CARDINALITY-CORRECTION case: slide ENUMERATION stays sourced from
+// slides.typ (the built deck, e.g. 38 slides incl. 17 drifted appendix), and the OUTLINE-row↔built-slide
+// JOIN stays an UNBIASED SEMANTIC step. A parity variance-study (opv-parity, n=3) showed that injecting the
+// parser's rows as a candidate MENU into the Discover prompt CONTAMINATES the join — the agent greedily
+// forces unspecced appendix slides onto the nearest row (false COVERED, once 38/38). So the parser does NOT
+// feed the join: the Discover prompt is byte-identical to the LLM-Discover (free OUTLINE read, []-is-common).
+// The parser's contribution is instead a DETERMINISTIC WHITELIST applied in JS AFTER Discover — drop any
+// inventoryRef that is not a real SOURCES.md id (the no-hallucination guard), without biasing the join.
+const SLIDE_INDEX = (cfg.slideIndex && Array.isArray(cfg.slideIndex.slides) && cfg.slideIndex.slides.length) ? cfg.slideIndex : null
+const INV_WHITELIST = SLIDE_INDEX && Array.isArray(SLIDE_INDEX.sourcesInventory) && SLIDE_INDEX.sourcesInventory.length
+  ? new Set(SLIDE_INDEX.sourcesInventory.map(String)) : null
 
 // ── Schemas ───────────────────────────────────────────────────────────────────
 const FINDING = {
@@ -140,13 +152,27 @@ const disc = await agent(
 2. checkAllPath = ${checkAllHint}.
 3. detectWidowsPath = \`command ls -d ~/.claude/plugins/cache/tinymist-plugin/tinymist/*/skills/typst-widow-orphan/scripts/detect_widows.py 2>/dev/null | sort -V | tail -1\` (or "" if none).
 4. lookAtPath = ${lookAtHint} (or "" if none).
-5. Read slides.typ and list every slide in document order. A slide is a \`#slide[ ... ]\` block; its title is the \`=== ...\` line inside it. Assign stable IDs S1, S2, ... in order. For each slide, read .planning/OUTLINE.md and record the F/T/R/A inventory IDs that outline maps to that slide (inventoryRefs; empty array if none listed).
+5. Read slides.typ and list every slide in document order. A slide is a \`#slide[ ... ]\` block; its title is the \`=== ...\` line inside it. Assign stable IDs S1, S2, ... in order. For each slide, read .planning/OUTLINE.md and record the F/T/R/A inventory IDs that outline maps to that slide (inventoryRefs; empty array if none listed — MANY built slides, especially appendix/Q&A backups, have NO outline row, so [] is the correct and common answer; do not force a match).
 6. List every diagram: \`cetz.canvas\` blocks (kind "cetz") and \`fletcher-diagram\`/\`#diagram(\` blocks (kind "fletcher"), each tied to the slide title it appears under.
 
 Return DISCOVERY_SCHEMA. Absolute paths only.`,
   { label: 'discover', phase: 'Discover', schema: DISCOVERY_SCHEMA, model: 'sonnet' }
 )
 if (!disc.slides.length) throw new Error('No slides discovered — check slides.typ exists with #slide[ ... ] blocks')
+
+// Deterministic inventory WHITELIST (DESIGN §3a-join): the join stayed unbiased (free OUTLINE read);
+// here we drop any inventoryRef the agent attributed that is NOT a real SOURCES.md id (no-hallucination
+// guard) — applied in JS, OUTSIDE the agent, so it cannot bias the join. No-op when no index is passed.
+if (INV_WHITELIST) {
+  let dropped = 0
+  for (const s of disc.slides) {
+    const refs = Array.isArray(s.inventoryRefs) ? s.inventoryRefs : []
+    const kept = refs.filter(r => INV_WHITELIST.has(String(r)))
+    dropped += refs.length - kept.length
+    s.inventoryRefs = kept
+  }
+  if (dropped) log(`Inventory whitelist: dropped ${dropped} non-SOURCES id(s) attributed by Discover`)
+}
 log(`Deck: ${disc.slides.length} slides, ${disc.diagrams.length} diagrams; ${ONLY ? `re-review ${ONLY.size}` : 'full review'}`)
 
 // ── Phase 2: Mechanical leg (compile + scripts; early-exit on compile failure) ──
@@ -174,6 +200,7 @@ if (!mech.slidesCompiled) {
     findings: [{ severity: 'critical', area: 'compile', location: `${disc.slidesPath}`, detail: `slides.typ failed to compile: ${(mech.compileErrors || []).join('; ').slice(0, 400)}` }],
     reviews: [],
     slidesThatFlagged: disc.slides.map(s => s.id),
+    scope: { checked: ['typst compile (slides) — FAILED'], notChecked: ['everything downstream — per-slide review, constraints, widows, overflow, visual: SKIPPED (short-circuit on compile failure)'] },
     mechanical: mech,
   }
 }
@@ -319,10 +346,29 @@ log(substratePass
   ? (total === 0 ? '✅ Workshop verify CLEAN — no issues' : `✅ Workshop verify CLEAN — substrate clean; ${sev.minor} advisory minor note(s) (non-blocking)`)
   : `Workshop verify: ISSUES FOUND — ${sev.critical} critical / ${sev.major} major (blocking) + ${sev.minor} minor (advisory)`)
 
+// D1 contract / doctrine #3 addendum (DESIGN move 2 / §4b): a clean mechanical pass MUST disclose what
+// the deterministic floor did and did NOT verify — so a green check never over-claims coverage.
+const scope = {
+  checked: [
+    'typst compile (slides + notes) — real exit code',
+    'check-all.py constraints — exit code (CAVEAT: rides cross-domain phantom + a broken module → permanently red on every deck; see DESIGN §4c / D-w-8)',
+    'detect_widows.py — deterministic count',
+    'overflow — handout page-count heuristic (CAVEAT: divider-naive, over-counts theme section/title pages; D-w-8)',
+    SLIDE_INDEX ? 'inventoryRefs whitelist — dropped non-SOURCES ids (no-hallucination guard)' : 'inventory ids — agent-attributed (no index whitelist this run)',
+  ],
+  notChecked: [
+    'per-slide convention / notes-coverage / source-fidelity — SEMANTIC (LLM reviewers, OUTSIDE the deterministic floor; the primary arbiter)',
+    'OUTLINE-row↔slide JOIN — semantic (free read); appendix slides w/o a row are PARTIAL by design, not verified-absent',
+    disc.lookAtPath ? null : 'visual-defect detection — look_at.py UNRESOLVED → diagrams NOT visually verified (skipped, not passed)',
+    'spelled-out / non-F·T·R·A-token claims — the inventory floor only sees F/T/R/A id tokens',
+  ].filter(Boolean),
+}
+
 return {
   overallPass,
   substratePass,
   verdict,
+  scope,
   summary: { ...sev, total, blocking, advisoryMinors: sev.minor },
   scoreTable,
   findings: findings.sort((a, b) => ({ critical: 0, major: 1, minor: 2 }[a.severity] - { critical: 0, major: 1, minor: 2 }[b.severity])),


### PR DESCRIPTION
## Summary

Ports the `spec → plan → compiled-runner` pattern to the **workshop** workflow — the **4th instance** after ds/dev (exit-code) and writing (judgment). Workshop is **writing's twin**: flat-parallel section fan-out, `compile = DATA work-list`, **no per-project `run.js`, no DAG**. Distinct contribution: a **rich-mechanical floor** (`typst compile` + `check-all.py` real exit codes) + a **semantic ceiling** — a new gate-type data point for the pass #9 run-core extraction.

## What changed
- **ONE shared parser** `scripts/workshop/workshop_slide_table.py` (canonical 7-col TABLE + legacy 4-field PROSE; tolerant-at-parser, canonical-at-emitter) replaces the doubled LLM Discover and emits a DATA work-list.
- **`workshop-generate.js`**: `discFromIndex` full-replaces the LLM Discover when `slideIndex` is passed; grep-grounded inventory fidelity; **notes-compile gate** (notes were previously ungated — could ship malformed).
- **`workshop-verify.js`**: keeps the `slides.typ` enumeration + an **unbiased free-read semantic join** (a candidate menu biased it → appendix over-match, caught by n=3 variance); the parser contributes a **JS inventory whitelist applied outside the agent**; `scope:{checked,notChecked}` disclosure (D1 / doctrine #3).
- **Guard** reconciled to `validate = build_index().violations` (S6, −89 lines). **Prose now passes** → the shipped opv deck is no longer rejected (parity regression fixed by construction); stale-approval = allow+WARN.
- Skills wired to run the parser + pass `args.slideIndex` (back-compat fallback). Born-canonical table emitter reconciled; structure-reorder PAUSE fixture.

## Parity validation (real `~/projects/opv` deck, via the `opv-parity` partner)
- Track A — compile-fail short-circuit **byte-identical** (zero wasted agents).
- Track B — **n=3 clean** after fixing an appendix over-match regression: COVERED `[21,21,21]`, over-match `[0,0,0]`.
- Parser A/B: generate 21/21 exact + verify 21/21 via semantic join; grep-fidelity independently confirmed file-backed; generate end-to-end PASS.
- **8 real issues surfaced + folded** (parity-regression, cardinality, semantic-join, appendix-over-match, paperPath `~`, Track-A count nondeterminism, permanently-red floor, notes gate-gap).

## Doctrine deepenings (recorded for pass #9)
- A join turns semantic exactly when the work-list enumerates from **>1 source**; the parser owns enumeration, **never a drifting-identifier join**.
- **Don't feed the deterministic artifact *into* the semantic step** — even as a "helpful menu" it biases it; a JS post-filter > a prompt instruction.
- **Single-sample parity is insufficient for judgment seams — n≥3 variance required.**
- **Gate only what you compile** (notes are a first-class deliverable).

## Tests
parser **37/37** · guard **6/6** · engines **23/23**.

## Out of scope (separate fast-follow — D-w-8)
Pre-existing mechanical-floor bugs deliberately **preserved for parity**, fixed separately: `check-all.py` rides cross-domain phantom constraints (→ permanently-red gate on every deck), divider-naive overflow, `summary.critical`≠`findings.length`.

DESIGN: `docs/DESIGN-workshop-spec-plan-compile.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)