### PR TITLE
feat(writing-legal): three-part-body default — start at three, split only on unwieldiness (v5.65.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.65.4"
+    "version": "5.65.5"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.65.4",
+      "version": "5.65.5",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.65.4",
+  "version": "5.65.5",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/writing-legal/SKILL.md
+++ b/skills/writing-legal/SKILL.md
@@ -100,6 +100,32 @@ Start with CONCRETE QUESTION that matters, not abstract topic description.
 
 ## Law Review Article Structure
 
+<EXTREMELY-IMPORTANT>
+### The Three-Part Body is the DEFAULT — start at three, ALWAYS
+
+A law-review article DEFAULTS to **Introduction + three body Parts + Conclusion**. Seed exactly
+these three body Parts before any decomposition:
+
+| Part | Mode | Holds |
+|------|------|-------|
+| **Part I — Background** | descriptive | the law / doctrine / facts the argument needs |
+| **Part II — The Argument (Proof of the Claim)** | analytical | the proof, with **counterarguments FOLDED IN** — not a separate Part |
+| **Part III — The Prescription** | normative | the reform / fix |
+
+**Splitting a Part into two+ numbered Parts is an EXCEPTION, not the starting point.** Split
+ONLY when a Part has become genuinely too large to hold together as one — and that is a demonstrated
+condition you reach, never the initial decomposition. Begin three-part; expand only on demonstrated
+unwieldiness, and log the split as an R4 decision in LEARNINGS.md.
+
+**Anti-pattern (do NOT do this):** opening by decomposing the body into 4–5 Parts — e.g. splitting
+the Proof into separate "Elimination" and "Window" Parts, or breaking counterarguments out as their
+own Part — before any Part has proven unwieldy. Counterarguments belong folded into Part II. Five
+small Parts where three would hold is a structure smell, not thoroughness.
+
+The subsections below describe what each section/Part DOES; the three-part body above is how many
+there are by default.
+</EXTREMELY-IMPORTANT>
+
 ### Introduction
 
 The introduction serves three functions:
@@ -144,6 +170,13 @@ For prescriptive claims: Show the proposal is both doctrinally sound AND good po
 - How does the claim relate to parallel debates?
 - What subsidiary discoveries emerged?
 - What questions remain for future research?
+
+### Prescription (Part III)
+
+The normative payoff: the reform/fix the argument earns. Keep it ONE Part by default.
+- State the fix concretely and minimally — the smallest change that solves the problem proven in Part II.
+- Show it is feasible and administrable (who implements it, by what mechanism), and tie it back to the doctrine from Part I.
+- Anticipate implementation objections here; deeper merits-counterarguments stay folded into Part II's argument.
 
 ### Conclusion
 

--- a/skills/writing-setup/SKILL.md
+++ b/skills/writing-setup/SKILL.md
@@ -217,10 +217,20 @@ already pinned in PRECIS.md (Step 2), so read the matching domain skill's struct
 | econ | `${CLAUDE_SKILL_DIR}/../../skills/writing-econ/SKILL.md` → its document-structure section (hook-with-finding → … → conclusion) |
 | general | `${CLAUDE_SKILL_DIR}/../../skills/writing-general/SKILL.md` → its structure guidance |
 
-Build the master `## Structure` so its sections CONFORM to that template (e.g. for legal: an
-Introduction, a Background that does not exceed the Proof, a Proof-of-the-Claim core, a
-Conclusion). If the argument needs to deviate from the canonical flow, that is an R4 decision —
-note it in LEARNINGS.md, don't drift silently.
+Build the master `## Structure` so its sections CONFORM to that template. **For `style: legal`,
+SEED THE CANONICAL THREE-PART BODY by default — start at three, always:**
+
+- `### Introduction`
+- `### Part I. Background` — descriptive: the law / doctrine / facts the argument needs
+- `### Part II. The Argument` — analytical: the proof, **counterarguments FOLDED IN** (not a separate Part)
+- `### Part III. The Prescription` — normative: the reform / fix
+- `### Conclusion`
+
+**Do NOT open by decomposing the body into 4–5 Parts** (e.g. splitting the Proof into two Parts, or
+breaking counterarguments out as their own Part). Splitting a Part is an EXCEPTION that requires the
+Part to be demonstrably too large to hold together — it is never the starting decomposition. Begin
+three-part; if a Part later proves unwieldy, splitting it is an R4 decision logged in LEARNINGS.md.
+Any deviation from the canonical flow is likewise R4 — note it, don't drift silently.
 
 ### OUTLINE.md is a MACHINE-EXECUTABLE SPEC (born-canonical)
 


### PR DESCRIPTION
**User standing instruction.** A law-review outline DEFAULTS to **Introduction + three body Parts + Conclusion** — start at three, *always*:

- **Part I — Background** (descriptive: the law/doctrine/facts the argument needs)
- **Part II — The Argument / Proof of the Claim** (analytical; **counterarguments FOLDED IN**, not a separate Part)
- **Part III — The Prescription** (normative: the reform/fix)

Splitting a Part into 2+ numbered Parts is an **exception** requiring the Part to be demonstrably too large to hold together — never the starting decomposition. Five small Parts where three would hold is a structure smell, not thoroughness.

*(Prompted by the tender paper being decomposed into 5 then 4 Parts up front — the Proof split into "Elimination" + "Window" — instead of starting from three and splitting only under pressure.)*

## Encoded
Rides on the v5.65.3/5.65.4 domain-skill-loads-*before*-structure fix, so the template is in context when structure is committed:
- `skills/writing-legal/SKILL.md` "Law Review Article Structure": new `<EXTREMELY-IMPORTANT>` **"Three-Part Body is the DEFAULT"** block (table + split-only-if-unwieldy caveat + the 4–5-Part anti-pattern) + a new **Prescription (Part III)** subsection.
- `skills/writing-setup` Step 3a: for `style: legal`, **seed** Intro + Part I Background / II Argument / III Prescription + Conclusion by default; do not open by decomposing into 4–5 Parts; splits are R4-logged in LEARNINGS.md.

## Regression
section-index 30/30 · constraint-lints 12/12. Standing instruction also recorded in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)