### PR TITLE
fix(writing): load domain structure at writing-outline too — completes phase-ordering fix (v5.65.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.65.3"
+    "version": "5.65.4"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.65.3",
+      "version": "5.65.4",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.65.3",
+  "version": "5.65.4",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/writing-outline/SKILL.md
+++ b/skills/writing-outline/SKILL.md
@@ -59,7 +59,8 @@ Auto-load all constraints matching `applies-to: writing-outline`:
 ```
 START (PRECIS + master OUTLINE exist)
   │
-  ├─ Step 1: Load context (PRECIS, OUTLINE, ACTIVE_WORKFLOW)
+  ├─ Step 1: Load context (PRECIS, OUTLINE, ACTIVE_WORKFLOW) + the DOMAIN structure template
+  │           (writing-{domain} → section-role structure, before outlining a section)
   │
   ├─ Step 2: Select section (user choice or next unoutlined)
   │
@@ -123,6 +124,21 @@ Read(".planning/OUTLINE.md")
 ```
 
 If master OUTLINE.md is missing, run writing-brainstorm first.
+
+**Also load the domain's structure template (same phase-ordering rule as writing-setup Step 3a).**
+The master OUTLINE pins each section's PLACE in the document, but a section's *internal* outline
+depends on its ROLE — a "Proof of the Claim" Part is structured differently from a "Background"
+Part. That role-structure lives in the domain skill, so read its document-structure section
+BEFORE outlining a section (keyed on `style` in ACTIVE_WORKFLOW.md / `## Domain` in PRECIS):
+
+| Domain | Read |
+|---|---|
+| legal | `${CLAUDE_SKILL_DIR}/../../skills/writing-legal/SKILL.md` → **"Law Review Article Structure"** (what a Background vs Proof vs Conclusion section does) |
+| econ | `${CLAUDE_SKILL_DIR}/../../skills/writing-econ/SKILL.md` → its document-structure section |
+| general | `${CLAUDE_SKILL_DIR}/../../skills/writing-general/SKILL.md` → its structure guidance |
+
+Outline each section to fit its role in that template (e.g. legal: keep Background from
+exceeding the Proof; make a Proof section argument-and-evidence, not just exposition).
 
 ### Step 2: Select Section
 


### PR DESCRIPTION
Follow-up to #38 (v5.65.3, which fixed the writing-**setup** half). The original defect report named writing-setup **and** writing-outline; the tender-paper-rewrite session re-flagged the outline half.

**Real secondary instance:** writing-outline commits each section's *internal* structure, but Step 1 loaded only ACTIVE_WORKFLOW/PRECIS/OUTLINE — not the domain skill. The master OUTLINE (now conformant after #38) pins a section's *place*, but its *role*-structure (a Proof Part is built differently from a Background Part — legal 'Background must not exceed Proof'; Proof = argument+evidence, not exposition) lives in the domain skill, which wasn't in context until draft.

**Fix:** writing-outline Step 1 now also loads the domain skill's document-structure section (keyed on style/Domain), mirroring writing-setup Step 3a; outline each section to fit its role. Flowchart (authoritative spec) updated. Uses `CLAUDE_SKILL_DIR` (skill content), not `PLUGIN_ROOT`.

Regression: section-index 30/30, constraint-lints 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)