### PR TITLE
test(writing): force-add gitignored .planning/ fixture (clean-checkout fix)

### DIFF
--- a/tests/fixtures/writing-section-index/.planning/ACTIVE_WORKFLOW.md
+++ b/tests/fixtures/writing-section-index/.planning/ACTIVE_WORKFLOW.md
@@ -1,0 +1,5 @@
+---
+workflow: writing
+style: legal
+phase: draft
+---

--- a/tests/fixtures/writing-section-index/.planning/OUTLINE.md
+++ b/tests/fixtures/writing-section-index/.planning/OUTLINE.md
@@ -1,0 +1,33 @@
+# Master Outline — Fixture
+
+## Structure
+
+### Introduction
+- **Goal**: hook + thesis + roadmap.
+- **Claims preview**: CLAIM-01 → CLAIM-03.
+- A second bullet so this is granular.
+- A third bullet so this is granular.
+
+### Part I. The Setup — Foundations
+- Implements: setup for CLAIM-01; concept for CLAIM-02.
+- **A. First thing**: a substantive point [@smith2019].
+- **B. Second thing**: another point.
+- **C. Third thing**: closing point.
+
+### Part II — The Core Channels
+- Implements: CLAIM-02 + CLAIM-03.
+- **A. The core point** (CLAIM-02): the main empirical result.
+- **B. The second point** (CLAIM-03): the follow-on result.
+- **C. A third** point to be granular.
+
+### Conclusion
+- **Goal**: synthesize CLAIM-01 … CLAIM-03.
+- A second bullet.
+- A third bullet.
+
+## Claim → Section Map
+| Claim | Primary home | Setup / echo |
+|-------|--------------|--------------|
+| CLAIM-01 (framing) | I.A | Intro |
+| CLAIM-02 (core) | II.A | I.B |
+| CLAIM-03 (follow-on) | II.B | Intro |

--- a/tests/fixtures/writing-section-index/.planning/PRECIS_REVIEWED.md
+++ b/tests/fixtures/writing-section-index/.planning/PRECIS_REVIEWED.md
@@ -1,0 +1,4 @@
+---
+status: APPROVED
+---
+Precis reviewed: covers four claims across two substantive Parts.


### PR DESCRIPTION
**Caught by run-core-extract** running the full suite on a clean worktree: two writing tests fail on main HEAD even though no writing code changed —
- `tests/writing_section_index_test.py` → `KeyError 'Introduction'`
- `tests/writing_guards_test.py` → 2 failed

## Root cause
The section-index test fixture needs a real `.planning/` dir (`OUTLINE.md` + `ACTIVE_WORKFLOW.md` + `PRECIS_REVIEWED.md`), but `.gitignore:41` (`.planning/`) silently excluded them from PR #18's commits — `git add -A` respects gitignore. The files existed locally (untracked), so local runs passed, but a **clean checkout** had no fixture `.planning/` → `build_index` finds no `OUTLINE.md` → 0 sections → `KeyError`, and the exec-guard CLI test on the fixture sees no OUTLINE/PRECIS → 2 failures.

The gate-probe (23/23) and engine-discover (13/13) tests stayed green because they build their own tempdirs / pass data inline — they don't read this committed fixture, which is exactly the observed pattern.

## Fix
`git add -f` the 3 fixture files. Test-fixture only — **no plugin runtime change, no version bump**.

## Verification
True clean-checkout test via `git archive HEAD` (tracked files only) → extract → run: **section-index 28/28, guards 12/12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)