### PR TITLE
feat(writing): scoped check-all gate hook + lxml fix (v5.67.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.67.4"
+    "version": "5.67.5"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.67.4",
+      "version": "5.67.5",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.67.4",
+  "version": "5.67.5",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/writing-mechanical-gate.py
+++ b/hooks/writing-mechanical-gate.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env -S uv run python3
+"""PreToolUse gate: guarantee the deterministic mechanical floor (check-all.py) actually ran and
+PASSED before the writing-review semantic fan-out spends tokens. Prose "run check-all" is a
+suggestion the model can skip; this is the enforcement (the plugin's "Hooks over prompt" doctrine).
+
+TIGHTLY SCOPED on purpose (the "check-all runs all .py" history):
+  - FIRES only on a `Workflow` tool call whose target is the writing-review engine — NOT on every
+    Write/Edit, NOT on other workflows. (Skill-scoped to writing-review in the frontmatter too.)
+  - RUNS check-all from the PROJECT dir, so check-all self-scopes to the WRITING constraints via its
+    APPLIES_TO + detected-workflow filter (non-writing constraints are skipped, not run).
+  - BLOCKS only on HARD failures (check-all exit 1 = `failed`/`errors`); advisory "conventions"
+    (judgment-only) never block.
+
+Result: the Leg-1 mechanical floor is guaranteed clean before the review workflow runs, without
+re-running on every edit and without dragging in other workflows' constraints.
+
+CLI (debug):  uv run python3 writing-mechanical-gate.py /abs/project   # prints the would-be gate result
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CHECK_ALL = Path(__file__).resolve().parent.parent / "references" / "constraints" / "check-all.py"
+
+
+def _run_check_all(project: str):
+    """Return (ok, failed_names, error_names, summary). ok=True iff no hard content FAILURES.
+
+    Blocks on `failed` (real writing-content violations) only. `errors` (a constraint script that
+    threw — e.g. a missing dependency) are surfaced but do NOT block: a broken/under-provisioned
+    constraint must not wall off the author's review. check-all is run with `--with lxml` so the
+    lxml-dependent constraints actually run instead of erroring."""
+    try:
+        out = subprocess.run(
+            ["uv", "run", "--with", "lxml", "python3", str(CHECK_ALL), project],
+            capture_output=True, text=True, timeout=180)
+    except Exception as e:
+        # Never hard-block the workflow on a harness error running the gate.
+        return True, [], [], f"(check-all could not run: {e})"
+    failed, errors = [], []
+    try:
+        raw = out.stdout
+        data = json.loads(raw[:raw.rfind("}") + 1])  # strip the trailing human summary line
+        failed = [f.get("name", "?") if isinstance(f, dict) else str(f) for f in data.get("failed", [])]
+        errors = [e.get("name", "?") if isinstance(e, dict) else str(e) for e in data.get("errors", [])]
+    except Exception:
+        # Parse failed → fall back to the process exit code, but never invent failures.
+        if out.returncode != 0:
+            failed = [(out.stdout.strip().splitlines() or ["check-all reported failures"])[-1]]
+    summary = (out.stdout.strip().splitlines() or ["(no output)"])[-1]
+    return (len(failed) == 0), failed, errors, summary
+
+
+def deny(reason: str):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+    sys.exit(0)
+
+
+def _project_from_args(tool_input: dict) -> str:
+    args = tool_input.get("args")
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except Exception:
+            args = {}
+    if isinstance(args, dict) and args.get("projectDir"):
+        return str(args["projectDir"])
+    return "."
+
+
+def main():
+    # CLI debug mode
+    if len(sys.argv) > 1 and sys.argv[1] not in ("-",):
+        ok, failed, errors, summary = _run_check_all(sys.argv[1])
+        print(f"ok={ok} | {summary}")
+        if failed:
+            print("FAILED (blocking):\n- " + "\n- ".join(failed))
+        if errors:
+            print("errors (non-blocking — tooling):\n- " + "\n- ".join(errors))
+        sys.exit(0 if ok else 1)
+
+    try:
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    if hook_input.get("tool_name", "") != "Workflow":
+        sys.exit(0)
+    tool_input = hook_input.get("tool_input", {}) or {}
+    # SCOPE: only the writing-draft / writing-review engines, nothing else.
+    target = f"{tool_input.get('scriptPath', '')} {tool_input.get('name', '')}"
+    is_review = "writing-review" in target
+    is_draft = "writing-draft" in target
+    if not (is_review or is_draft):
+        sys.exit(0)
+
+    # Soft check (both engines): the deterministic section-index should be COMPILED and passed.
+    # Warn (don't deny) when it's absent — the engine's LLM-Discover fallback still works, but the
+    # deterministic compile is the intended path. (Hard-denying would defeat the documented fallback.)
+    args = tool_input.get("args")
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except Exception:
+            args = {}
+    si = (args or {}).get("sectionIndex") if isinstance(args, dict) else None
+    section_warn = "" if si else (
+        " NOTE: args.sectionIndex was not passed — the engine will fall back to the LLM Discover. "
+        "For the deterministic path, compile it first: "
+        "`uv run python3 scripts/writing/writing_section_index.py <project>` and pass it as args.sectionIndex.")
+
+    # The check-all mechanical gate is the REVIEW floor only (drafting fixes those issues; gating the
+    # draft on them would deadlock). For writing-draft we only do the soft section-index nudge.
+    if is_draft:
+        if section_warn:
+            print(json.dumps({"hookSpecificOutput": {
+                "hookEventName": "PreToolUse", "permissionDecision": "allow",
+                "permissionDecisionReason": section_warn.strip()}}))
+        sys.exit(0)
+
+    project = _project_from_args(tool_input)
+    ok, failed, errors, summary = _run_check_all(project)
+    if not ok:
+        note = ("\n\n(Plus " + str(len(errors)) + " constraint(s) errored — tooling, NOT blocking.)"
+                if errors else "")
+        deny(
+            "GATE BLOCKED: the deterministic mechanical floor (check-all.py — bold-lead, "
+            "topic-sentences, anchored-numbers, AI-smell, outline-sync, etc.) has hard failures, so "
+            "the semantic review fan-out must not run yet. Fix these first, then re-invoke:\n- "
+            + "\n- ".join(failed or [summary]) + note + section_warn
+            + "\n\n(Only writing constraints were checked; advisory 'conventions' do not block. "
+              "Run `uv run --with lxml python3 references/constraints/check-all.py .` for details.)")
+    if section_warn:
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse", "permissionDecision": "allow",
+            "permissionDecisionReason": "Mechanical floor clean." + section_warn}}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/references/constraints/check-all.py
+++ b/references/constraints/check-all.py
@@ -1,5 +1,10 @@
-#!/usr/bin/env -S uv run python3
+#!/usr/bin/env -S uv run --with lxml python3
 """check-all.py — auto-discovers and runs all constraint checks.
+
+NOTE: invoked with `--with lxml` because several constraint scripts (ai-anti-patterns
+wikipedia-*, writing-general strunk, writing-legal volokh) import lxml. Without it they raise
+"lxml is required" and land in `errors` — i.e. those prose checks silently DON'T run. Callers that
+invoke this as `uv run python3 check-all.py` must also pass `--with lxml`.
 
 Discovers from two directories:
   - references/constraints/*.py       — plugin-wide constraints

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -24,7 +24,7 @@ for check in "$CHECKS_DIR"/check-*.py; do
     TOTAL=$((TOTAL + 1))
     check_name=$(basename "$check" .py | sed 's/^check-//')
 
-    if output=$(uv run python3 "$check" 2>&1); then
+    if output=$(uv run --with lxml python3 "$check" 2>&1); then
         echo "  ✓ $check_name"
         PASS=$((PASS + 1))
     else

--- a/skills/writing-draft/SKILL.md
+++ b/skills/writing-draft/SKILL.md
@@ -19,6 +19,10 @@ hooks:
       hooks:
         - type: command
           command: "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/writing-outline-guard.py"
+    - matcher: "Workflow"
+      hooks:
+        - type: command
+          command: "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/writing-mechanical-gate.py"
   PostToolUse:
     - matcher: "Edit|Write"
       hooks:

--- a/skills/writing-review/SKILL.md
+++ b/skills/writing-review/SKILL.md
@@ -16,6 +16,10 @@ hooks:
             GATE_DESCRIPTION="Claim validation"
             GATE_REMEDY="Run writing-validate first to validate claim coverage before review"
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
+    - matcher: "Workflow"
+      hooks:
+        - type: command
+          command: "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/writing-mechanical-gate.py"
 ---
 
 # Writing Review

--- a/tests/test_writing_mechanical_gate.py
+++ b/tests/test_writing_mechanical_gate.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S uv run python3
+"""Regression: the writing-review/draft mechanical-gate hook must stay TIGHTLY SCOPED.
+
+The whole point of this hook (per the "check-all runs all .py" history + the user's "limit the
+scope" directive) is that it fires ONLY on the writing-draft/writing-review Workflow engines and
+no-ops on everything else. These tests lock the routing/scoping WITHOUT running check-all (which
+needs a real project + lxml); the check-all integration is exercised by the CLI debug mode.
+
+Run: uv run python3 tests/test_writing_mechanical_gate.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "writing-mechanical-gate.py"
+
+_p = _f = 0
+
+
+def ok(name, cond, extra=""):
+    global _p, _f
+    if cond:
+        _p += 1; print(f"  ok  {name}")
+    else:
+        _f += 1; print(f"FAIL  {name} {extra}")
+
+
+def run(payload: dict):
+    """Return (exit_code, parsed_stdout_or_None)."""
+    r = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(payload),
+                       capture_output=True, text=True, timeout=60)
+    out = None
+    if r.stdout.strip():
+        try:
+            out = json.loads(r.stdout)
+        except Exception:
+            out = {"_raw": r.stdout}
+    return r.returncode, out
+
+
+def decision(out):
+    return (out or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+# 1. Non-Workflow tool → no-op (silent allow, exit 0, no output)
+code, out = run({"tool_name": "Write", "tool_input": {"file_path": "x"}})
+ok("non-Workflow tool is a no-op", code == 0 and out is None, f"code={code} out={out}")
+
+# 2. Unrelated Workflow (ds/dev/etc.) → no-op — does NOT drag in other workflows
+code, out = run({"tool_name": "Workflow", "tool_input": {"name": "ds-run"}})
+ok("unrelated Workflow is a no-op (scope)", code == 0 and out is None, f"code={code} out={out}")
+
+# 3. writing-draft WITHOUT sectionIndex → ALLOW + soft section-index warn (never check-all, never deny)
+code, out = run({"tool_name": "Workflow",
+                 "tool_input": {"scriptPath": "writing-draft.js", "args": {"projectDir": "/nonexistent"}}})
+ok("writing-draft no-index → allow", decision(out) == "allow", f"out={out}")
+ok("writing-draft no-index warns about sectionIndex",
+   "sectionIndex" in (out or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", ""))
+
+# 4. writing-draft WITH sectionIndex → silent allow (no nag)
+code, out = run({"tool_name": "Workflow",
+                 "tool_input": {"scriptPath": "writing-draft.js",
+                                "args": {"projectDir": "/nonexistent", "sectionIndex": {"sections": [1]}}}})
+ok("writing-draft with-index → silent allow", code == 0 and out is None, f"out={out}")
+
+# 5. writing-draft NEVER denies (drafting fixes the issues the floor checks; gating it would deadlock)
+ok("writing-draft never denies", decision(out) != "deny")
+
+# 6. The hook resolves check-all and invokes it WITH lxml (so prose constraints actually run)
+src = HOOK.read_text()
+ok("hook invokes check-all with --with lxml",
+   '"--with", "lxml"' in src and "check-all.py" in src.replace('"references"', "") or
+   ('"--with", "lxml"' in src and "CHECK_ALL" in src))
+
+# 7. ERRORS are non-blocking; only `failed` blocks (limit-scope: a broken dep must not wall off review)
+ok("hook blocks on failed only (errors non-blocking)",
+   "len(failed) == 0" in src and "NOT blocking" in src)
+
+print(f"\n{_p} passed, {_f} failed")
+sys.exit(1 if _f else 0)


### PR DESCRIPTION
## What

Two enforcement gaps in the writing pipeline — both answering "how do we *guarantee* the scripts run?"

### 1. Scoped mechanical-gate hook (`hooks/writing-mechanical-gate.py`)
Prose "run check-all" is skippable. This makes it a `PreToolUse` gate, **tightly scoped** per the limit-scope directive:
- fires **only** on the `writing-review` / `writing-draft` Workflow engines (skill-scoped frontmatter + target match) — never on other Write/Edit/Agent calls, never on other workflows
- runs check-all from the project dir → self-scopes to **writing** constraints
- `writing-review`: **denies** the semantic fan-out when the deterministic floor has hard content failures (lists them). `writing-draft`: soft section-index nudge only (gating it would deadlock — drafting *fixes* those issues)
- blocks on `failed` (content) only; `errors` (tooling/missing dep) surfaced but never block
- soft section-index warn **preserves** the documented LLM-Discover fallback

### 2. check-all actually runs its lxml constraints
check-all was invoked without `lxml` everywhere, so 8 prose constraints (`ai-anti-patterns` wikipedia-*, `strunk`, `volokh`) silently **errored — never ran**. Added `--with lxml` to the check-all.py shebang + `scripts/check-all.sh`. On the tender paper: errors **8 → 0**, and the now-running checks surface 12 real content failures.

## Tests
- `tests/test_writing_mechanical_gate.py` — routing/scope locks (8/8)
- footnote regression unchanged (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)