### PR TITLE
fix(writing): load domain structure template before building the master outline (v5.65.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.65.2"
+    "version": "5.65.3"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.65.2",
+      "version": "5.65.3",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.65.2",
+  "version": "5.65.3",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/writing-setup/SKILL.md
+++ b/skills/writing-setup/SKILL.md
@@ -67,10 +67,12 @@ START (brainstorm confirmed)
   │     └─ ISSUES_FOUND → fix PRECIS.md → re-dispatch (max 5)
   │
   ├─ Step 3: Create OUTLINE.md
-  │  └─ Map sections → claims from PRECIS
+  │  ├─ Step 3a: Load the DOMAIN structure template FIRST (writing-{domain} → its
+  │  │           document-structure section; domain is already pinned in PRECIS Step 2)
+  │  └─ Map sections → claims from PRECIS, CONFORMING to that structure template
   │     Each section has: Goal, Claim, Key Points, Transition
   │
-  ├─ Step 4: Detect domain (legal/econ/general)
+  ├─ Step 4: Confirm domain (already pinned in PRECIS; do NOT re-detect after the outline)
   │
   ├─ Step 5: Create ACTIVE_WORKFLOW.md
   │
@@ -199,6 +201,27 @@ Follow the reviewer skill instructions: dispatch the subagent, handle APPROVED/I
 Structure the argument with sections mapped to claims from PRECIS.md.
 
 <EXTREMELY-IMPORTANT>
+### Step 3a: Load the domain's document-structure template FIRST (before building structure)
+
+**NO MASTER OUTLINE WITHOUT THE DOMAIN STRUCTURE TEMPLATE IN CONTEXT. This is not negotiable.**
+
+The master `## Structure` you build here commits the article's section flow — and the canonical
+flow lives in the **domain skill**, not this skill. Building the outline before reading it means
+the structure is set one-to-two phases before its own template is ever in context (the
+phase-ordering defect: the domain was only loaded at draft/review). The `## Domain` field is
+already pinned in PRECIS.md (Step 2), so read the matching domain skill's structure section NOW:
+
+| Domain (from PRECIS) | Read this structure section |
+|---|---|
+| legal | `${CLAUDE_SKILL_DIR}/../../skills/writing-legal/SKILL.md` → **"Law Review Article Structure"** (Introduction → Background → Proof of the Claim → Conclusion) |
+| econ | `${CLAUDE_SKILL_DIR}/../../skills/writing-econ/SKILL.md` → its document-structure section (hook-with-finding → … → conclusion) |
+| general | `${CLAUDE_SKILL_DIR}/../../skills/writing-general/SKILL.md` → its structure guidance |
+
+Build the master `## Structure` so its sections CONFORM to that template (e.g. for legal: an
+Introduction, a Background that does not exceed the Proof, a Proof-of-the-Claim core, a
+Conclusion). If the argument needs to deviate from the canonical flow, that is an R4 decision —
+note it in LEARNINGS.md, don't drift silently.
+
 ### OUTLINE.md is a MACHINE-EXECUTABLE SPEC (born-canonical)
 
 `scripts/writing/writing_section_index.py` parses OUTLINE.md to build the section set the
@@ -262,9 +285,13 @@ regex papering over drift):
 [Gaps to address before drafting]
 ```
 
-## Step 4: Domain Detection
+## Step 4: Confirm Domain (already pinned in PRECIS — do NOT re-detect after the outline)
 
-Detect domain from sources and topic:
+The domain is set in PRECIS.md's `## Domain` (Step 2) and was used to load the structure template
+in Step 3a — it must be known BEFORE the outline, not detected after it. Here, just **confirm** the
+PRECIS domain matches the source/topic indicators and **record** it for ACTIVE_WORKFLOW.md. If the
+indicators contradict the PRECIS domain, that is a Step-2 error — fix PRECIS and re-run Step 3a, do
+not silently proceed with an outline built against the wrong structure template.
 
 | Domain Indicators | Style | Skill |
 |---|---|---|

--- a/tests/writing_section_index_test.py
+++ b/tests/writing_section_index_test.py
@@ -126,22 +126,38 @@ with tempfile.TemporaryDirectory() as td:
     check("style econ read", r2.style == "econ")
 
 
-# ── real-repo parity (skipped if absent): the golden ground truth ────────────────
+# ── real-repo smoke (skipped if absent): assert INVARIANTS, not mutable contents ──────
+# NB: tender_offers/paper is a LIVE repo that gets restructured (section count/names/claim
+# count change as the paper is revised). Asserting an exact section list here is brittle and
+# false-fails whenever the author edits the paper. So check only the parser INVARIANTS that
+# must hold for ANY well-formed writing project; the exact-contents oracle lives in the
+# committed fixture above (writing-section-index), which is stable.
 REAL = Path.home() / "projects" / "tender_offers" / "paper"
 if (REAL / ".planning" / "OUTLINE.md").is_file():
     rr = wsi.build_index(REAL)
-    names = [s.name for s in rr.sections]
-    check("[real] 5 sections, Intro→Conclusion order",
-          names == ["Introduction", "Part I. The Law and Economics of the Tender-Offer Clock",
-                    "Part II. What the Cut Affects — The Two Offer-Period Channels",
-                    "Part III. Objections and the Targeted Fix", "Conclusion"], str(names))
-    check("[real] all claimOk under ⊇", all(s.claim_ok for s in rr.sections))
-    check("[real] stale-approval fired (5≠6 claims, 4≠3 Parts)",
-          len(rr.stale_approval) >= 2, str(rr.stale_approval))
-    check("[real] every section paired to outline+draft",
-          all(s.outline_file and s.draft_file for s in rr.sections))
+    n = len(rr.sections)
+    check("[real] build_index returns sections", n >= 3, f"got {n}")
+    check("[real] document order is contiguous 0..n-1",
+          [s.order for s in rr.sections] == list(range(n)))
+    check("[real] ends have empty prev/next, interiors don't",
+          n >= 2 and rr.sections[0].prev_name == "" and rr.sections[-1].next_name == ""
+          and all(rr.sections[i].prev_name for i in range(1, n)))
+    # Pairing is REPO-STATE-dependent: a WIP repo mid-revision may have ## Structure headings the
+    # outline/draft filenames don't yet match (the parser CORRECTLY surfaces that drift as unpaired
+    # — it's not a parser bug). So assert only that the pairing fields are well-formed (str|None),
+    # and LOG the paired count rather than requiring all-paired.
+    check("[real] pairing fields well-formed (str|None)",
+          all((s.outline_file is None or isinstance(s.outline_file, str))
+              and (s.draft_file is None or isinstance(s.draft_file, str)) for s in rr.sections))
+    paired = sum(1 for s in rr.sections if s.outline_file and s.draft_file)
+    print(f"  -- [real] {paired}/{n} sections fully paired (informational; WIP repos drift)")
+    check("[real] ⊇ claim gate holds for every section", all(s.claim_ok for s in rr.sections),
+          str([s.name for s in rr.sections if not s.claim_ok]))
+    # stale_approval is state-dependent (true iff a *_REVIEWED predates the live structure) — it is
+    # a LIST (possibly empty); assert only that the field is well-formed, never a specific count.
+    check("[real] stale_approval is a well-formed list", isinstance(rr.stale_approval, list))
 else:
-    print("  -- real tender_offers repo absent; parity check skipped")
+    print("  -- real tender_offers repo absent; smoke check skipped")
 
 
 print(f"\n{_passed} passed, {_failed} failed")


### PR DESCRIPTION
**Phase-ordering defect** (surfaced while drafting the tender-offer law review; routed in by the drafting session).

## Bug
The domain skill (`writing-legal`/`econ`/`general`) holds the canonical **document-structure template** — e.g. `writing-legal`'s *Law Review Article Structure*: Introduction → Background → Proof of the Claim → Conclusion. But it was only loaded at **draft/review/revise**, never at `writing-setup` (which creates the master `OUTLINE.md`) or `writing-outline`. Worse, `writing-setup` placed **Domain Detection at Step 4 — *after* OUTLINE creation at Step 3**. So the article's section structure was committed one-to-two phases **before** its structural template ever entered context. (Did not corrupt the current paper — its outline happened to conform — but the gap is real.)

## Fix (root cause — `writing-setup`)
- **New Step 3a:** load the domain skill's document-structure section **first** (keyed on the `## Domain` already pinned in PRECIS at Step 2) and build the master `## Structure` to **conform** to it; deviation is an R4 logged to LEARNINGS.md.
- **Reframed Step 4** from "Domain Detection" (mis-ordered, post-outline) to "Confirm Domain" — already pinned in PRECIS; a contradiction means fix PRECIS + re-run Step 3a, not proceed against the wrong template.
- Updated the **Decision Flowchart** (authoritative spec) to match.
- `writing-outline` needs no change: section-*internal* structure is domain-agnostic; document-level section flow is the master OUTLINE's job, now fixed.

## Bundled (test health)
The `writing_section_index` `[real]` block hard-coded the tender_offers paper's exact 5-section list, but that's a **live repo that gets restructured** (now 7 sections) — it false-failed for every session running the suite (run-core-extract hit it too). Rewrote it to assert parser **invariants** (sections discovered · contiguous order · ends-empty prev/next · claim ⊇ gate · well-formed pairing + informational paired-count · stale_approval well-formed) instead of mutable contents. The exact-contents oracle stays in the stable committed fixture. **30/30 now (was 25/3 on main, pre-existing).**

## Regression
section-index 30/30 · guards 12/12 · gate-probe 21/21 · constraint-lints 12/12 · engine-discover 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)