### PR TITLE
fix(ds): action-targeted the remaining 2 Red Flags (class-complete)

### DIFF
--- a/skills/ds-handoff/SKILL.md
+++ b/skills/ds-handoff/SKILL.md
@@ -30,7 +30,7 @@ Before writing `.planning/HANDOFF.md`, you MUST:
 4. ASSESS what is actually done vs. what remains
 5. Only THEN write the handoff document
 
-**If you catch yourself writing a handoff without reading state files first, STOP.**
+**About to write the handoff without having read the state files first → STOP (read them, then write).**
 </EXTREMELY-IMPORTANT>
 
 ## Handoff Facts

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -339,7 +339,7 @@ This applies even when:
 - "The approach seems unusual"
 - "I would have done it differently"
 
-**STOP - If you catch yourself about to report a low-confidence issue, DISCARD IT. You're about to compromise the review's integrity.**
+**About to report a low-confidence (<80) issue → DISCARD IT (you'd compromise the review's integrity).**
 </EXTREMELY-IMPORTANT>
 
 <EXTREMELY-IMPORTANT>


### PR DESCRIPTION
Class-completeness follow-up to PR#32: the rate-limited enforcement reviewer sampled 2 findings; fixing the whole class found 2 more of the same deprecated intention-targeted form (ds-review L342, ds-handoff L33), now action-targeted per v5.36.0. No 'catch yourself' phrasing remains in any ds skill. Minor/format-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)