### PR TITLE
fix(writing): wc-audit P17 (allowed-tools) + P16 (implements trace) (v5.64.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.64.0"
+    "version": "5.64.1"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.64.0",
+      "version": "5.64.1",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.64.0",
+  "version": "5.64.1",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/references/constraints/phase-summary-frontmatter.md
+++ b/references/constraints/phase-summary-frontmatter.md
@@ -14,6 +14,7 @@ phase: [phase-name]
 status: completed
 sections_affected: [list of section names]
 artifacts_produced: [list of files created/modified]
+implements: [CLAIM-XX ids this phase advanced — the requirement→phase trace]
 requires: [artifacts this phase consumed]
 provides: [artifacts this phase produced]
 deviations: {r1: 0, r2: 0, r3: 0, r4: 0}

--- a/skills/writing-draft/SKILL.md
+++ b/skills/writing-draft/SKILL.md
@@ -292,6 +292,7 @@ Before proceeding to edit/verify (see `constraints/gate-function-standard.md` fo
 6. **SUMMARY**: Append phase summary to `.planning/PHASE_SUMMARY.md` (see `constraints/phase-summary-frontmatter.md`):
    - phase: draft
    - artifacts_produced: [list all drafts/*.md files created]
+   - implements: [CLAIM-XX ids the drafted sections advance — the requirement→phase trace]
    - provides: [drafts/*.md]
    - deviations: {r1: X, r2: Y, r3: Z, r4: W}
    - Include substantive one-liner (NOT "Drafting complete")

--- a/skills/writing-outline/SKILL.md
+++ b/skills/writing-outline/SKILL.md
@@ -329,6 +329,7 @@ Before proceeding to draft phase (see `constraints/gate-function-standard.md` fo
 7. **SUMMARY**: Append phase summary to `.planning/PHASE_SUMMARY.md` (see `constraints/phase-summary-frontmatter.md`):
    - phase: outline
    - artifacts_produced: [list all outlines/*.md files created]
+   - implements: [CLAIM-XX ids these outlines advance — the requirement→phase trace]
    - provides: [outlines/*.md, .planning/OUTLINE_REVIEWED.md]
    - deviations: {r1: X, r2: Y, r3: Z, r4: W}
    - Include substantive one-liner (NOT "Outlining complete")

--- a/skills/writing-review/SKILL.md
+++ b/skills/writing-review/SKILL.md
@@ -3,7 +3,7 @@ name: writing-review
 description: "Internal skill for hierarchical document review. Called by writing-validate after claim validation passes."
 user-invocable: false
 disable-model-invocation: true
-allowed-tools: Read, Grep, Glob, Agent, Skill
+allowed-tools: Read, Grep, Glob, Bash, Write, Agent, Skill, Workflow
 hooks:
   PreToolUse:
     - matcher: "Write|Edit|Agent"
@@ -269,6 +269,7 @@ Before declaring review complete:
 6. **SUMMARY**: Append phase summary to `.planning/PHASE_SUMMARY.md` (see `constraints/phase-summary-frontmatter.md`):
    - phase: review
    - artifacts_produced: [.planning/REVIEW.md]
+   - implements: [CLAIM-XX ids the reviewed sections cover — the requirement→phase trace]
    - provides: [.planning/REVIEW.md]
    - Include substantive one-liner with issue counts by severity (NOT "Review complete")
 

--- a/skills/writing-revise/SKILL.md
+++ b/skills/writing-revise/SKILL.md
@@ -536,6 +536,7 @@ verdict: COMPLETE
 **SUMMARY**: Append final phase summary to `.planning/PHASE_SUMMARY.md` (see `constraints/phase-summary-frontmatter.md`):
 - phase: revise
 - artifacts_produced: [list all modified drafts/*.md files]
+- implements: [CLAIM-XX ids the revised sections advance — the requirement→phase trace]
 - provides: [final drafts/*.md]
 - deviations: {r1: X, r2: Y, r3: Z, r4: W}
 - Include substantive one-liner with total iterations and final verdict (NOT "Revision complete")

--- a/skills/writing-setup/SKILL.md
+++ b/skills/writing-setup/SKILL.md
@@ -354,6 +354,7 @@ Before proceeding to outline phase (see `constraints/gate-function-standard.md` 
 6. **SUMMARY**: Append phase summary to `.planning/PHASE_SUMMARY.md` (see `constraints/phase-summary-frontmatter.md`):
    - phase: setup
    - artifacts_produced: [PRECIS.md, OUTLINE.md, ACTIVE_WORKFLOW.md, PRECIS_REVIEWED.md]
+   - implements: [all CLAIM-XX ids defined in PRECIS — the requirement→phase trace]
    - provides: [.planning/PRECIS.md, .planning/OUTLINE.md, .planning/ACTIVE_WORKFLOW.md]
    - Include substantive one-liner (NOT "Setup complete")
 


### PR DESCRIPTION
Fleet wc-audit (v5.64.0, P01–P30) on the **writing** workflow returned: **substrate gate CLEAN** (0 critical, 0 enforcement-Absent, portability Clean), **executionClass=compiled-runner**, composite 8.94. Fixing the 2 genuinely-real findings — **not** chasing the noise-band composite past the clean substrate gate (per the audit's own guidance).

## P17 — real functional defect
`skills/writing-review/SKILL.md` `allowed-tools` was `Read, Grep, Glob, Agent, Skill` — but the skill must `Write .planning/REVIEW.md` (:243), run Bash bang-lines (load-constraints :31, check-all :154), and invoke the `writing-review.js` Workflow (:203/:226). Under the declared set it **could not produce its own output**. Added `Bash, Write, Workflow` (`Edit` intentionally still omitted — review never edits drafts).

## P16 — traceability gap
The phase-summary frontmatter omitted `implements:` (which CLAIM-XX a phase advances), so the requirement→phase trace was absent from the durable summary. Added it to the canonical template (`references/constraints/phase-summary-frontmatter.md`) + the per-skill SUMMARY steps (setup/outline/draft/review/revise). Kept a **documented** field, **not** a newly-required lint field (no speculative enforcement; existing summaries don't break — lint still PASS).

## Deferred (advisory / by-design, justified)
- **P18** scope-tagging (v1/v2/out-of-scope per claim) — speculative feature, doesn't fit writing's free-text scope.
- **P28** filename tolerance — deliberate, documented back-compat shim (the parser accepts legacy + canonical; the emitter is canonical going forward).
- **GATE_BLOCKED `Agent` vs `Task`** — known env-version-dependent phase-gate-guard quirk; Write/Edit gating still holds, risky to flip.

## Verification
constraint-lints 12/12 · section-index 28/28 · guards 12/12 · phase-summary lint PASS · `writing-review` frontmatter parses with Write/Bash/Workflow present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)