### PR TITLE
docs(workshop): Generation Facts — wc-audit v5.64.0 compliance (v5.64.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.64.0"
+    "version": "5.64.1"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.64.0",
+      "version": "5.64.1",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.64.0",
+  "version": "5.64.1",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/workshop/SKILL.md
+++ b/skills/workshop/SKILL.md
@@ -490,6 +490,13 @@ Correct:
 This applies to EVERY list in EVERY slide. No exceptions.
 </EXTREMELY-IMPORTANT>
 
+### Generation Facts
+
+- The secreg/university theme requires `qr: none` in `config-info` — omit it and the deck does not compile. A deck that won't render is not a faster deck; the missing field surfaces as a compile failure the presenter debugs at their desk.
+- `cetz-plot` is NOT the theme's bundled `cetz` — importing `cetz-plot` breaks the compile. Build diagrams from the theme's `cetz.canvas`; reaching for the familiar package name ships a deck that won't build.
+- A fragment-agent that cites an inventory id absent from `SOURCES.md` fabricates evidence: the verify gate's source-fidelity reviewer flags it AND the JS inventory whitelist silently drops it, so the slide ships PARTIAL with an ungrounded claim. Cite ONLY the row's allowed ids — `citedInventory` is grep-grounded from the written fragment, so a memory-reported list that disagrees with the file is caught.
+- `notes.typ` is compile-gated, not slides-only — an invented note macro (`#slide-notes`, `#speaker-note`) that compiles this run only by an assembly-agent alias ships malformed notes on a less-defensive run. Notes are plain `=`/`==` headings + prose; inventing a macro to force a compile is rework, not speed.
+
 ### Typst Slide Conventions (from working example)
 
 **File header (slides.typ):**


### PR DESCRIPTION
## Summary

Fleet-wide wc-audit (v5.64.0) compliance pass on the **workshop** workflow.

**Audit result: PASS** — substrate gate clean (0 critical · 0 enforcement-Absent · **portability Clean**), **executionClass = `compiled-runner`** (data variant, correctly classified by the new detector), composite **9.32** (> 9.0).

## The one real fix
Phase 3 (generate) — a HIGH-drift file-generation phase — lacked a consolidated `### Generation Facts` section that all 3 sibling phases carry. The incident-grounded facts existed but sat inline in the Typst-conventions prose. Consolidated into 4 drive-consequence fact rows:
- `qr: none` is required by the secreg theme — omit it and the deck won't compile.
- `cetz-plot` ≠ the theme's bundled `cetz` — importing it breaks the compile.
- An out-of-inventory citation → verify source-fidelity flag + silent JS whitelist-drop → slide ships PARTIAL.
- `notes.typ` is compile-gated — no invented note macros.

After the fix, **Fact Rows scores Present** (was Weak in generate).

## Deliberately not fixed (justified)
The MINOR Red Flags table in Phase 2 (medium-drift). The audit marks it optional/low-priority — the gate + independent OUTLINE reviewer already cover the phase's drift, the substrate gate is clean without it, and no named incident grounds it. Adding it would be speculative enforcement; the audit itself warns "do not chase the composite past the substrate gate."

## Notable P22–P30 scores (compiled-runner)
P23 single-source parser **10** · P27 join-trust-class **10** · P29 phantom-canonical **10** (guard ran against the real opv OUTLINE → exit 0) · P30 gate-all-outputs **10** (notesCompiled gated).

Doc-only; workshop tests unaffected (parser 37/37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)