### PR TITLE
fix(writing): cite-fidelity constraints use CLAUDE_SKILL_DIR not CLAUDE_PLUGIN_ROOT (v5.63.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.63.1"
+    "version": "5.63.2"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.63.1",
+      "version": "5.63.2",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.63.1",
+  "version": "5.63.2",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/references/constraints/cite-fidelity-nlm-grounding.md
+++ b/references/constraints/cite-fidelity-nlm-grounding.md
@@ -16,7 +16,7 @@ inverted from write-then-cite to **ask-then-write**:
 3. Run Stage 2 to get the actual supporting passage:
 
    ```bash
-   uv run ${CLAUDE_PLUGIN_ROOT}/scripts/cite-fidelity/nlm_footnote_pull.py \
+   uv run ${CLAUDE_SKILL_DIR}/../../scripts/cite-fidelity/nlm_footnote_pull.py \
      --claim "TEXT" --keys k1,k2,k3
    ```
 

--- a/references/constraints/cite-fidelity-section-gate.md
+++ b/references/constraints/cite-fidelity-section-gate.md
@@ -12,7 +12,7 @@ MUST run Stage 3 of the cite-fidelity pipeline before marking the workflow
 COMPLETE:
 
 ```bash
-uv run ${CLAUDE_PLUGIN_ROOT}/scripts/cite-fidelity/check_section_cites.py --all
+uv run ${CLAUDE_SKILL_DIR}/../../scripts/cite-fidelity/check_section_cites.py --all
 ```
 
 The script writes `.planning/CITES-{section}.md` per draft section with

--- a/references/constraints/cite-fidelity-source-inventory.md
+++ b/references/constraints/cite-fidelity-source-inventory.md
@@ -11,7 +11,7 @@ If `.planning/ACTIVE_WORKFLOW.md` has an `nlm_notebook` field set, run Stage 1
 of the cite-fidelity pipeline before handing off to writing-outline:
 
 ```bash
-uv run ${CLAUDE_PLUGIN_ROOT}/scripts/cite-fidelity/nlm_source_inventory.py
+uv run ${CLAUDE_SKILL_DIR}/../../scripts/cite-fidelity/nlm_source_inventory.py
 ```
 
 This produces `references/source_summaries.md` — one entry per cited bibkey


### PR DESCRIPTION
Found via a workflow-creator self-audit.

## Bug
3 cite-fidelity constraint `.md` files embed a runnable bash command using `${CLAUDE_PLUGIN_ROOT}`:
- `cite-fidelity-source-inventory.md` (applies-to: writing-setup)
- `cite-fidelity-nlm-grounding.md` (applies-to: writing-draft, writing-revise)
- `cite-fidelity-section-gate.md` (applies-to: writing-revise)

But constraint `.md` is loaded as **skill content** (via `load-constraints.py`), where only `${CLAUDE_SKILL_DIR}` / `${CLAUDE_SESSION_ID}` / `$ARGUMENTS` are substituted — `${CLAUDE_PLUGIN_ROOT}` is **hook-command-only**, so it stays literal and the command the model is told to run fails.

## Fix
Use the skill-content convention every other constraint `.md` uses (`auto-loader-usage`, `atomic-constraints`, `ds-data-quality-checks`, `writing-common-constraints`):
`${CLAUDE_SKILL_DIR}/../../scripts/cite-fidelity/...`

Verified the resolved path (`skills/writing-*/../../scripts/cite-fidelity`) points at the real scripts. No other `${CLAUDE_PLUGIN_ROOT}` usages remain in `references/constraints/*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)