### PR TITLE
fix(ds): action-targeted Red Flags in ds-verify + ds-review (wc-audit)

### DIFF
--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -733,7 +733,7 @@ When presenting review findings to the user (especially at CHANGES REQUIRED verd
 - **You must treat alternative valid approaches as non-issues (confidence = 0).** If the approach works correctly, don't report it.
 - Ensure each reported issue is immediately actionable
 - **If you're unsure, rate it below 80 confidence.** Uncertainty is not a reason to report—it's a reason to investigate more.
-- Focus on what affects conclusions, not style. **STOP if you catch yourself criticizing coding style—that's not your role here.**
+- Focus on what affects conclusions, not style. **About to report a style/preference/coding-convention issue → DISCARD it (out of scope — this review judges conclusions, not style).**
 
 ## Gate: Exit Review Loop
 

--- a/skills/ds-verify/SKILL.md
+++ b/skills/ds-verify/SKILL.md
@@ -102,7 +102,7 @@ This applies even when:
 - "It should reproduce"
 - "User seemed happy earlier"
 
-**If you catch yourself thinking "I can skip verification," STOP — you're about to deliver unverified results that waste the user's time.**
+**About to claim COMPLETE without a fresh re-run this session → STOP (you ship unverified results that waste the user's time).**
 </EXTREMELY-IMPORTANT>
 
 ## Verification Facts


### PR DESCRIPTION
wc-audit v5.64.0 enforcement-checklist found 2 minor findings — deprecated intention-targeted Red Flag phrasing. Reworded both to action-targeted per v5.36.0 (ds-verify: 'about to claim COMPLETE without a fresh re-run → STOP'; ds-review: 'about to report a style issue → DISCARD'). Minor/format-only; substrate gate was already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)