### PR TITLE
fix: 8 code-review findings — front-matter guard, gate cwd fallback, dedup (v5.68.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.68.0"
+    "version": "5.68.1"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.68.0",
+      "version": "5.68.1",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.68.0",
+  "version": "5.68.1",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/_gate_common.py
+++ b/hooks/_gate_common.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S uv run python3
+"""Shared helpers for the PreToolUse mechanical-floor/mechanical-gate hooks
+(hooks/mechanical-floor-gate.py FLOOR=dev/ds, hooks/writing-mechanical-gate.py).
+
+`deny` and `_project_from_args` were duplicated byte-for-byte across both
+hooks; this module is the single source of truth for them. Each hook still
+runs standalone as a script (`uv run python3 <path>`, invoked from whatever
+cwd the harness happens to be in) — see the sys.path-insert import pattern in
+either hook file for how to import this module reliably regardless of cwd.
+"""
+import json
+import sys
+from typing import Optional
+
+
+def deny(reason: str):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+    sys.exit(0)
+
+
+def _project_from_args(tool_input: dict, hook_input: Optional[dict] = None) -> str:
+    """Resolve the project directory the gate should audit.
+
+    `args.projectDir` is only ever populated on `Workflow` tool calls — `Agent`
+    tool calls (e.g. the dev-verify goal-backward verifier, FLOOR=dev) NEVER
+    carry it. Without a fallback, FLOOR=dev always audited "." — the hook
+    process's own cwd, not the project actually being worked on — silently
+    no-oping the gate. Falls back to the hook payload's top-level `cwd` (which
+    Claude Code always sets for PreToolUse hooks), then "." as a last resort.
+    """
+    args = tool_input.get("args")
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except Exception:
+            args = {}
+    if isinstance(args, dict) and args.get("projectDir"):
+        return str(args["projectDir"])
+    if hook_input and hook_input.get("cwd"):
+        return str(hook_input["cwd"])
+    return "."

--- a/hooks/mechanical-floor-gate.py
+++ b/hooks/mechanical-floor-gate.py
@@ -43,6 +43,12 @@ REPO = HOOKS_DIR.parent
 CHECK_ALL_PY = REPO / "references" / "constraints" / "check-all.py"
 CHECK_ALL_DS = REPO / "scripts" / "check-all-ds.sh"
 
+# Hooks run standalone (`uv run python3 <path>`) from an unknown cwd, so
+# sys.path-insert this file's own directory before importing the sibling
+# shared module rather than assuming a package/relative import will resolve.
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import deny, _project_from_args  # noqa: E402
+
 
 def _run_dev(project: str):
     """check-all.py (dev). Return (ok, failed, errors, summary). ok iff no hard content FAILURES.
@@ -86,27 +92,6 @@ def _run_ds(project: str):
     return ok, failed, [], summary
 
 
-def deny(reason: str):
-    print(json.dumps({"hookSpecificOutput": {
-        "hookEventName": "PreToolUse",
-        "permissionDecision": "deny",
-        "permissionDecisionReason": reason,
-    }}))
-    sys.exit(0)
-
-
-def _project_from_args(tool_input: dict) -> str:
-    args = tool_input.get("args")
-    if isinstance(args, str):
-        try:
-            args = json.loads(args)
-        except Exception:
-            args = {}
-    if isinstance(args, dict) and args.get("projectDir"):
-        return str(args["projectDir"])
-    return "."
-
-
 def main():
     floor = os.environ.get("FLOOR", "").strip().lower()
 
@@ -132,7 +117,7 @@ def main():
         # Gate the ds-validate-coverage Workflow fan-out ONLY (never Agent — fix subagents must run).
         if tool_name != "Workflow":
             sys.exit(0)
-        project = _project_from_args(tool_input)
+        project = _project_from_args(tool_input, hook_input)
         ok, failed, errors, summary = _run_ds(project)
         if not ok:
             deny(
@@ -148,7 +133,7 @@ def main():
     # FLOOR=dev (default): gate the goal-backward verifier Agent spawn.
     if tool_name != "Agent":
         sys.exit(0)
-    project = _project_from_args(tool_input)
+    project = _project_from_args(tool_input, hook_input)
     ok, failed, errors, summary = _run_dev(project)
     if not ok:
         note = ("\n\n(Plus " + str(len(errors)) + " constraint(s) errored — tooling, NOT blocking.)"

--- a/hooks/writing-mechanical-gate.py
+++ b/hooks/writing-mechanical-gate.py
@@ -21,7 +21,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-CHECK_ALL = Path(__file__).resolve().parent.parent / "references" / "constraints" / "check-all.py"
+HOOKS_DIR = Path(__file__).resolve().parent
+CHECK_ALL = HOOKS_DIR.parent / "references" / "constraints" / "check-all.py"
+
+# Hooks run standalone (`uv run python3 <path>`) from an unknown cwd, so
+# sys.path-insert this file's own directory before importing the sibling
+# shared module rather than assuming a package/relative import will resolve.
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import deny, _project_from_args  # noqa: E402
 
 
 def _run_check_all(project: str):
@@ -50,27 +57,6 @@ def _run_check_all(project: str):
             failed = [(out.stdout.strip().splitlines() or ["check-all reported failures"])[-1]]
     summary = (out.stdout.strip().splitlines() or ["(no output)"])[-1]
     return (len(failed) == 0), failed, errors, summary
-
-
-def deny(reason: str):
-    print(json.dumps({"hookSpecificOutput": {
-        "hookEventName": "PreToolUse",
-        "permissionDecision": "deny",
-        "permissionDecisionReason": reason,
-    }}))
-    sys.exit(0)
-
-
-def _project_from_args(tool_input: dict) -> str:
-    args = tool_input.get("args")
-    if isinstance(args, str):
-        try:
-            args = json.loads(args)
-        except Exception:
-            args = {}
-    if isinstance(args, dict) and args.get("projectDir"):
-        return str(args["projectDir"])
-    return "."
 
 
 def main():
@@ -122,7 +108,7 @@ def main():
                 "permissionDecisionReason": section_warn.strip()}}))
         sys.exit(0)
 
-    project = _project_from_args(tool_input)
+    project = _project_from_args(tool_input, hook_input)
     ok, failed, errors, summary = _run_check_all(project)
     if not ok:
         note = ("\n\n(Plus " + str(len(errors)) + " constraint(s) errored — tooling, NOT blocking.)"

--- a/skills/docx-repair/SKILL.md
+++ b/skills/docx-repair/SKILL.md
@@ -361,7 +361,12 @@ things, both under this flag:
   child of the first run; a tab elsewhere is a real tab, left alone) and sets
   `firstLine=<dominant>`. Detected as `leading_tab_indent(N)` in `detect_issues`
   even without the flag; fixed only when `--normalize-body-indent` is passed.
-  Idempotent. Same >60-char Normal/unstyled guard.
+  Idempotent. Same >60-char Normal/unstyled guard, AND the same front-matter
+  guard (only paragraphs after the first Heading1) — title/abstract/TOC are
+  never touched. If tab-led paragraphs exist but the document has no real
+  firstLine indent anywhere to infer the dominant value from, this does not
+  silently no-op: it emits a WARNING change entry so the unfixed issue still
+  surfaces in the log.
 
 Logged, never silent.
 

--- a/skills/docx-repair/scripts/fix_footnotes.py
+++ b/skills/docx-repair/scripts/fix_footnotes.py
@@ -1355,6 +1355,28 @@ def ensure_footnote_styles(styles_xml, template_path, needed=(FN_PSTYLE,)):
 _BODY_STYLE = "BodyText"
 
 
+def _iter_unstyled_body_paras(root):
+    """Yield (p, pPr, ind) for every Normal/unstyled body paragraph (AFTER the
+    first Heading1 — front matter keeps its own formatting) that carries a
+    *direct* first-line indent with no left/hanging indent. Shared structural
+    predicate for both the detect-count and the fix passes — text-emptiness
+    (empty vs non-empty) is left to the caller since count/apply treat it
+    differently."""
+    seen_h1 = False
+    for p in root.iter(_wq("p")):
+        st = _para_style(p)
+        if st == "Heading1":
+            seen_h1 = True
+            continue
+        if not seen_h1 or st not in (None, "Normal"):
+            continue  # front matter (abstract/TOC) keeps its own formatting
+        pPr = p.find(_wq("pPr"))
+        ind = pPr.find(_wq("ind")) if pPr is not None else None
+        if (ind is not None and ind.get(_wq("firstLine"))
+                and not ind.get(_wq("left")) and not ind.get(_wq("hanging"))):
+            yield p, pPr, ind
+
+
 def _count_unstyled_body_indents(doc_xml):
     """Count Normal/unstyled body paragraphs that carry a *direct* first-line
     indent — the template's BodyText style should supply it instead. Signals a
@@ -1365,19 +1387,8 @@ def _count_unstyled_body_indents(doc_xml):
     except Exception:
         return 0
     n = 0
-    seen_h1 = False
-    for p in root.iter(_wq("p")):
-        st = _para_style(p)
-        if st == "Heading1":
-            seen_h1 = True
-            continue
-        if not seen_h1 or st not in (None, "Normal"):
-            continue  # front matter (abstract/TOC) keeps its own formatting
-        if not "".join(t.text or "" for t in p.iter(_wq("t"))).strip():
-            continue
-        ind = p.find(f"{_wq('pPr')}/{_wq('ind')}")
-        if (ind is not None and ind.get(_wq("firstLine"))
-                and not ind.get(_wq("left")) and not ind.get(_wq("hanging"))):
+    for p, _pPr, _ind in _iter_unstyled_body_paras(root):
+        if "".join(t.text or "" for t in p.iter(_wq("t"))).strip():
             n += 1
     return n
 
@@ -1434,21 +1445,7 @@ def apply_template_body_styles(doc_xml, styles_xml, template_path):
     # spills it to a second page).
     root = etree.fromstring(doc_xml.encode("utf-8"))
     restyled = emptied = 0
-    seen_h1 = False
-    for p in root.iter(_wq("p")):
-        st = _para_style(p)
-        if st == "Heading1":
-            seen_h1 = True
-            continue
-        if not seen_h1:
-            continue
-        if st not in (None, "Normal"):
-            continue
-        pPr = p.find(_wq("pPr"))
-        ind = pPr.find(_wq("ind")) if pPr is not None else None
-        if (ind is None or not ind.get(_wq("firstLine"))
-                or ind.get(_wq("left")) or ind.get(_wq("hanging"))):
-            continue  # not a standard direct first-line indent (skip quotes etc.)
+    for p, pPr, ind in _iter_unstyled_body_paras(root):
         if "".join(t.text or "" for t in p.iter(_wq("t"))).strip():
             ps = pPr.find(_wq("pStyle"))
             if ps is None:
@@ -1627,17 +1624,9 @@ def normalize_body_indent(doc_xml):
     """
     root = etree.fromstring(doc_xml.encode("utf-8"))
     paras = list(root.iter(_wq("p")))
-    from collections import Counter
-    firstlines = Counter()
-    for p in paras:
-        if _para_style(p) not in (None, "Normal"):
-            continue
-        ind = p.find(f"{_wq('pPr')}/{_wq('ind')}")
-        if ind is not None and ind.get(_wq("firstLine")):
-            firstlines[ind.get(_wq("firstLine"))] += 1
-    if not firstlines:
+    dominant = _dominant_firstline(paras)
+    if dominant is None:
         return doc_xml, []
-    dominant = firstlines.most_common(1)[0][0]
 
     seen_h1 = False
     applied = 0
@@ -1660,15 +1649,7 @@ def normalize_body_indent(doc_xml):
         if pPr is None:
             pPr = etree.Element(_wq("pPr"))
             p.insert(0, pPr)
-        if ind is None:
-            ind = etree.Element(_wq("ind"))
-            ref = pPr.find(_wq("rPr"))
-            if ref is None:
-                ref = pPr.find(_wq("sectPr"))
-            if ref is not None:
-                ref.addprevious(ind)
-            else:
-                pPr.append(ind)
+        ind = _ensure_ind(pPr)
         ind.set(_wq("firstLine"), dominant)
         applied += 1
     if not applied:
@@ -1678,6 +1659,40 @@ def normalize_body_indent(doc_xml):
     ).decode("utf-8")
     return out, [f"Normalized body first-line indent (firstLine={dominant}) "
                  f"on {applied} paragraph(s)"]
+
+
+def _dominant_firstline(paras):
+    """Mode of ``<w:ind firstLine>`` over Normal/unstyled paragraphs, or None
+    if no paragraph carries a real firstLine indent to infer from. Shared by
+    :func:`normalize_body_indent` and :func:`fix_leading_tab_indents`."""
+    from collections import Counter
+    firstlines = Counter()
+    for p in paras:
+        if _para_style(p) not in (None, "Normal"):
+            continue
+        ind = p.find(f"{_wq('pPr')}/{_wq('ind')}")
+        if ind is not None and ind.get(_wq("firstLine")):
+            firstlines[ind.get(_wq("firstLine"))] += 1
+    return firstlines.most_common(1)[0][0] if firstlines else None
+
+
+def _ensure_ind(pPr):
+    """Return ``pPr``'s ``<w:ind>`` child, creating one at the correct
+    schema-ordered insertion point if absent. Word silently drops pPr children
+    that appear out of CT_PPr schema order, so a freshly created ``<w:ind>``
+    must land before ``rPr``/``sectPr`` (whichever comes first), else appended
+    at the end."""
+    ind = pPr.find(_wq("ind"))
+    if ind is None:
+        ind = etree.Element(_wq("ind"))
+        ref = pPr.find(_wq("rPr"))
+        if ref is None:
+            ref = pPr.find(_wq("sectPr"))
+        if ref is not None:
+            ref.addprevious(ind)
+        else:
+            pPr.append(ind)
+    return ind
 
 
 _RUN_CONTENT_TAGS = ("tab", "t", "br", "drawing", "footnoteReference")
@@ -1702,22 +1717,33 @@ def _para_leads_with_tab(p):
     return first_run, None
 
 
+def _iter_leading_tab_paras(root):
+    """Yield body paragraphs whose first-line indent is a leading tab (GDocs).
+
+    Same front-matter guard as :func:`_iter_unstyled_body_paras`: only
+    paragraphs AFTER the first Heading1 (title/abstract/TOC excluded), only
+    Normal/unstyled paragraphs, only text longer than 60 chars."""
+    seen_h1 = False
+    for p in root.iter(_wq("p")):
+        st = _para_style(p)
+        if st == "Heading1":
+            seen_h1 = True
+            continue
+        if not seen_h1 or st not in (None, "Normal"):
+            continue  # front matter (abstract/TOC) keeps its own formatting
+        if len("".join(t.text or "" for t in p.iter(_wq("t"))).strip()) <= 60:
+            continue
+        if _para_leads_with_tab(p)[1] is not None:
+            yield p
+
+
 def _count_leading_tab_indents(doc_xml):
     """Count body paragraphs whose first-line indent is a leading tab (GDocs)."""
     try:
         root = etree.fromstring(doc_xml.encode("utf-8"))
     except Exception:
         return 0
-    n = 0
-    for p in root.iter(_wq("p")):
-        if _para_style(p) not in (None, "Normal"):
-            continue
-        if len("".join(t.text or "" for t in p.iter(_wq("t"))).strip()) <= 60:
-            continue
-        _, tab = _para_leads_with_tab(p)
-        if tab is not None:
-            n += 1
-    return n
+    return sum(1 for _ in _iter_leading_tab_paras(root))
 
 
 def fix_leading_tab_indents(doc_xml):
@@ -1733,30 +1759,27 @@ def fix_leading_tab_indents(doc_xml):
 
     Editorial (it changes the visual indent of the affected paragraphs to the
     dominant value), so it runs under ``--normalize-body-indent`` alongside
-    :func:`normalize_body_indent`. Same guards: Normal/unstyled paragraphs only,
-    text longer than 60 chars.
+    :func:`normalize_body_indent`. Same guards: front matter (before the first
+    Heading1) is untouched, Normal/unstyled paragraphs only, text longer than
+    60 chars.
+
+    If tab-led paragraphs exist but no paragraph in the document carries a
+    real firstLine indent to infer the dominant value from, this does NOT
+    silently no-op — it returns a WARNING change entry so the caller/log
+    surfaces the unfixed issue (matches ``detect_issues``' report).
     """
     root = etree.fromstring(doc_xml.encode("utf-8"))
     paras = list(root.iter(_wq("p")))
-    from collections import Counter
-    firstlines = Counter()
-    for p in paras:
-        if _para_style(p) not in (None, "Normal"):
-            continue
-        ind = p.find(f"{_wq('pPr')}/{_wq('ind')}")
-        if ind is not None and ind.get(_wq("firstLine")):
-            firstlines[ind.get(_wq("firstLine"))] += 1
-    if not firstlines:
+    targets = list(_iter_leading_tab_paras(root))
+    if not targets:
         return doc_xml, []
-    dominant = firstlines.most_common(1)[0][0]
+    dominant = _dominant_firstline(paras)
+    if dominant is None:
+        return doc_xml, [
+            f"WARNING: {len(targets)} leading-tab paragraph(s) detected but no "
+            f"real firstLine indent exists to infer the dominant value — not fixed"]
 
     content_tags = {_wq(t) for t in _RUN_CONTENT_TAGS}
-    # Collect target paragraphs first (don't mutate mid-scan).
-    targets = [p for p in paras
-               if _para_style(p) in (None, "Normal")
-               and len("".join(t.text or "" for t in p.iter(_wq("t"))).strip()) > 60
-               and _para_leads_with_tab(p)[1] is not None]
-
     fixed = 0
     for p in targets:
         # Strip EVERY leading tab — Google Docs can stack a tab-only run before a
@@ -1774,16 +1797,7 @@ def fix_leading_tab_indents(doc_xml):
         if pPr is None:
             pPr = etree.Element(_wq("pPr"))
             p.insert(0, pPr)
-        ind = pPr.find(_wq("ind"))
-        if ind is None:
-            ind = etree.Element(_wq("ind"))
-            ref = pPr.find(_wq("rPr"))
-            if ref is None:
-                ref = pPr.find(_wq("sectPr"))
-            if ref is not None:
-                ref.addprevious(ind)
-            else:
-                pPr.append(ind)
+        ind = _ensure_ind(pPr)
         # a leading tab is mutually exclusive with firstLine/hanging
         for a in ("firstLine", "hanging"):
             if ind.get(_wq(a)) is not None:

--- a/skills/law-review-docx/scripts/build_docx.py
+++ b/skills/law-review-docx/scripts/build_docx.py
@@ -569,6 +569,14 @@ def convert_to_pdf(docx_path: Path) -> Optional[Path]:
             # strict — it raises instead of falling back — which is right for the
             # CLI but wrong here, where the build just needs *a* PDF.)
             return _convert(docx_path, out, renderer="auto", allow_word=True)
+        # Word unavailable (not macOS, or Word not installed) — falls back to
+        # the non-Word auto path (x2t/LibreOffice). This contradicts the
+        # docx-render Iron Law ("--renderer word for deliverables": Word is the
+        # only faithful-layout renderer), so make the fallback loud instead of
+        # silent — the caller must know to re-render before submission.
+        print("WARNING: Word unavailable — PDF rendered via x2t/LibreOffice, "
+              "layout may reflow; re-render with --renderer word before submission",
+              file=sys.stderr)
         return _convert(docx_path, out)
     except Exception as e:
         print(f"WARN: PDF conversion failed: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Fixes 8 verified code-review findings (3 correctness, 5 cleanup) surfaced against `skills/docx-repair/scripts/fix_footnotes.py`, `hooks/mechanical-floor-gate.py` / `hooks/writing-mechanical-gate.py`, and `skills/law-review-docx/scripts/build_docx.py`.

1. **CONFIRMED bug** — `_count_leading_tab_indents`/`fix_leading_tab_indents` were missing the `seen_h1` front-matter guard their siblings (`normalize_body_indent`, `_count_unstyled_body_indents`, `apply_template_body_styles`) all enforce. Added the guard to both (via a shared `_iter_leading_tab_paras` generator — see #6). Updated `skills/docx-repair/SKILL.md` (~line 364) to document the front-matter guard applies here too.
2. **CONFIRMED bug** — `_project_from_args` only read `args.projectDir`, which `Agent` tool calls never carry, so `FLOOR=dev` always audited `"."` (the hook process's own cwd) instead of the real project. Fixed by falling back to `hook_input["cwd"]` (threaded through from `main()`) before defaulting to `"."`. Applied identically to the `ds` branch and to `writing-mechanical-gate.py`'s call site, via the shared helper in #4.
3. **CONFIRMED edge bug** — `fix_leading_tab_indents` silently returned `[]` when tab-led paragraphs existed but no paragraph anywhere had a real `firstLine` indent to infer the dominant value from — contradicting `detect_issues` (which still reports `leading_tab_indent(N)`) and the SKILL.md "Logged, never silent" claim. Now returns a `WARNING: N leading-tab paragraph(s) detected but no real firstLine indent exists to infer the dominant value — not fixed` change entry instead.
4. **Reuse** — Extracted `hooks/_gate_common.py` (`deny`, `_project_from_args`) shared by both `mechanical-floor-gate.py` and `writing-mechanical-gate.py`, which duplicated them byte-for-byte. Each hook still runs standalone via `uv run python3 <path>` — imports the sibling module with a `sys.path.insert(0, str(HOOKS_DIR))` since hooks run from an unknown cwd. `_run_dev`/`_run_ds`/`_run_check_all` (dev/ds/writing-specific check-all invocations) were left in their respective hook files — the existing regression tests (`tests/test_mechanical_floor_gate.py`, `tests/test_writing_mechanical_gate.py`) assert on literal source-text of each hook's own file (e.g. `'"--with", "lxml"' in src`), so extracting those would have broken the tests without adding real dedup value (they already differ per-branch: `CHECK_ALL_PY` vs `CHECK_ALL_DS` vs `CHECK_ALL`).
5. **Reuse** — Extracted `_dominant_firstline(paras)` (the dominant-firstLine `Counter` loop) and `_ensure_ind(pPr)` (the schema-ordered `<w:ind>` create-and-insert block), previously duplicated between `normalize_body_indent` and `fix_leading_tab_indents`. Both functions now call the shared helpers; insertion-point behavior (before `rPr`/`sectPr`, else appended) is preserved exactly.
6. **Simplification** — Extracted `_iter_unstyled_body_paras(root)` and `_iter_leading_tab_paras(root)` generators, each shared by its count function and its fix function (mirroring `_iter_bio_ref_runs`). The front-matter guard fix from #1 lives in these shared iterators, so both the detector and the fixer get it for free.
7. **Efficiency (--restyle-body 3x round-trip)** — **Skipped.** Given findings 5/6 already land a refactor in this file, layering the round-trip-collapse on top risked destabilizing three interacting passes for a perf win that wasn't asked to be prioritized. Left as future work.
8. **Consistency** — `build_docx.py`'s `convert_to_pdf` now prints a loud `WARNING: Word unavailable — PDF rendered via x2t/LibreOffice, layout may reflow; re-render with --renderer word before submission` to stderr when it takes the non-Word fallback path, instead of silently contradicting the docx-render Iron Law ("--renderer word for deliverables"). `doc_render.py` itself was not touched.

## Test plan

- [x] `uv run python3 tests/test_mechanical_floor_gate.py` — 11/11 passed
- [x] `uv run python3 tests/test_writing_mechanical_gate.py` — 8/8 passed
- [x] `python3 -m py_compile` on every edited `.py` file (fix_footnotes.py, both hooks, `_gate_common.py`, build_docx.py)
- [x] `FLOOR=dev uv run python3 hooks/mechanical-floor-gate.py .` and `uv run python3 hooks/writing-mechanical-gate.py .` — both run cleanly (no crash) in CLI debug mode
- [x] Synthetic-XML smoke tests against `fix_footnotes.py` (no fixture docx exists in-repo): front-matter guard preserves a leading-tab paragraph before Heading1 while fixing one after it; the "no real firstLine anywhere" case returns the WARNING and leaves the doc byte-identical; `fix_leading_tab_indents` is idempotent (second run produces no changes); `_count_unstyled_body_indents`/`apply_template_body_styles` count/apply parity holds after the shared-iterator refactor

## Version

Bumped 5.68.0 → 5.68.1 in all 3 locations (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` `metadata.version` + `plugins[0].version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3NEAUUosUHyci4iFZBH2J