### PR TITLE
fix(law-review-docx): no spurious author symbol footnotes when there are no bios (v5.67.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.67.3"
+    "version": "5.67.4"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.67.3",
+      "version": "5.67.4",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.67.3",
+  "version": "5.67.4",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/docx-repair/scripts/fix_footnotes.py
+++ b/skills/docx-repair/scripts/fix_footnotes.py
@@ -1087,6 +1087,10 @@ def fix_numbering_offset(settings_xml, fn_xml, doc_xml, bio_count=3):
     """
     changes = []
 
+    # No bios → no numbering offset to correct; never add numRestart on a bio-less paper.
+    if bio_count <= 0:
+        return settings_xml, fn_xml, doc_xml, changes
+
     # Check if already fixed
     if 'numRestart' in settings_xml:
         return settings_xml, fn_xml, doc_xml, changes
@@ -1514,8 +1518,12 @@ def main():
     parser.add_argument("docx", help="Path to the .docx file")
     parser.add_argument("--output", "-o", help="Output path (default: overwrite input)")
     parser.add_argument("--dry-run", action="store_true", help="Show what would change")
-    parser.add_argument("--bio-footnotes", type=int, default=3,
-                        help="Number of author bio footnotes (default: 3)")
+    parser.add_argument("--bio-footnotes", type=int, default=None,
+                        help="Number of author bio footnotes. Default: AUTO-DETECT from the "
+                             "doc's customMarkFollows refs (0 if none) — do NOT assume 3, or a "
+                             "paper with no author bios gets *,†,‡ stamped on its real first three "
+                             "footnotes. Pass an explicit count for a Google-Docs round-trip that "
+                             "stripped the marks (auto-detect would see 0).")
     parser.add_argument("--crossrefs", action="store_true",
                         help="Also run create_crossrefs.py after fixing")
     parser.add_argument("--fix-numbering", action="store_true",
@@ -1554,6 +1562,14 @@ def main():
         # styles.xml is read to verify the FNStyleBest definition survives.
         styles_xml = read_zip_member(zf, 'word/styles.xml')
 
+    # Bio-footnote count: AUTO-DETECT from the customMarkFollows refs the build set, NOT a
+    # hardcoded 3. A paper with no author bios (single author, no acknowledgements) has zero
+    # customMarkFollows refs → bio_count=0 → no symbols forced onto its real footnotes. An
+    # explicit --bio-footnotes overrides (e.g. a Google Docs round-trip that stripped the marks).
+    bio_count = args.bio_footnotes if args.bio_footnotes is not None else (doc_xml or '').count('customMarkFollows="1"')
+    if args.bio_footnotes is None:
+        print(f"Auto-detected {bio_count} author bio footnote(s) from customMarkFollows refs.")
+
     issues = detect_issues(fn_xml, doc_xml, settings_xml, styles_xml)
     if not issues and not args.fix_numbering and not args.normalize_headings:
         print("No footnote damage detected.")
@@ -1571,14 +1587,14 @@ def main():
     if fn_sdt_changes:
         all_changes.append("footnotes.xml: " + fn_sdt_changes[0])
 
-    fn_xml_fixed, fn_changes = fix_footnotes_xml(fn_xml_fixed, args.bio_footnotes)
+    fn_xml_fixed, fn_changes = fix_footnotes_xml(fn_xml_fixed, bio_count)
     all_changes.extend(fn_changes)
 
     fn_xml_fixed, pandoc_changes = fix_pandoc_cite_wraps(fn_xml_fixed)
     all_changes.extend(pandoc_changes)
 
     fn_xml_fixed, bio_body_changes = fix_bio_superscript_in_footnotes(
-        fn_xml_fixed, args.bio_footnotes)
+        fn_xml_fixed, bio_count)
     all_changes.extend(bio_body_changes)
 
     # Feature 1: strip Google Docs leftover content controls FIRST so every
@@ -1587,18 +1603,18 @@ def main():
     if sdt_changes:
         all_changes.append("document.xml: " + sdt_changes[0])
 
-    doc_xml_fixed, doc_changes = fix_document_xml(doc_xml_fixed, args.bio_footnotes)
+    doc_xml_fixed, doc_changes = fix_document_xml(doc_xml_fixed, bio_count)
     all_changes.extend(doc_changes)
 
     doc_xml_fixed, bio_ref_changes = fix_bio_superscript(
-        doc_xml_fixed, args.bio_footnotes)
+        doc_xml_fixed, bio_count)
     all_changes.extend(bio_ref_changes)
 
     # Authoritative bio normalization (lxml, position-based). Runs after the
     # regex bio fixers so it also repairs the Google-Docs bare-reference case
     # they cannot match, and leaves a correct bio untouched (idempotent).
     doc_xml_fixed, fn_xml_fixed, bio_norm_changes = restore_bio_custom_marks(
-        doc_xml_fixed, fn_xml_fixed, args.bio_footnotes)
+        doc_xml_fixed, fn_xml_fixed, bio_count)
     all_changes.extend(bio_norm_changes)
 
     doc_xml_fixed, toc_changes = fix_toc_separator(doc_xml_fixed)
@@ -1639,7 +1655,7 @@ def main():
 
     if args.fix_numbering:
         settings_xml_fixed, fn_xml_fixed, doc_xml_fixed, num_changes = fix_numbering_offset(
-            settings_xml_fixed, fn_xml_fixed, doc_xml_fixed, args.bio_footnotes)
+            settings_xml_fixed, fn_xml_fixed, doc_xml_fixed, bio_count)
         all_changes.extend(num_changes)
 
     # Body-paragraph first-line-indent normalization (editorial, opt-in).

--- a/skills/law-review-docx/scripts/build_docx.py
+++ b/skills/law-review-docx/scripts/build_docx.py
@@ -111,10 +111,6 @@ def get_prefix(path: Path) -> str:
     return stem.lower().replace(" ", "_")[:6]
 
 
-LOREM = ("Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-         "Acknowledgements placeholder — replace via the acknowledgements: field "
-         "in .planning/ACTIVE_WORKFLOW.md.")
-
 
 DEFAULT_CSL = Path.home() / "projects" / "bluebook-law-review-21e.csl"
 
@@ -172,8 +168,10 @@ def parse_metadata(project_dir: Path) -> dict:
     if not meta["short_title"]:
         meta["short_title"] = meta["title"]
 
-    if not meta["acknowledgements"]:
-        meta["acknowledgements"] = LOREM
+    # No LOREM placeholder acknowledgement. A star (*) author footnote is emitted ONLY when the
+    # author actually sets `acknowledgements:` or `author_ack_N:`. Auto-filling a placeholder created
+    # a spurious `*` author footnote on bio-less papers that collided with the real numbered notes
+    # (the reported bug: fn 1 shows `*`). Leave acknowledgements empty when unset → no injection.
 
     if not meta["date"]:
         from datetime import date
@@ -241,6 +239,13 @@ def inject_acknowledgement(docx_path: Path, ack_text: str, author_acks: list = N
     author_text = html.unescape(text_m.group(1))
     footnotes_xml = ''
     filtered_acks = [a for a in (author_acks or []) if a]
+
+    # No per-author acks AND no acknowledgement text → inject NOTHING. Otherwise the legacy
+    # single-star fallback stamps an empty `*` author footnote onto a paper that has no bios,
+    # which then collides with the real numbered footnotes (the bug: fn 1 shows `*`).
+    if not filtered_acks and not (ack_text or '').strip():
+        print('INFO: no author acknowledgements; skipping author bio footnote injection')
+        return
 
     if filtered_acks:
         # Split author_text on each recognized symbol in order of appearance

--- a/tests/test_law_review_footnote_symbols.py
+++ b/tests/test_law_review_footnote_symbols.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env -S uv run python3
+"""Regression: a law-review paper with NO author acknowledgements must NOT get a `*` author
+footnote (and the footnote-repair must NOT assume 3 bios). Root cause of the tender-paper bug:
+build_docx auto-filled a LOREM placeholder acknowledgement → a spurious `*` footnote that
+collided with the real numbered footnotes; fix_footnotes then defaulted to 3 bios and stamped
+*,†,‡ on real footnotes 1-3.
+
+Run: uv run python3 tests/test_law_review_footnote_symbols.py
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "skills" / "law-review-docx" / "scripts"))
+import build_docx as bd  # noqa: E402
+
+_p = _f = 0
+
+
+def ok(name, cond, extra=""):
+    global _p, _f
+    if cond:
+        _p += 1; print(f"  ok  {name}")
+    else:
+        _f += 1; print(f"FAIL  {name} {extra}")
+
+
+def proj(aw_body: str) -> Path:
+    d = Path(tempfile.mkdtemp())
+    (d / ".planning").mkdir()
+    (d / ".planning" / "ACTIVE_WORKFLOW.md").write_text(aw_body)
+    return d
+
+
+# 1. No acknowledgements → acknowledgements stays "" (NO LOREM placeholder → no `*` footnote)
+m = bd.parse_metadata(proj('---\nworkflow: writing\nstyle: legal\ntitle: "T"\nauthor: "Edwin Hu"\n---\n'))
+ok("no-acks: acknowledgements is empty (LOREM placeholder removed)", m["acknowledgements"] == "", repr(m["acknowledgements"]))
+ok("no-acks: no LOREM text leaked in", "Lorem" not in m["acknowledgements"] and "placeholder" not in m["acknowledgements"].lower())
+ok("no-acks: author_acks empty", m["author_acks"] == [])
+
+# 2. Real acknowledgement set → preserved (a legit `*` author footnote WILL be injected)
+m2 = bd.parse_metadata(proj('---\nworkflow: writing\ntitle: "T"\nauthor: "Edwin Hu"\nacknowledgements: "Thanks to colleagues."\n---\n'))
+ok("with-acks: acknowledgement preserved", m2["acknowledgements"] == "Thanks to colleagues.")
+
+# 3. Multi-author author_ack_N → parsed (legit *,† bios)
+m3 = bd.parse_metadata(proj(
+    '---\nworkflow: writing\ntitle: "T"\nauthor: "A* & B†"\n'
+    'author_ack_1: "Prof, X."\nauthor_ack_2: "Prof, Y."\n---\n'))
+ok("multi-author: 2 author_acks parsed", [a for a in m3["author_acks"] if a] == ["Prof, X.", "Prof, Y."], repr(m3["author_acks"]))
+
+# 4. LOREM constant is gone from the module (no placeholder mechanism left)
+ok("LOREM constant removed from build_docx", not hasattr(bd, "LOREM"))
+
+# 5. fix_footnotes no longer hardcodes 3 bios — default is auto-detect (None)
+import importlib.util  # noqa: E402
+fp = ROOT / "skills" / "docx-repair" / "scripts" / "fix_footnotes.py"
+src = fp.read_text()
+ok("fix_footnotes --bio-footnotes default is auto-detect (not 3)",
+   'default=None' in src and 'customMarkFollows="1"' in src and 'auto-detect' in src.lower())
+ok("fix_footnotes guards numbering-offset on zero bios",
+   "if bio_count <= 0:" in src)
+
+print(f"\n{_p} passed, {_f} failed")
+sys.exit(1 if _f else 0)


### PR DESCRIPTION
**Bug (tender paper v4):** the compiled docx stamped symbols (`*`) and consumed numbers on **real** footnotes 1–3, even though the paper has a single author and **no acknowledgements**. Two compounding causes:

1. **`build_docx.py` auto-filled a LOREM placeholder acknowledgement** when none was set → that non-empty placeholder drove the legacy single-star fallback to inject a spurious `*` author footnote on a bio-less paper. **Fix:** removed the LOREM default (+ constant); `inject_acknowledgement` now injects **nothing** when there are no `author_acks` and no acknowledgement text. A `*` footnote is emitted **only** for a real acknowledgement.
2. **`docx-repair/fix_footnotes.py` defaulted `--bio-footnotes` to 3** and force-stamped `*,†,‡` on the first three footnotes regardless of whether they were bios. **Fix:** default is now **auto-detect** from the doc's `customMarkFollows="1"` refs (0 if none) — never assume 3; explicit `--bio-footnotes` overrides (e.g. a Google-Docs round-trip that stripped the marks). `fix_numbering_offset` now no-ops when `bio_count<=0`.

**Convention now enforced end-to-end:** symbols stand alone **only** for real author/bio notes; everything else is plain numbered from 1.

**Verified on the real tender paper** (read-only; built to `/tmp`): 0 `customMarkFollows`, 0 symbol glyphs, footnotes plain-numbered, `"no author acknowledgements; skipping"` logged. The bio path (`author_acks` set) is unchanged. `tests/test_law_review_footnote_symbols.py` **8/8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)