### PR TITLE
feat(de-ai-revise): auto-mask footnotes before scoring (v5.66.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.65.5"
+    "version": "5.66.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.65.5",
+      "version": "5.66.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.65.5",
+  "version": "5.66.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/de-ai-revise/SKILL.md
+++ b/skills/de-ai-revise/SKILL.md
@@ -95,6 +95,10 @@ user's own published prose — uses them deliberately. Do NOT zero them out.
   flag or swap — these are legal/finance-normal; the audit already excludes them.
 - **Quoted text, block quotes, statutory language, party names, code, citations:** flag
   at most; never rewrite someone else's words or a term of art.
+- **Footnotes are auto-excluded:** the audit MASKS pandoc inline `^[...]` and markdown `[^id]:`
+  footnotes before scoring, so findings never land inside them (citation/legal-normal text). You
+  will not see footnote spans to triage; if you ever do, do not edit them. (`--keep-footnotes`
+  disables masking for debugging the raw signal only.)
 - **A flagged span the author clearly chose** (a fragment for emphasis, a repeated key
   term over elegant variation): leave it; note it in the report.
 

--- a/skills/de-ai-revise/scripts/de_ai_audit.py
+++ b/skills/de-ai-revise/scripts/de_ai_audit.py
@@ -20,6 +20,14 @@ rewrite revises the flagged spans — it does NOT chase the composite. Diction
 `dropped`-tier words are never emitted: flagging legal-normal vocabulary is the
 false-positive failure this tiering exists to prevent.
 
+FOOTNOTES ARE MASKED before scoring (default; `--keep-footnotes` to disable): pandoc inline
+`^[...]` and markdown `[^id]:` definition blocks are blanked to spaces (line numbers + offsets
+preserved) so NO finding lands inside a footnote. Footnotes/citations are off-limits to a de-AI
+rewrite — they carry [@bibkey] cites, quoted/statutory text, and legal-normal prose — and without
+masking the scorers emit metronomic-run / nominalization / em-dash findings inside citation text
+that the rewriter must exclude by hand. Masking enforces the SKILL's Preserve-Human rule
+mechanically. (Applies to the tics + diction scans AND style_metrics, which runs on the masked text.)
+
 Usage:
   de_ai_audit.py draft.md                 # human-readable report
   de_ai_audit.py --json draft.md ...      # machine output (review/revise consume this)
@@ -30,9 +38,11 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 SKILL_DIR = Path(__file__).resolve().parent.parent          # skills/de-ai-revise
@@ -119,8 +129,49 @@ def _paragraphs(text: str):
         yield start, "\n".join(buf)
 
 
+# ── footnote masking ──────────────────────────────────────────────────────────
+# Footnotes/citations are OFF-LIMITS to a de-AI rewrite (they carry [@bibkey] cites, quoted and
+# statutory text, and legal-normal prose). The scorers (tics + diction + style_metrics) otherwise
+# treat footnote text as body and emit findings INSIDE footnotes — metronomic runs, nominalizations,
+# em-dashes — which the rewriter must then exclude by hand. Masking them here (blanking to spaces,
+# PRESERVING line count + offsets so line-anchoring stays exact) means findings never target a
+# footnote in the first place. Covers pandoc inline `^[...]` (one level of nested `[...]` for cites)
+# and markdown reference definitions `[^id]: ...` + their indented continuation lines.
+_INLINE_FN = re.compile(r"\^\[(?:[^\[\]]|\[[^\]]*\])*\]")
+_REF_FN_DEF = re.compile(r"^\s*\[\^[^\]]+\]:")
+
+
+def _blank(s: str) -> str:
+    """Replace every non-newline char with a space (keeps length + line breaks)."""
+    return re.sub(r"[^\n]", " ", s)
+
+
+def mask_footnotes(text: str) -> str:
+    # 1. inline ^[...] footnotes (may span lines; _blank preserves the newlines)
+    text = _INLINE_FN.sub(lambda m: _blank(m.group(0)), text)
+    # 2. reference [^id]: definition blocks — the def line + indented continuation lines
+    out, in_def = [], False
+    for ln in text.split("\n"):
+        if _REF_FN_DEF.match(ln):
+            in_def = True
+            out.append(_blank(ln)); continue
+        if in_def:
+            if ln.strip() == "":          # blank line ends the definition block
+                in_def = False; out.append(ln); continue
+            if re.match(r"^(\s{2,}|\t)", ln):  # indented continuation stays masked
+                out.append(_blank(ln)); continue
+            in_def = False                # non-indented line ends the block
+        out.append(ln)
+    return "\n".join(out)
+
+
 def audit_text(text: str, path: str = "<text>",
-               tiers_on=("always_flag", "cluster", "density")) -> dict:
+               tiers_on=("always_flag", "cluster", "density"),
+               mask_fn: bool = True) -> dict:
+    # OFF-LIMITS footnotes/citations are masked (to spaces, offsets preserved) BEFORE scoring so no
+    # finding lands inside one. --keep-footnotes disables this for debugging the raw signal.
+    if mask_fn:
+        text = mask_footnotes(text)
     tics = _load_tics()
     diction = _load_diction()
     lines = text.split("\n")
@@ -191,8 +242,25 @@ def audit_text(text: str, path: str = "<text>",
                     "message": f"density saturation ({density_rate*100:.1f}% fancy words): '{w}' x{n} — vary toward plainer diction",
                 })
 
-    # --- stylometrics ---
-    style = _run_style(Path(path)) if path not in ("<text>",) else {}
+    # --- stylometrics (run on the MASKED text so footnote spans don't produce findings either;
+    #     blanking preserves line numbers, so style findings still anchor to the right body lines) ---
+    style = {}
+    if path not in ("<text>",):
+        if mask_fn:
+            tmp = None
+            try:
+                fd, tmp = tempfile.mkstemp(suffix=".md")
+                with os.fdopen(fd, "w", encoding="utf-8") as tf:
+                    tf.write(text)  # already masked above
+                style = _run_style(Path(tmp))
+            finally:
+                if tmp:
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+        else:
+            style = _run_style(Path(path))
     style_findings = style.get("findings", [])
     for f in style_findings:
         spans.append({
@@ -225,9 +293,9 @@ def audit_text(text: str, path: str = "<text>",
     }
 
 
-def audit_file(path: str, tiers_on) -> dict:
+def audit_file(path: str, tiers_on, mask_fn: bool = True) -> dict:
     text = Path(path).read_text(encoding="utf-8", errors="ignore")
-    return audit_text(text, path, tiers_on)
+    return audit_text(text, path, tiers_on, mask_fn=mask_fn)
 
 
 def _report(res: dict) -> None:
@@ -254,12 +322,15 @@ def main():
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--tier", default="always_flag,cluster,density",
                     help="diction tiers to apply (comma-sep): always_flag,cluster,density")
+    ap.add_argument("--keep-footnotes", action="store_true",
+                    help="do NOT mask footnotes before scoring (default: mask ^[...] and [^id]: — "
+                         "footnotes/citations are off-limits to a de-AI rewrite)")
     a = ap.parse_args()
     tiers_on = tuple(t.strip() for t in a.tier.split(",") if t.strip())
     allres = {}
     worst = 0
     for f in a.files:
-        res = audit_file(f, tiers_on)
+        res = audit_file(f, tiers_on, mask_fn=not a.keep_footnotes)
         allres[f] = res
         if res["n_spans"]:
             worst = 1

--- a/tests/test_de_ai_footnote_masking.py
+++ b/tests/test_de_ai_footnote_masking.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S uv run --with pyyaml python3
+"""Tests for de_ai_audit.py footnote masking — findings must never land inside a footnote
+(pandoc inline ^[...] or markdown [^id]: definitions), since footnotes/citations are off-limits
+to a de-AI rewrite. Run: uv run --with pyyaml python3 tests/test_de_ai_footnote_masking.py"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "skills" / "de-ai-revise" / "scripts"))
+import de_ai_audit as d  # noqa: E402
+
+_p = _f = 0
+
+
+def ok(name, cond, extra=""):
+    global _p, _f
+    if cond:
+        _p += 1; print(f"  ok  {name}")
+    else:
+        _f += 1; print(f"FAIL  {name} {extra}")
+
+
+# 'tapestry' is an always_flag diction word → flagged on EVERY occurrence (no cluster threshold).
+BODY_L1 = "The market is a rich tapestry of incentives."          # line 1 — body, MUST flag
+FN_INLINE = "A claim with a note.^[This tapestry sits in a footnote [@smith2019].]"  # line 3 — footnote, must NOT flag
+REF_DEF = "[^x]: A reference footnote about a tapestry."          # line 5 — footnote def, must NOT flag
+REF_CONT = "    continued tapestry text, indented."              # line 6 — continuation, must NOT flag
+BODY_L8 = "A final tapestry in the body."                         # line 8 — body, MUST flag
+TEXT = "\n".join([BODY_L1, "", FN_INLINE, "", REF_DEF, REF_CONT, "", BODY_L8]) + "\n"
+
+# ── masking preserves structure ──
+masked = d.mask_footnotes(TEXT)
+ok("line count preserved", len(masked.split("\n")) == len(TEXT.split("\n")))
+ok("inline ^[...] blanked", "tapestry sits in a footnote" not in masked)
+ok("[^id]: def blanked", "reference footnote about a tapestry" not in masked)
+ok("indented continuation blanked", "continued tapestry text" not in masked)
+ok("body line 1 intact", "rich tapestry of incentives" in masked)
+ok("body line 8 intact", "final tapestry in the body" in masked)
+ok("the [^x]: marker column offsets preserved (still line 5)",
+   masked.split("\n")[4].startswith(" ") and len(masked.split("\n")[4]) == len(REF_DEF))
+
+# ── audit: with masking, only BODY tapestry flags (lines 1 + 8), never footnote lines ──
+res = d.audit_text(TEXT, mask_fn=True)
+tap_lines = sorted({s["line"] for s in res["spans"] if s.get("text", "").lower() == "tapestry"})
+ok("masked: tapestry flagged ONLY on body lines 1 & 8", tap_lines == [1, 8], str(tap_lines))
+ok("masked: no finding on footnote lines 3/5/6",
+   not any(s["line"] in (3, 5, 6) for s in res["spans"]), str([s["line"] for s in res["spans"]]))
+
+# ── --keep-footnotes: footnote occurrences DO surface (proves masking is what suppresses them) ──
+res_keep = d.audit_text(TEXT, mask_fn=False)
+tap_keep = sorted({s["line"] for s in res_keep["spans"] if s.get("text", "").lower() == "tapestry"})
+ok("keep-footnotes: tapestry also flagged on footnote lines 3 & 5",
+   3 in tap_keep and 5 in tap_keep, str(tap_keep))
+ok("masking strictly reduces findings", len(res["spans"]) < len(res_keep["spans"]))
+
+# ── nested-cite footnote: ^[text [@a; @b] more] fully masked (one level of nested [...]) ──
+nested = "Body.^[See *Id.* [@a2019]; cf. [@b2020], at 5 — a tapestry.]\n"
+mn = d.mask_footnotes(nested)
+ok("nested-bracket footnote fully masked", "tapestry" not in mn and "@a2019" not in mn)
+ok("nested-cite body prefix intact", mn.startswith("Body."))
+
+print(f"\n{_p} passed, {_f} failed")
+sys.exit(1 if _f else 0)


### PR DESCRIPTION
de-ai-revise improvement (a) from the tender_offers **corpus-prose** coordination.

## Problem
`de_ai_audit.py` + `style_metrics` scored pandoc inline `^[...]` and markdown `[^id]:` footnotes as **body text**, so the scorers emitted metronomic-run / nominalization / em-dash findings **inside citation text** — which the rewriter then had to exclude by hand. The corpus session hit exactly this on the tender PartII/PartIII drafts. Footnotes/citations are off-limits to a de-AI rewrite ([@bibkey] cites, quoted/statutory text, legal-normal prose).

## Fix
`mask_footnotes()` blanks footnote spans to spaces (**line numbers + offsets preserved**, so line-anchoring stays exact) **before** scoring:
- pandoc inline `^[...]` (one level of nested `[...]` so cite-bearing footnotes mask fully)
- markdown `[^id]:` definition blocks (def line + indented continuations)

Applied to the tics + diction scans **and** `style_metrics` (now run on the masked text via a temp file). **Default ON**; `--keep-footnotes` restores the raw signal. Enforces the SKILL's Preserve-Human rule mechanically instead of relying on the rewriter to recognize footnote-located findings.

## Verification
End-to-end on the real tender PartII: masking suppressed exactly the 2 footnote/citation findings (metronomic-run in a blog-title cite, nominalization in citation text) while keeping all body findings. `tests/test_de_ai_footnote_masking.py` **13/13**; existing `test_de_ai_audit.py` **7/7** (no regression). SKILL Preserve-Human + docstring updated.

Improvement (b) — corpus z-vs-human reporting — remains noted for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)