### PR TITLE
feat(workflows): close systemic P20 check-all gap in dev + ds, fix workshop portability (v5.68.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.67.6"
+    "version": "5.68.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.67.6",
+      "version": "5.68.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.67.6",
+  "version": "5.68.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/mechanical-floor-gate.py
+++ b/hooks/mechanical-floor-gate.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env -S uv run python3
+"""PreToolUse gate: guarantee the deterministic static-analysis floor (check-all) actually RAN and
+PASSED before a phase spends tokens on its expensive fan-out. Prose "run check-all" is a suggestion
+the model can skip; this is the enforcement (the plugin's "Hooks over prompt" doctrine). This is the
+dev/ds sibling of hooks/writing-mechanical-gate.py — the same gap (the Leg-1 mechanical floor sat in
+skippable prose while the phase hook gated on a *different* artifact) the wc-audit P20 sub-probe
+flagged across writing, dev, and ds.
+
+Parameterized by the FLOOR env var (set in the skill frontmatter hook command):
+
+  FLOOR=dev  → gate the Agent spawn (the goal-backward verifier in dev-verify, Leg 2).
+               Runs references/constraints/check-all.py, which self-scopes to the dev constraints via
+               its APPLIES_TO + detected-workflow filter. Denies on HARD failures only.
+               Fixes are ordinary main-chat edits, so denying Agent does not deadlock.
+
+  FLOOR=ds   → gate the Workflow spawn (the ds-validate-coverage per-requirement fan-out).
+               Runs scripts/check-all-ds.sh; denies on non-zero exit.
+               Gates the WORKFLOW only — NOT Agent — on purpose: ds forbids main-chat analysis-code
+               edits (ds-no-main-chat-code-guard), so a failing floor is fixed by a FIX SUBAGENT
+               (an Agent). Denying Agent here would wall off the only legal way to fix it. The
+               coverage Workflow is the expensive fan-out worth protecting; fix subagents stay free.
+
+TIGHTLY SCOPED on purpose (the "check-all runs all .py" history): this hook is wired only into
+dev-verify (FLOOR=dev) and ds-validate (FLOOR=ds) frontmatter, and each branch gates exactly one
+tool. It never fires on Write/Edit and never drags in another workflow's constraints (check-all
+self-scopes by detected workflow / the ds-*.py glob).
+
+In all cases a constraint that ERRORED (threw — e.g. a missing dependency) is surfaced but does NOT
+block: a broken/under-provisioned constraint must not wall off the phase. Only real content
+FAILURES block. A harness error running the gate itself never blocks either (fail-open).
+
+CLI (debug):  FLOOR=dev uv run python3 mechanical-floor-gate.py /abs/project
+              FLOOR=ds  uv run python3 mechanical-floor-gate.py /abs/project
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent
+REPO = HOOKS_DIR.parent
+CHECK_ALL_PY = REPO / "references" / "constraints" / "check-all.py"
+CHECK_ALL_DS = REPO / "scripts" / "check-all-ds.sh"
+
+
+def _run_dev(project: str):
+    """check-all.py (dev). Return (ok, failed, errors, summary). ok iff no hard content FAILURES.
+
+    Run with `--with lxml` so the lxml-dependent constraints actually run instead of landing in
+    `errors` (the same invocation fix shipped in v5.67.5)."""
+    try:
+        out = subprocess.run(
+            ["uv", "run", "--with", "lxml", "python3", str(CHECK_ALL_PY), project],
+            capture_output=True, text=True, timeout=180)
+    except Exception as e:
+        return True, [], [], f"(check-all.py could not run: {e})"
+    failed, errors = [], []
+    try:
+        raw = out.stdout
+        data = json.loads(raw[:raw.rfind("}") + 1])  # strip the trailing human summary line
+        failed = [f.get("name", "?") if isinstance(f, dict) else str(f) for f in data.get("failed", [])]
+        errors = [e.get("name", "?") if isinstance(e, dict) else str(e) for e in data.get("errors", [])]
+    except Exception:
+        if out.returncode != 0:
+            failed = [(out.stdout.strip().splitlines() or ["check-all reported failures"])[-1]]
+    summary = (out.stdout.strip().splitlines() or ["(no output)"])[-1]
+    return (len(failed) == 0), failed, errors, summary
+
+
+def _run_ds(project: str):
+    """check-all-ds.sh (ds). Return (ok, failed, errors, summary). ok iff exit 0.
+
+    The bash runner prints `✗ <name>` per failing constraint and exits non-zero iff any failed."""
+    try:
+        out = subprocess.run(
+            ["bash", str(CHECK_ALL_DS), project],
+            capture_output=True, text=True, timeout=180)
+    except Exception as e:
+        return True, [], [], f"(check-all-ds.sh could not run: {e})"
+    failed = [ln.split("✗", 1)[1].strip() for ln in out.stdout.splitlines() if "✗" in ln]
+    summary = (out.stdout.strip().splitlines() or ["(no output)"])[-1]
+    ok = out.returncode == 0
+    if not ok and not failed:
+        failed = [summary]
+    return ok, failed, [], summary
+
+
+def deny(reason: str):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+    sys.exit(0)
+
+
+def _project_from_args(tool_input: dict) -> str:
+    args = tool_input.get("args")
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except Exception:
+            args = {}
+    if isinstance(args, dict) and args.get("projectDir"):
+        return str(args["projectDir"])
+    return "."
+
+
+def main():
+    floor = os.environ.get("FLOOR", "").strip().lower()
+
+    # CLI debug mode
+    if len(sys.argv) > 1 and sys.argv[1] not in ("-",):
+        runner = _run_ds if floor == "ds" else _run_dev
+        ok, failed, errors, summary = runner(sys.argv[1])
+        print(f"FLOOR={floor or 'dev'} ok={ok} | {summary}")
+        if failed:
+            print("FAILED (blocking):\n- " + "\n- ".join(failed))
+        if errors:
+            print("errors (non-blocking — tooling):\n- " + "\n- ".join(errors))
+        sys.exit(0 if ok else 1)
+
+    try:
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    tool_name = hook_input.get("tool_name", "")
+    tool_input = hook_input.get("tool_input", {}) or {}
+
+    if floor == "ds":
+        # Gate the ds-validate-coverage Workflow fan-out ONLY (never Agent — fix subagents must run).
+        if tool_name != "Workflow":
+            sys.exit(0)
+        project = _project_from_args(tool_input)
+        ok, failed, errors, summary = _run_ds(project)
+        if not ok:
+            deny(
+                "GATE BLOCKED: the DS static-analysis floor (check-all-ds.sh — determinism, join "
+                "audits, idempotency, error handling, schema contracts, standard errors, viz "
+                "integrity) has failures, so the per-requirement validation fan-out must not run "
+                "yet. These are code-quality defects in the analysis scripts. Dispatch a FIX "
+                "SUBAGENT (an Agent — not blocked) to fix them, then re-invoke:\n- "
+                + "\n- ".join(failed or [summary])
+                + "\n\n(Run `bash scripts/check-all-ds.sh .` for details.)")
+        sys.exit(0)
+
+    # FLOOR=dev (default): gate the goal-backward verifier Agent spawn.
+    if tool_name != "Agent":
+        sys.exit(0)
+    project = _project_from_args(tool_input)
+    ok, failed, errors, summary = _run_dev(project)
+    if not ok:
+        note = ("\n\n(Plus " + str(len(errors)) + " constraint(s) errored — tooling, NOT blocking.)"
+                if errors else "")
+        deny(
+            "GATE BLOCKED: the constraint floor (check-all.py — Leg 1) has hard failures, so the "
+            "goal-backward verifier must not run yet. Constraint failures are hard blocks — fix "
+            "these first, then re-spawn the verifier:\n- "
+            + "\n- ".join(failed or [summary]) + note
+            + "\n\n(Run `uv run --with lxml python3 references/constraints/check-all.py .` for details.)")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/dev-verify/SKILL.md
+++ b/skills/dev-verify/SKILL.md
@@ -19,6 +19,8 @@ hooks:
             GATE_DESCRIPTION="Code review approved"
             GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify."
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
+        - type: command
+          command: "FLOOR=dev uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/mechanical-floor-gate.py"
 ---
 
 Announce: "Using dev-verify (Phase 7) to confirm completion with fresh evidence."
@@ -230,7 +232,7 @@ Before spawning the goal-backward verifier, run the auto-discovering constraint 
 uv run python3 ${CLAUDE_SKILL_DIR}/../../references/constraints/check-all.py .
 ```
 
-**If any constraint FAILS:** Address the failure before proceeding. Constraint failures are hard blocks — do not proceed to goal-backward verification with failing constraints.
+**If any constraint FAILS:** Address the failure before proceeding. Constraint failures are hard blocks — do not proceed to goal-backward verification with failing constraints. This is **hook-enforced**, not just prose: `mechanical-floor-gate.py` (FLOOR=dev, wired on the Agent matcher) re-runs check-all and DENIES the verifier spawn until the floor is clean.
 
 **If all constraints PASS:** Proceed to goal-backward verification below.
 

--- a/skills/ds-validate/SKILL.md
+++ b/skills/ds-validate/SKILL.md
@@ -48,6 +48,10 @@ hooks:
             GATE_REMEDY="Finish ds-implement (all PLAN.md tasks verified in LEARNINGS.md) before validating outputs."
             GATE_BLOCKED_TOOLS=Agent,Workflow
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
+    - matcher: "Workflow"
+      hooks:
+        - type: command
+          command: "FLOOR=ds uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/mechanical-floor-gate.py"
 ---
 
 Announce: "Using ds-validate (Phase 3.5) to validate analysis outputs against SPEC.md requirements."
@@ -98,7 +102,7 @@ bash "${CLAUDE_SKILL_DIR}/../../scripts/check-all-ds.sh" "$(pwd)"
 
 This runs all DS constraint check scripts (determinism, join audits, idempotency, error handling, schema contracts, standard errors, visualization integrity).
 
-**If any check FAILS:** Report the failures in LEARNINGS.md. These are code quality issues in the analysis scripts that must be fixed before proceeding. Dispatch a fix subagent if needed.
+**If any check FAILS:** Report the failures in LEARNINGS.md. These are code quality issues in the analysis scripts that must be fixed before proceeding. Dispatch a fix subagent if needed. This is **hook-enforced**, not just prose: `mechanical-floor-gate.py` (FLOOR=ds, wired on the Workflow matcher) re-runs `check-all-ds.sh` and DENIES the `ds-validate-coverage` fan-out until the floor is clean. It gates the Workflow only — Agent (the fix subagent) stays free so you can actually fix the failures.
 
 **If all checks PASS:** Proceed to runtime DQ checks.
 

--- a/skills/ds-verify/SKILL.md
+++ b/skills/ds-verify/SKILL.md
@@ -125,6 +125,8 @@ This runs all DS constraint check scripts (determinism, join audits, idempotency
 
 **If any check FAILS:** Report the failures in LEARNINGS.md. These are code quality issues in the analysis scripts that must be fixed before proceeding. Dispatch a fix subagent if needed.
 
+> This re-run is defense-in-depth. The same `check-all-ds.sh` floor is **hook-enforced** one phase upstream at ds-validate (`mechanical-floor-gate.py`, FLOOR=ds). ds-verify deliberately carries no hook for it: its only fan-out is a single fresh-Agent reproducibility check, and gating Agent here would deadlock against `ds-no-main-chat-code-guard` (a failing floor could not be fixed — fixes require an Agent).
+
 **If all checks PASS:** Proceed to runtime DQ checks.
 
 ## The Verification Gate

--- a/skills/workshop-revise/SKILL.md
+++ b/skills/workshop-revise/SKILL.md
@@ -208,7 +208,7 @@ For content or structural changes (NOT simple formatting fixes), the edited deck
 
 1. **Compile** so `slides.pdf` reflects the edits: `cd [presentation directory] && typst compile slides.typ && typst compile notes.typ`
 2. **Invoke selectively** (review only the changed slides; carry the rest forward). Pass `slideIndex` =
-   the parsed `.planning/slide-index.json` (recompile via `scripts/workshop/workshop_slide_table.py "<project>" --json`
+   the parsed `.planning/slide-index.json` (recompile via `uv run python3 ${CLAUDE_SKILL_DIR}/../../scripts/workshop/workshop_slide_table.py "<project>" --json`
    if the OUTLINE changed) — the deterministic OUTLINE side-table; the workflow still enumerates the built
    `slides.typ` and joins inventory semantically (DESIGN §3a-join). Omit to fall back to the LLM Discover.
    ```

--- a/tests/test_mechanical_floor_gate.py
+++ b/tests/test_mechanical_floor_gate.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env -S uv run python3
+"""Regression: the dev/ds mechanical-floor gate must stay TIGHTLY SCOPED and route by FLOOR.
+
+These lock the routing/scoping WITHOUT running check-all (which needs a real project + lxml):
+  - FLOOR=dev gates the Agent spawn ONLY (the goal-backward verifier). Workflow/Write are no-ops.
+  - FLOOR=ds  gates the Workflow spawn ONLY (the ds-validate-coverage fan-out). Agent is a NO-OP —
+    this is the deadlock-avoidance invariant: ds forbids main-chat code edits, so a failing floor is
+    fixed by a FIX SUBAGENT (an Agent); the gate must never block Agent. (Tested directly below.)
+
+Run: uv run python3 tests/test_mechanical_floor_gate.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "mechanical-floor-gate.py"
+
+_p = _f = 0
+
+
+def ok(name, cond, extra=""):
+    global _p, _f
+    if cond:
+        _p += 1; print(f"  ok  {name}")
+    else:
+        _f += 1; print(f"FAIL  {name} {extra}")
+
+
+def run(payload: dict, floor: str):
+    """Return (exit_code, parsed_stdout_or_None)."""
+    env = dict(os.environ, FLOOR=floor)
+    r = subprocess.run([sys.executable, str(HOOK)], input=json.dumps(payload),
+                       capture_output=True, text=True, timeout=60, env=env)
+    out = None
+    if r.stdout.strip():
+        try:
+            out = json.loads(r.stdout)
+        except Exception:
+            out = {"_raw": r.stdout}
+    return r.returncode, out
+
+
+def decision(out):
+    return (out or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+# ── FLOOR=dev: gates Agent only ──────────────────────────────────────────────
+# 1. dev + Workflow → no-op (dev does NOT gate Workflow; that's ds's job)
+code, out = run({"tool_name": "Workflow", "tool_input": {"name": "anything"}}, "dev")
+ok("dev + Workflow is a no-op", code == 0 and out is None, f"code={code} out={out}")
+
+# 2. dev + Write → no-op (never fires on edits)
+code, out = run({"tool_name": "Write", "tool_input": {"file_path": "x"}}, "dev")
+ok("dev + Write is a no-op", code == 0 and out is None, f"code={code} out={out}")
+
+# ── FLOOR=ds: gates Workflow only — Agent MUST stay free (fix-subagent deadlock-avoidance) ────
+# 3. ds + Agent → no-op  (THE invariant: a failing floor is fixed by a fix SUBAGENT)
+code, out = run({"tool_name": "Agent", "tool_input": {"subagent_type": "ds-engineer"}}, "ds")
+ok("ds + Agent is a no-op (fix-subagent must run)", code == 0 and out is None, f"code={code} out={out}")
+
+# 4. ds + Write → no-op
+code, out = run({"tool_name": "Write", "tool_input": {"file_path": "x"}}, "ds")
+ok("ds + Write is a no-op", code == 0 and out is None, f"code={code} out={out}")
+
+# 5. Malformed stdin → fail-open (never wall off the phase on a harness error)
+r = subprocess.run([sys.executable, str(HOOK)], input="not json",
+                   capture_output=True, text=True, timeout=60, env=dict(os.environ, FLOOR="ds"))
+ok("malformed stdin fails open", r.returncode == 0 and not r.stdout.strip(), f"code={r.returncode}")
+
+# ── Source invariants (the check-all integration runs live; locked here by construction) ──────
+src = HOOK.read_text()
+ok("dev branch runs check-all.py with --with lxml",
+   '"--with", "lxml"' in src and "CHECK_ALL_PY" in src)
+ok("ds branch runs check-all-ds.sh", "CHECK_ALL_DS" in src and "check-all-ds.sh" in src)
+ok("ds gates Workflow only (never Agent)",
+   'floor == "ds"' in src and 'tool_name != "Workflow"' in src)
+ok("dev gates Agent only", 'tool_name != "Agent"' in src)
+ok("ds deny names the fix-subagent path (no deadlock)", "FIX SUBAGENT" in src)
+ok("errors are non-blocking (only failed blocks)", "len(failed) == 0" in src and "NOT blocking" in src)
+
+print(f"\n{_p} passed, {_f} failed")
+sys.exit(1 if _f else 0)


### PR DESCRIPTION
## Summary

Acts on the audit batch (dev / ds / workshop). The wc-audit **P20 mechanical sub-probe** (shipped v5.67.6) flagged the **same class of gap across writing, dev, and ds**: the Leg-1 deterministic mechanical floor (`check-all`) sat in skippable prose while the phase hook gated on a *different* artifact. Writing was fixed in v5.67.5; this closes **dev** and **ds**.

## Changes

**New — `hooks/mechanical-floor-gate.py`** (dev/ds sibling of `writing-mechanical-gate.py`, parameterized by `FLOOR`):
- `FLOOR=dev` → gates the goal-backward verifier **Agent** spawn in dev-verify; re-runs `check-all.py` (`--with lxml`) and denies until clean. Fixes are main-chat edits → no deadlock.
- `FLOOR=ds` → gates the `ds-validate-coverage` **Workflow** fan-out in ds-validate; re-runs `check-all-ds.sh` and denies until clean. Gates the **Workflow only — never Agent**, because ds forbids main-chat analysis-code edits, so a failing floor is fixed by a *fix subagent* (an Agent); denying Agent would deadlock. ds-verify left un-hooked (same suite enforced upstream; documented inline).

**Fix — workshop portability** (`workshop-revise:211`): a *runnable* recompile instruction used a bare relative `scripts/workshop/...` path → switched to the portable `${CLAUDE_SKILL_DIR}/../../scripts/...` form. Clears workshop's only real defect (its failed substrate gate; composite was already 9.71).

**Tests** — `tests/test_mechanical_floor_gate.py`: 11 routing/scope assertions incl. the **ds-never-gates-Agent** deadlock-avoidance invariant. Live CLI smoke confirms both branches parse check-all output end-to-end (`0 errors` ⇒ lxml invocation correct).

## Audit results that drove this

| Workflow | Verdict | Composite | Substrate |
|----------|---------|-----------|-----------|
| dev | PASS | 9.58 | clean (P20→8 gap fixed here) |
| ds | PASS | 9.52 | clean (P20→8 gap fixed here) |
| workshop | NEEDS WORK → fixed | 9.71 | portability Partial → now clean |

## Not changed (audit false positive)

dev **P17** (`agents/security-reviewer.md` declares `Write, Edit`) — that agent is a standalone *"detection and remediation"* subagent, **not** the dev-review read-only lens (which uses `references/security-reviewer.md`). Its write tools are intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)