### PR TITLE
Fix 3 writing authoring-lints to verify real auto-load wiring (v5.59.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.59.1"
+    "version": "5.59.2"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.59.1",
+      "version": "5.59.2",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.59.1",
+  "version": "5.59.2",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/references/constraints/post-subagent-enforcement.py
+++ b/references/constraints/post-subagent-enforcement.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env -S uv run python3
-"""Constraint: post-subagent-enforcement — verify skills that use subagents load this constraint."""
+"""Constraint: post-subagent-enforcement — verify subagent-dispatching skills AUTO-LOAD this.
+
+Authoring lint (checks the plugin's own skills/, not a user's document). Verifies the REAL
+loading mechanism: (a) post-subagent-enforcement.md's `applies-to` includes the skill AND (b) the
+skill invokes `load-constraints.py` (the auto-loader). The earlier version checked for a literal
+`.md` string reference in SKILL.md — superseded by the auto-loader — so it false-failed.
+"""
 
 CONSTRAINT = "post-subagent-enforcement"
 APPLIES_TO = ["writing-review", "writing-revise"]
@@ -8,32 +14,42 @@ SEVERITY = "hard"
 import re
 from pathlib import Path
 
-# Skills that dispatch subagents must load this constraint
+# Skills that dispatch subagents must auto-load this constraint
 SUBAGENT_SKILLS = ['writing-review', 'writing-revise']
-CONSTRAINT_PATTERN = re.compile(r'post-subagent-enforcement\.md')
+
+
+def _md_applies_to(md_path):
+    """Parse the `applies-to` list from a constraint .md's frontmatter (list or scalar form)."""
+    if not md_path.exists():
+        return []
+    text = md_path.read_text()
+    m = re.search(r'^applies-to:\s*\[(.*?)\]', text, re.M)
+    if m:
+        return [s.strip().strip('"\'').lower() for s in m.group(1).split(',') if s.strip()]
+    m = re.search(r'^applies-to:\s*(\S.*)$', text, re.M)
+    return [m.group(1).strip().lower()] if m else []
 
 
 def check(context):
-    """Returns list of violations. Empty list = pass."""
+    """Returns list of violations. Empty list = pass. Verifies the auto-load wiring."""
     violations = []
     plugin_dir = Path(__file__).resolve().parent.parent.parent
     skills_dir = plugin_dir / 'skills'
-
     if not skills_dir.exists():
         return violations
 
+    applies = _md_applies_to(plugin_dir / 'references' / 'constraints' / f'{CONSTRAINT}.md')
     for skill_name in SUBAGENT_SKILLS:
         skill_file = skills_dir / skill_name / 'SKILL.md'
         if not skill_file.exists():
             continue
-
-        text = skill_file.read_text()
-        if not CONSTRAINT_PATTERN.search(text):
+        if skill_name.lower() not in applies:
             violations.append(
-                f"{skill_name}/SKILL.md does not reference post-subagent-enforcement.md — "
-                "skills that dispatch subagents must load post-subagent boundaries"
-            )
-
+                f"{CONSTRAINT}.md `applies-to` omits {skill_name} — it will NOT auto-load there.")
+        elif 'load-constraints.py' not in skill_file.read_text():
+            violations.append(
+                f"{skill_name}/SKILL.md does not invoke load-constraints.py — {CONSTRAINT} "
+                "won't auto-load (subagent-dispatching skills must run the constraint auto-loader).")
     return violations
 
 

--- a/references/constraints/topic-change-protocol.py
+++ b/references/constraints/topic-change-protocol.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env -S uv run python3
-"""Constraint: topic-change-protocol — verify workflow skills load this constraint."""
+"""Constraint: topic-change-protocol — verify workflow phase skills AUTO-LOAD this constraint.
+
+Authoring lint (checks the plugin's own skills/, not a user's document). Verifies the REAL
+loading mechanism: (a) topic-change-protocol.md's `applies-to` includes the phase skill AND
+(b) the skill invokes `load-constraints.py` (the auto-loader). The earlier version checked for a
+literal `.md` string reference in SKILL.md — a mechanism the auto-loader superseded — so it
+false-failed once check-all correctly scoped it to writing projects.
+"""
 
 CONSTRAINT = "topic-change-protocol"
 APPLIES_TO = ["writing-setup", "writing-outline", "writing-draft",
@@ -9,33 +16,43 @@ SEVERITY = "hard"
 import re
 from pathlib import Path
 
-# All workflow phase skills (except entry router) must load this
+# All workflow phase skills (except the entry router, which loads only the index) must auto-load this
 PHASE_SKILLS = ['writing-setup', 'writing-outline', 'writing-draft',
                 'writing-validate', 'writing-review', 'writing-revise']
-CONSTRAINT_PATTERN = re.compile(r'topic-change-protocol\.md')
+
+
+def _md_applies_to(md_path):
+    """Parse the `applies-to` list from a constraint .md's frontmatter (list or scalar form)."""
+    if not md_path.exists():
+        return []
+    text = md_path.read_text()
+    m = re.search(r'^applies-to:\s*\[(.*?)\]', text, re.M)
+    if m:
+        return [s.strip().strip('"\'').lower() for s in m.group(1).split(',') if s.strip()]
+    m = re.search(r'^applies-to:\s*(\S.*)$', text, re.M)
+    return [m.group(1).strip().lower()] if m else []
 
 
 def check(context):
-    """Returns list of violations. Empty list = pass."""
+    """Returns list of violations. Empty list = pass. Verifies the auto-load wiring."""
     violations = []
     plugin_dir = Path(__file__).resolve().parent.parent.parent
     skills_dir = plugin_dir / 'skills'
-
     if not skills_dir.exists():
         return violations
 
+    applies = _md_applies_to(plugin_dir / 'references' / 'constraints' / f'{CONSTRAINT}.md')
     for skill_name in PHASE_SKILLS:
         skill_file = skills_dir / skill_name / 'SKILL.md'
         if not skill_file.exists():
             continue
-
-        text = skill_file.read_text()
-        if not CONSTRAINT_PATTERN.search(text):
+        if skill_name.lower() not in applies:
             violations.append(
-                f"{skill_name}/SKILL.md does not reference topic-change-protocol.md — "
-                "workflow phases must handle off-topic messages gracefully"
-            )
-
+                f"{CONSTRAINT}.md `applies-to` omits {skill_name} — it will NOT auto-load there.")
+        elif 'load-constraints.py' not in skill_file.read_text():
+            violations.append(
+                f"{skill_name}/SKILL.md does not invoke load-constraints.py — {CONSTRAINT} "
+                "won't auto-load (workflow phases must run the constraint auto-loader).")
     return violations
 
 

--- a/references/constraints/writing-stop-triggers.py
+++ b/references/constraints/writing-stop-triggers.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env -S uv run python3
-"""Constraint: writing-stop-triggers — verify prose-producing skills load this constraint."""
+"""Constraint: writing-stop-triggers — verify prose-producing skills AUTO-LOAD this constraint.
+
+Authoring lint (checks the plugin's own skills/, not a user's document). It verifies the REAL
+loading mechanism: a constraint reaches a skill when (a) writing-stop-triggers.md's `applies-to`
+frontmatter includes that skill AND (b) the skill's SKILL.md invokes `load-constraints.py`
+(the auto-loader that concatenates every applies-to-matching .md). The earlier version checked
+for a literal `writing-stop-triggers.md` STRING in SKILL.md — a mechanism the load-constraints.py
+auto-loader superseded (the skills never inline-referenced constraints), so it false-failed.
+"""
 
 CONSTRAINT = "writing-stop-triggers"
 APPLIES_TO = ["writing-draft", "writing-review", "writing-revise"]
@@ -8,32 +16,44 @@ SEVERITY = "hard"
 import re
 from pathlib import Path
 
-# Skills that produce or modify prose must load stop triggers
+# Skills that produce or modify prose must auto-load stop triggers
 PROSE_SKILLS = ['writing-draft', 'writing-review', 'writing-revise']
-CONSTRAINT_PATTERN = re.compile(r'writing-stop-triggers\.md')
+
+
+def _md_applies_to(md_path):
+    """Parse the `applies-to` list from a constraint .md's frontmatter (list or scalar form)."""
+    if not md_path.exists():
+        return []
+    text = md_path.read_text()
+    m = re.search(r'^applies-to:\s*\[(.*?)\]', text, re.M)
+    if m:
+        return [s.strip().strip('"\'').lower() for s in m.group(1).split(',') if s.strip()]
+    m = re.search(r'^applies-to:\s*(\S.*)$', text, re.M)
+    return [m.group(1).strip().lower()] if m else []
 
 
 def check(context):
-    """Returns list of violations. Empty list = pass."""
+    """Returns list of violations. Empty list = pass. Verifies the auto-load wiring, not an
+    inline string reference."""
     violations = []
     plugin_dir = Path(__file__).resolve().parent.parent.parent
     skills_dir = plugin_dir / 'skills'
-
     if not skills_dir.exists():
         return violations
 
+    applies = _md_applies_to(plugin_dir / 'references' / 'constraints' / f'{CONSTRAINT}.md')
     for skill_name in PROSE_SKILLS:
         skill_file = skills_dir / skill_name / 'SKILL.md'
         if not skill_file.exists():
             continue
-
-        text = skill_file.read_text()
-        if not CONSTRAINT_PATTERN.search(text):
+        if skill_name.lower() not in applies:
             violations.append(
-                f"{skill_name}/SKILL.md does not reference writing-stop-triggers.md — "
-                "prose-producing skills must load stop trigger patterns"
-            )
-
+                f"{CONSTRAINT}.md `applies-to` omits {skill_name} — it will NOT auto-load there "
+                "(add the skill to the .md frontmatter)")
+        elif 'load-constraints.py' not in skill_file.read_text():
+            violations.append(
+                f"{skill_name}/SKILL.md does not invoke load-constraints.py — {CONSTRAINT} "
+                "won't auto-load (prose-producing skills must run the constraint auto-loader)")
     return violations
 
 

--- a/tests/test_writing_constraint_lints.py
+++ b/tests/test_writing_constraint_lints.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env -S uv run python3
+"""Regression test for the 3 writing authoring-lints (writing-stop-triggers,
+topic-change-protocol, post-subagent-enforcement).
+
+They verify the REAL auto-load wiring — (a) the constraint .md's `applies-to` includes the
+skill AND (b) the skill invokes load-constraints.py — NOT a defunct inline `.md` string
+reference (which false-failed once check-all correctly scoped APPLIES_TO to writing projects).
+
+Run:  uv run python3 tests/test_writing_constraint_lints.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LINTS = ["writing-stop-triggers", "topic-change-protocol", "post-subagent-enforcement"]
+
+_p = _f = 0
+
+
+def ok(name, cond, extra=""):
+    global _p, _f
+    if cond:
+        _p += 1; print(f"  ok  {name}")
+    else:
+        _f += 1; print(f"FAIL  {name} {extra}")
+
+
+def load(stem):
+    spec = importlib.util.spec_from_file_location(stem.replace("-", "_"),
+                                                  ROOT / "references" / "constraints" / f"{stem}.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+for stem in LINTS:
+    m = load(stem)
+    # 1. passes against the real plugin (the wiring is correct: applies-to + load-constraints call)
+    v = m.check({})
+    ok(f"{stem}: PASSES on the real plugin (wiring intact)", v == [], str(v))
+
+    # 2. still catches a real regression: simulate the .md applies-to dropping a required skill
+    skills_attr = next(a for a in ("PROSE_SKILLS", "PHASE_SKILLS", "SUBAGENT_SKILLS") if hasattr(m, a))
+    required = getattr(m, skills_attr)
+    orig = m._md_applies_to
+    m._md_applies_to = lambda p, _o=orig: [a for a in _o(p) if a != required[0]]
+    v = m.check({})
+    ok(f"{stem}: FAILS when applies-to omits {required[0]} (real regression caught)",
+       any(required[0] in x for x in v), str(v))
+    m._md_applies_to = orig
+
+    # 3. the .md it guards actually exists and lists the required skills
+    md = ROOT / "references" / "constraints" / f"{stem}.md"
+    ok(f"{stem}.md exists", md.is_file())
+    applies = m._md_applies_to(md)
+    ok(f"{stem}.md applies-to covers all required skills",
+       all(s.lower() in applies for s in required), f"applies={applies} required={required}")
+
+print(f"\n{_p} passed, {_f} failed")
+sys.exit(1 if _f else 0)


### PR DESCRIPTION
Handoff from the workshop D-w-8 check-all cleanup (#19/v5.59.1), which correctly made `check-all.py` honor `APPLIES_TO` — so writing's constraints now fire only on writing projects. But 3 of them then **failed**, turning writing's gate red:
`writing-stop-triggers.py`, `topic-change-protocol.py`, `post-subagent-enforcement.py`.

## Root cause
Each lint checked for a literal `<name>.md` **string inside** `skills/writing-*/SKILL.md` — a mechanism the `load-constraints.py` auto-loader **superseded**. Constraints actually reach a skill via (a) the constraint `.md`'s `applies-to` frontmatter + (b) the skill's `load-constraints.py` bang-line; the skills never inline-referenced constraint filenames, so the lint false-failed. Proven: all 3 `.md` carry correct `applies-to`, and `load-constraints.py writing-draft` already emits all 3.

These are **authoring lints** (they scan the plugin's own `skills/`, ignoring the user's document) — part of an established 7-lint family, so deleting only these 3 would be inconsistent.

## Fix (option 3 — repair, don't delete)
Each `check()` now verifies the **real** wiring: the `.md`'s `applies-to` includes the skill **and** the skill invokes `load-constraints.py`. Turns green **honestly** (the constraint genuinely reaches the skill) and still catches real regressions (broken `applies-to` or a missing auto-loader call) via the correct mechanism.

## Verification
- `tests/test_writing_constraint_lints.py` **12/12** — passes on the real plugin, a negative regression case (omit a required skill from `applies-to` → violation), and `.md` existence/coverage.
- `check-all.py` in a writing project: the 3 phantoms gone, **0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)