### PR TITLE
fix: 8 code-review findings — continuous-section detection, docx-repair bio auto-detect, footnote-masking gaps (v5.68.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.68.0"
+    "version": "5.68.2"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.68.0",
+      "version": "5.68.2",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.68.0",
+  "version": "5.68.2",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/writing-prose-check.py
+++ b/hooks/writing-prose-check.py
@@ -28,14 +28,23 @@ Non-blocking: reports violations as an additionalContext message.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 PLUGIN_ROOT = Path(__file__).parent.parent
 CHECK_ALL = PLUGIN_ROOT / "references" / "constraints" / "check-all.py"
 PROSE_LINT = PLUGIN_ROOT / "scripts" / "prose-lint.py"
+# Shared footnote/citation masker (scripts/lib/footnote_mask.py) — footnotes are off-limits to
+# prose linting the same way they're off-limits to the de-AI rewrite (skills/de-ai-revise); mask
+# BEFORE handing the draft to style_metrics.py --lint so a style finding never lands inside a
+# footnote span. Masking blanks to spaces and preserves line count/length, so reported line
+# numbers stay valid without any extra offset bookkeeping.
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "lib"))
+from footnote_mask import mask_footnotes  # noqa: E402
 # Corpus-derived stylometric linter (line-level span findings only — em-dash,
 # metronomic-run, opener-transition, nominalization). Its draft-level advisories
 # (burstiness, diction) belong in the review stage, NOT this on-edit hook.
@@ -149,17 +158,34 @@ def _run_prose_lint(path: Path, style: str | None,
 
 
 def _run_style_lint(path: Path, ranges: list[tuple[int, int]]) -> list[str]:
-    """Run style_metrics --lint; return ONLY line-level span findings scoped to
-    edited lines. Advisories (global rhythm/diction tells) are intentionally
-    dropped here — they're review-stage signals, not inline fixes."""
+    """Run style_metrics --lint on a FOOTNOTE-MASKED copy of the draft; return ONLY
+    line-level span findings scoped to edited lines. Advisories (global rhythm/diction
+    tells) are intentionally dropped here — they're review-stage signals, not inline
+    fixes. Masking (blank-to-spaces, line/offset-preserving) keeps line numbers valid
+    while stopping em-dash/metronomic/nominalization findings from landing inside a
+    footnote's citation prose."""
+    tmp = None
     try:
+        raw = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+    try:
+        fd, tmp = tempfile.mkstemp(suffix=path.suffix or ".md")
+        with os.fdopen(fd, "w", encoding="utf-8") as tf:
+            tf.write(mask_footnotes(raw))
         proc = subprocess.run(
-            [sys.executable, str(STYLE_LINT), "--lint", "--json", str(path)],
+            [sys.executable, str(STYLE_LINT), "--lint", "--json", tmp],
             capture_output=True, text=True, timeout=30,
         )
         data = json.loads(proc.stdout or "{}")
     except Exception:
         return []
+    finally:
+        if tmp:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
     out: list[str] = []
     for f in data.get("findings", []):
         ln = f.get("line")

--- a/references/constraints/dev-common-constraints.md
+++ b/references/constraints/dev-common-constraints.md
@@ -93,7 +93,7 @@ Structural enforcement (Layer 2). Two PreToolUse guards are declared in skill fr
 Run all constraint checks:
 
 ```bash
-uv run python3 references/constraints/check-all.py .
+uv run --with lxml python3 references/constraints/check-all.py .
 ```
 
 Coverage: 6/6 dev constraints have `.py` check scripts = 100%.

--- a/references/constraints/writing-ai-smell-em-dash.py
+++ b/references/constraints/writing-ai-smell-em-dash.py
@@ -5,6 +5,14 @@ import re
 import sys
 from pathlib import Path
 
+# Shared footnote/citation masker — this constraint already skips `[^id]:` DEFINITION
+# lines (_FOOTNOTE_DEF below), but an INLINE `^[...]` footnote embedded mid-line (a quoted
+# case or statute passage) was never masked, so a genuine em-dash inside quoted source text
+# could trip the density/colon-combo checks as if the author wrote it. Mask before scanning;
+# stdlib-only, no new dependency.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+from footnote_mask import mask_footnotes  # noqa: E402
+
 CONSTRAINT = "writing-ai-smell-em-dash"
 APPLIES_TO = ["writing-draft", "writing-review", "writing-revise"]
 SEVERITY = "soft"
@@ -139,7 +147,7 @@ def check(context):
         return violations
 
     for md_file in sorted(drafts_dir.glob("*.md")):
-        text = md_file.read_text(encoding="utf-8", errors="ignore")
+        text = mask_footnotes(md_file.read_text(encoding="utf-8", errors="ignore"))
 
         # (1) Per-paragraph checks (existing behavior)
         for start_line, para in _prose_paragraphs(text):

--- a/references/constraints/writing-ai-smell-puffery.py
+++ b/references/constraints/writing-ai-smell-puffery.py
@@ -5,6 +5,14 @@ import re
 import sys
 from pathlib import Path
 
+# Shared footnote/citation masker — this constraint already skips `[^id]:` DEFINITION
+# lines (_FOOTNOTE_DEF below), but an INLINE `^[...]` footnote embedded mid-line (a quoted
+# case, e.g. a court calling something "unprecedented") was never masked, so quoted source
+# language could trip the puffery/superlative checks as if the author wrote it. Mask before
+# scanning; stdlib-only, no new dependency.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+from footnote_mask import mask_footnotes  # noqa: E402
+
 CONSTRAINT = "writing-ai-smell-puffery"
 APPLIES_TO = ["writing-draft", "writing-review", "writing-revise"]
 SEVERITY = "soft"
@@ -129,7 +137,7 @@ def check(context):
         return violations
 
     for md_file in sorted(drafts_dir.glob("*.md")):
-        text = md_file.read_text(encoding="utf-8", errors="ignore")
+        text = mask_footnotes(md_file.read_text(encoding="utf-8", errors="ignore"))
         for lineno, line in _prose_lines(text):
             # General puffery patterns
             for pat, label in _PATTERNS:

--- a/scripts/lib/footnote_mask.py
+++ b/scripts/lib/footnote_mask.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S uv run python3
+"""footnote_mask — shared footnote/citation masker for prose scorers.
+
+Footnotes/citations are OFF-LIMITS to a de-AI rewrite and to prose-quality linting: they
+carry `[@bibkey]` cites, quoted and statutory text, and legal-normal prose that would
+otherwise trip tic/diction/style findings meant for BODY prose only. Masking blanks
+footnote spans to spaces — PRESERVING line count and every line's length — so line-anchored
+findings never land inside a footnote and reported line numbers stay valid without any
+caller needing to track an offset map.
+
+Extracted (finding 5/7, code-review pass) from skills/de-ai-revise/scripts/de_ai_audit.py,
+which was the only caller, so that hooks/writing-prose-check.py (which invokes
+style_metrics.py --lint directly on an on-disk draft) can mask BEFORE linting too, instead
+of scoring footnote text as if it were body prose.
+
+Covers:
+  - pandoc inline `^[...]` footnotes (one level of nested `[...]` for citations)
+  - markdown reference-style `[^id]: ...` definitions, including MULTI-PARAGRAPH
+    continuations (a blank line does not end the block if the next non-blank line is
+    still indented — pandoc's syntax for a footnote spanning more than one paragraph)
+"""
+from __future__ import annotations
+
+import re
+
+_INLINE_FN = re.compile(r"\^\[(?:[^\[\]]|\[[^\]]*\])*\]")
+_REF_FN_DEF = re.compile(r"^\s*\[\^[^\]]+\]:")
+
+
+def _blank(s: str) -> str:
+    """Replace every non-newline char with a space (keeps length + line breaks)."""
+    return re.sub(r"[^\n]", " ", s)
+
+
+def mask_footnotes(text: str) -> str:
+    # 1. inline ^[...] footnotes (may span lines; _blank preserves the newlines)
+    text = _INLINE_FN.sub(lambda m: _blank(m.group(0)), text)
+    # 2. reference [^id]: definition blocks — the def line + indented continuation lines,
+    # INCLUDING multi-paragraph continuations. Pandoc footnotes may have a blank line between
+    # paragraphs of the SAME footnote, with the next paragraph still 4-space/tab indented — a
+    # blank line does NOT end the block unless the next non-blank line is un-indented (a new
+    # footnote def, or body text). Look past a run of blank lines to decide.
+    lines = text.split("\n")
+    n = len(lines)
+    out, in_def, i = [], False, 0
+    while i < n:
+        ln = lines[i]
+        if _REF_FN_DEF.match(ln):
+            in_def = True
+            out.append(_blank(ln)); i += 1; continue
+        if in_def:
+            if ln.strip() == "":
+                j = i
+                while j < n and lines[j].strip() == "":
+                    j += 1
+                if j < n and re.match(r"^(\s{2,}|\t)", lines[j]):
+                    out.append(_blank(ln)); i += 1; continue   # continuation paragraph ahead — stay masked
+                in_def = False
+                out.append(ln); i += 1; continue              # no continuation follows — block ends here
+            if re.match(r"^(\s{2,}|\t)", ln):  # indented continuation stays masked
+                out.append(_blank(ln)); i += 1; continue
+            in_def = False                # non-indented line ends the block
+        out.append(ln); i += 1
+    return "\n".join(out)

--- a/skills/de-ai-revise/scripts/de_ai_audit.py
+++ b/skills/de-ai-revise/scripts/de_ai_audit.py
@@ -136,33 +136,14 @@ def _paragraphs(text: str):
 # em-dashes — which the rewriter must then exclude by hand. Masking them here (blanking to spaces,
 # PRESERVING line count + offsets so line-anchoring stays exact) means findings never target a
 # footnote in the first place. Covers pandoc inline `^[...]` (one level of nested `[...]` for cites)
-# and markdown reference definitions `[^id]: ...` + their indented continuation lines.
-_INLINE_FN = re.compile(r"\^\[(?:[^\[\]]|\[[^\]]*\])*\]")
-_REF_FN_DEF = re.compile(r"^\s*\[\^[^\]]+\]:")
-
-
-def _blank(s: str) -> str:
-    """Replace every non-newline char with a space (keeps length + line breaks)."""
-    return re.sub(r"[^\n]", " ", s)
-
-
-def mask_footnotes(text: str) -> str:
-    # 1. inline ^[...] footnotes (may span lines; _blank preserves the newlines)
-    text = _INLINE_FN.sub(lambda m: _blank(m.group(0)), text)
-    # 2. reference [^id]: definition blocks — the def line + indented continuation lines
-    out, in_def = [], False
-    for ln in text.split("\n"):
-        if _REF_FN_DEF.match(ln):
-            in_def = True
-            out.append(_blank(ln)); continue
-        if in_def:
-            if ln.strip() == "":          # blank line ends the definition block
-                in_def = False; out.append(ln); continue
-            if re.match(r"^(\s{2,}|\t)", ln):  # indented continuation stays masked
-                out.append(_blank(ln)); continue
-            in_def = False                # non-indented line ends the block
-        out.append(ln)
-    return "\n".join(out)
+# and markdown reference definitions `[^id]: ...` + their indented (incl. multi-paragraph)
+# continuation lines.
+#
+# Lives in scripts/lib/footnote_mask.py — shared with hooks/writing-prose-check.py, which masks a
+# draft the same way before invoking style_metrics.py --lint. Re-exported here (mask_footnotes,
+# _blank, the two regexes) so existing importers of this module keep working unchanged.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "lib"))
+from footnote_mask import mask_footnotes, _blank, _INLINE_FN, _REF_FN_DEF  # noqa: E402
 
 
 def audit_text(text: str, path: str = "<text>",

--- a/skills/dev-verify/SKILL.md
+++ b/skills/dev-verify/SKILL.md
@@ -229,7 +229,7 @@ npm run build && echo "Exit code: $?"
 Before spawning the goal-backward verifier, run the auto-discovering constraint runner:
 
 ```bash
-uv run python3 ${CLAUDE_SKILL_DIR}/../../references/constraints/check-all.py .
+uv run --with lxml python3 ${CLAUDE_SKILL_DIR}/../../references/constraints/check-all.py .
 ```
 
 **If any constraint FAILS:** Address the failure before proceeding. Constraint failures are hard blocks — do not proceed to goal-backward verification with failing constraints. This is **hook-enforced**, not just prose: `mechanical-floor-gate.py` (FLOOR=dev, wired on the Agent matcher) re-runs check-all and DENIES the verifier spawn until the floor is clean.

--- a/skills/docx-repair/SKILL.md
+++ b/skills/docx-repair/SKILL.md
@@ -180,7 +180,7 @@ Detects and repairs OOXML footnote damage. Handles multiple sources. Idempotent.
 **Flags:**
 - `--output` / `-o`: Output path (default: overwrite input)
 - `--dry-run`: Show what would change without modifying
-- `--bio-footnotes N`: Number of author bio footnotes (default: 3)
+- `--bio-footnotes N`: Number of author bio footnotes. Default: **auto-detected** from the document's `customMarkFollows="1"`/`"0"` refs (0 if the paper has no bios); pass N only to override the auto-detect (e.g. a doc where the marks were stripped entirely).
 - `--crossrefs`: Chain to create_crossrefs.py after fixing
 - `--fix-numbering`: Fix numbering offset from customMarkFollows bio footnotes (adds numRestart, updates NOTEREFs and supra references)
 - `--normalize-headings`: Normalize headings (off by default) — style unstyled heading-looking paragraphs (2b) AND strip direct formatting + delete empty heading paragraphs (2a); restores Heading1–4 style defs from the template if missing. See §C.

--- a/skills/docx-repair/scripts/fix_footnotes.py
+++ b/skills/docx-repair/scripts/fix_footnotes.py
@@ -1862,11 +1862,24 @@ def main():
 
     # Bio-footnote count: AUTO-DETECT from the customMarkFollows refs the build set, NOT a
     # hardcoded 3. A paper with no author bios (single author, no acknowledgements) has zero
-    # customMarkFollows refs → bio_count=0 → no symbols forced onto its real footnotes. An
-    # explicit --bio-footnotes overrides (e.g. a Google Docs round-trip that stripped the marks).
-    bio_count = args.bio_footnotes if args.bio_footnotes is not None else (doc_xml or '').count('customMarkFollows="1"')
+    # customMarkFollows refs → bio_count=0 → no symbols forced onto its real footnotes.
+    # IMPORTANT: the documented Google Docs damage (footnotes-reference.md) ALWAYS flips
+    # customMarkFollows="1" → customMarkFollows="0" on round-trip, so counting only "1" misses
+    # every damaged paper's bio refs and silently skips bio restoration. Count BOTH variants —
+    # a bio-less paper has neither, so this preserves the no-spurious-bios behavior; a damaged
+    # paper (all "0") now detects correctly. An explicit --bio-footnotes overrides either way.
+    if args.bio_footnotes is not None:
+        bio_count = args.bio_footnotes
+    else:
+        cmf_1 = (doc_xml or '').count('customMarkFollows="1"')
+        cmf_0 = (doc_xml or '').count('customMarkFollows="0"')
+        bio_count = cmf_1 + cmf_0
     if args.bio_footnotes is None:
-        print(f"Auto-detected {bio_count} author bio footnote(s) from customMarkFollows refs.")
+        variant = 'customMarkFollows="1"' if cmf_1 and not cmf_0 else (
+            'customMarkFollows="0" (damaged — marks flipped by a Google Docs round-trip)' if cmf_0 and not cmf_1 else
+            f'customMarkFollows="1" ({cmf_1}) + customMarkFollows="0" ({cmf_0})' if cmf_1 and cmf_0 else
+            'customMarkFollows="1"/"0" (none found)')
+        print(f"Auto-detected {bio_count} author bio footnote(s) from {variant} refs.")
 
     issues = detect_issues(fn_xml, doc_xml, settings_xml, styles_xml)
     if not issues and not args.fix_numbering and not args.normalize_headings:

--- a/skills/workflow-creator/SKILL.md
+++ b/skills/workflow-creator/SKILL.md
@@ -974,7 +974,7 @@ sys.exit(1 if results["failed"] else 0)
 ```
 Verification Phase
     ↓
-Leg 1: uv run python3 check-all.py (auto-discovers constraints/*.py)
+Leg 1: uv run --with lxml python3 check-all.py (auto-discovers constraints/*.py)
     ↓
     Structured results: {passed: [...], failed: [...], conventions: [...]}
     ↓                              ↓

--- a/skills/workshop-revise/SKILL.md
+++ b/skills/workshop-revise/SKILL.md
@@ -265,7 +265,7 @@ Never silently abandon the loop. An off-topic message is not permission to stop 
 
    **Leg 1 — Constraint checks (hard block):**
    ```bash
-   cd [presentation directory] && uv run python3 ${CLAUDE_SKILL_DIR}/../../references/constraints/check-all.py .
+   cd [presentation directory] && uv run --with lxml python3 ${CLAUDE_SKILL_DIR}/../../references/constraints/check-all.py .
    ```
    - If any constraint fails → fix the violation → re-run (max 3 attempts)
    - Hard block: ALL constraints must pass

--- a/skills/writing-outline/SKILL.md
+++ b/skills/writing-outline/SKILL.md
@@ -365,8 +365,6 @@ Before finalizing each outline, verify:
 
 - [ ] Every top-level bullet is one paragraph's topic sentence (a full claim, not a label/topic), with evidence/ideas as sub-bullets; the top-level bullets read in document order form the argument on their own
 - [ ] Evidence is specific (quotes, data), not vague ("sources say")
-- [ ] Logic connecting evidence to point is explicit
-- [ ] Transitions between subsections are planned
 - [ ] Section contributes to thesis (not tangential)
 - [ ] Anticipated objections are noted where relevant
 - [ ] Length estimate is realistic

--- a/skills/writing-review/SKILL.md
+++ b/skills/writing-review/SKILL.md
@@ -155,7 +155,7 @@ Skill(skill="workflows:ai-anti-patterns")
 Before any review work, run all mechanical constraint checks:
 
 ```bash
-uv run python3 ${CLAUDE_SKILL_DIR}/../../references/constraints/check-all.py [project-root]
+uv run --with lxml python3 ${CLAUDE_SKILL_DIR}/../../references/constraints/check-all.py [project-root]
 ```
 
 This auto-discovers and runs all `writing-*.py` constraint scripts (bold-lead, topic sentences, source-anchored citations, etc.). If any check fails, report violations and fix them before proceeding to Level 1.

--- a/tests/test_de_ai_footnote_masking.py
+++ b/tests/test_de_ai_footnote_masking.py
@@ -61,5 +61,26 @@ mn = d.mask_footnotes(nested)
 ok("nested-bracket footnote fully masked", "tapestry" not in mn and "@a2019" not in mn)
 ok("nested-cite body prefix intact", mn.startswith("Body."))
 
+# ── multi-paragraph pandoc footnote: blank line + 4-space-indented continuation PARAGRAPH ──
+# (finding 3) a bare "blank line always ends the def block" rule leaves paragraph 2+ unmasked.
+MP_BODY = "Lead-in sentence.[^mp]"                                        # line 1
+MP_DEF = "[^mp]: First paragraph mentions a tapestry."                    # line 3
+MP_CONT = "    Second paragraph continuation, also a tapestry."           # line 5
+MP_AFTER = "Trailing body sentence about a tapestry."                    # line 7
+MP_TEXT = "\n".join([MP_BODY, "", MP_DEF, "", MP_CONT, "", MP_AFTER]) + "\n"
+
+mp_masked = d.mask_footnotes(MP_TEXT)
+ok("multi-para: line count preserved", len(mp_masked.split("\n")) == len(MP_TEXT.split("\n")))
+for idx, (a, b) in enumerate(zip(MP_TEXT.split("\n"), mp_masked.split("\n"))):
+    ok(f"multi-para: line {idx} length preserved", len(a) == len(b), f"{a!r} vs {b!r}")
+ok("multi-para: def paragraph 1 blanked", "First paragraph mentions a tapestry" not in mp_masked)
+ok("multi-para: continuation paragraph 2 blanked (finding 3)",
+   "Second paragraph continuation" not in mp_masked)
+ok("multi-para: trailing body sentence intact", "Trailing body sentence about a tapestry" in mp_masked)
+
+mp_res = d.audit_text(MP_TEXT, mask_fn=True)
+mp_tap_lines = sorted({s["line"] for s in mp_res["spans"] if s.get("text", "").lower() == "tapestry"})
+ok("multi-para: tapestry flagged ONLY on the trailing body line (7)", mp_tap_lines == [7], str(mp_tap_lines))
+
 print(f"\n{_p} passed, {_f} failed")
 sys.exit(1 if _f else 0)

--- a/workflows/writing-draft.js
+++ b/workflows/writing-draft.js
@@ -101,6 +101,25 @@ const VERIFY_SCHEMA = {
   },
 }
 
+// Section ROLE drives heading emission: only PARTS get lettered ## A./B./C. subsection headings;
+// an Introduction or Conclusion is continuous unheaded prose even when its outline groups its Body
+// as A/B/C (those groupings guide paragraph ORDER, not headings). Match on the FULL title after
+// stripping a leading enumeration prefix ("Part V:", "V.", "IV:", "2.", "Section 3:") — a substring/
+// prefix match would misclassify "Conclusions" / "Concluding Remarks" / "V. Conclusion" as non-continuous
+// (false negative → wrongly lettered subsections) and "Introduction to the Regime" as continuous
+// (false positive → verifier flags legit subsections, unsatisfiable /goal loop).
+function isContinuousSection(name) {
+  let s = String(name).trim()
+  // Strip an enumeration prefix, but require an explicit keyword ("Part") or a delimiter immediately
+  // after the roman/numeral run — otherwise "Conclusion" (which starts with the roman numeral "C")
+  // would get its leading "C" eaten by a bare-letters match.
+  s = s.replace(/^part\s+[ivxlcdm]+\.?:?\)?\s*/i, '')
+  s = s.replace(/^(?:[ivxlcdm]+|\d+)[.:)]\s*/i, '')
+  s = s.replace(/^section\s+\d+[.:)]?\s*/i, '')
+  s = s.trim().toLowerCase()
+  return /^(introduction|intro|conclusion(s)?|concluding remarks|summary and conclusions?|preface|foreword)$/.test(s)
+}
+
 // ── Phase 1: Discover ─────────────────────────────────────────────────────────
 // Map the deterministic section index → the DISCOVERY_SCHEMA shape (no LLM). draftFile is
 // recomputed from OUTDIR so a pilot subdir (e.g. drafts-pilot) is honored; precisClaim comes
@@ -151,7 +170,11 @@ if (underGranular.length) log(`⚠️ structureless outlines (NOT drafted): ${un
 const unpinned = draftable.filter(s => s.sourcesPinned === false).map(s => s.name)
 if (unpinned.length) log(`ℹ️ ${unpinned.length} outline(s) don't pin sources — draft agents will assign citations from the bib; fidelity check will verify each resolves: ${unpinned.join(', ')}`)
 
-// ── Phase 2: Transform (one write-agent per executable section, in parallel) ────
+// ── Phase 2+3: Transform → Verify, chained per section (one parallel() barrier) ──────────
+// Each section's verify used to wait on a SECOND parallel() barrier that blocked until every
+// section finished drafting — so a slow section's draft held up a fast section's verify for no
+// reason. Fix: compose draft→verify as ONE thunk per section and run all sections' chains in a
+// single parallel() call; a fast section's verify starts the moment ITS OWN draft lands.
 // Seams dissolve because the FULL spec exists up front: each agent reads the prior/next OUTLINE (not draft)
 // to write correct bridges — no dependency on sibling drafts, so the fan-out is genuinely parallel.
 phase('Transform')
@@ -174,8 +197,8 @@ for (const s of draftable) {
   // Section ROLE drives heading emission: only PARTS get lettered ## A./B./C. subsection headings;
   // an Introduction or Conclusion is continuous unheaded prose even when its outline groups its Body
   // as A/B/C (those groupings guide paragraph ORDER, not headings).
-  const continuous = /^\s*(introduction|intro|conclusion|preface|foreword)\b/i.test(String(s.name))
-  tasks.push(() => agent(
+  const continuous = isContinuousSection(s.name)
+  const draftPrompt =
     `You are a writing-draft prose generator. You EXPAND one section outline into prose. The outline pins the WHAT — the claims, their order at the section level, and the pinned sources. WITHIN the section you MAY merge, subordinate, or reorder the outline's points for PROPORTIONAL development: a minor point can become a clause inside a neighbor's paragraph; a pivotal one can run several paragraphs. What you may NOT do: add new claims, change the section-level structure the outline specifies, or invent citations the outline didn't pin. How the pinned points are developed, paced, and sentenced is YOURS — that judgment is what makes the prose read like a person wrote it.
 Set section="${s.name}" verbatim in your record (the gate keys on it).
 
@@ -198,25 +221,12 @@ Drafting contract (the Iron Laws of writing-draft):
 - CITATIONS: this outline may not pin sources to its claims. Where a substantive claim needs a citation, draw it from a REAL source: ${disc.bibPath ? `the project bibliography ${disc.bibPath}` : 'the user\'s Paperpile bibliography (~/Google Drive/My Drive/resources/Paperpile) or the project sources'}, and for legal claims a real, well-formed, verifiable authority (case/statute/article). Carry through any [@bibkey]/[CLAIM-XX] the outline DOES pin. **NEVER fabricate a citation, and NEVER attribute a claim to a source that does not support it.** If you cannot identify a real source for a claim, leave a literal \`[CITE-NEEDED: <what's needed>]\` marker instead of inventing one — the verify stage treats an invented cite as a critical failure but an honest CITE-NEEDED as a flag to resolve.
 - Apply R1-R3 deviations inline if drafting surfaces them (R1 factual fix, R2 add a real source, R3 structural bridge). If you hit an R4 (the argument itself needs restructuring), do NOT invent a fix — note it in summary and draft to the outline as written.
 
-Write the full prose to ${s.draftFile} with the Write tool (include frontmatter \`implements: [the outline's CLAIM ids]\`). Then return TRANSFORM_SCHEMA with status="drafted", content=the FULL prose you wrote, and pointsExpanded=the number of outline points you expanded.`,
-    { label: String(s.name), phase: 'Transform', schema: TRANSFORM_SCHEMA }))
-}
-const liveTransforms = (await parallel(tasks)).filter(Boolean)
-if (ONLY) log(`Selective re-draft: ${drafted} section(s) live, ${carriedCount} carried`)
-
-// ── Phase 3: Verify (read-only — execution-fidelity to the spec, NOT document quality) ─
-phase('Verify')
-const specByName = Object.fromEntries(draftable.map(s => [String(s.name), s]))
-const verifs = (await parallel(liveTransforms.map(t => () => {
-  const s = specByName[String(t.section)]
-  const prev = s && s.prevName ? outlineByName[String(s.prevName)] : null
-  const next = s && s.nextName ? outlineByName[String(s.nextName)] : null
-  const continuous = /^\s*(introduction|intro|conclusion|preface|foreword)\b/i.test(String(t.section))
-  return agent(
+Write the full prose to ${s.draftFile} with the Write tool (include frontmatter \`implements: [the outline's CLAIM ids]\`). Then return TRANSFORM_SCHEMA with status="drafted", content=the FULL prose you wrote, and pointsExpanded=the number of outline points you expanded.`
+  const buildVerifyPrompt = (t) =>
     `You are a READ-ONLY verifier. Do NOT create, edit, or overwrite any files. Confirm a drafted section faithfully EXECUTED its outline — this is execution-fidelity, NOT a document-quality review (writing-review does that later).
 Set section="${t.section}" verbatim.
 
-THE OUTLINE IT HAD TO EXPAND: ${s ? s.outlineFile : '(missing — flag critical)'}
+THE OUTLINE IT HAD TO EXPAND: ${s.outlineFile}
 GENERATED PROSE (as written by the draft agent):
 ${(t.content || '').slice(0, 8000)}
 Also try to Read ${t.draftFile} (prefer on-disk content if present).
@@ -227,11 +237,18 @@ Check, and report every gap in findings with severity:
 3. transitionOk — ${prev ? `does the FIRST sentence connect to what "${prev.name}" (${prev.outlineFile}) establishes?` : 'is the opening clean (no "as discussed above" with nothing prior)?'} ${next ? `does the LAST sentence set up "${next.name}" (${next.outlineFile})?` : 'is the close clean (no dangling hand-off)?'} A seam (abrupt jump, repeated setup, dangling reference) ⇒ transitionOk=false (major).
 4. SCAFFOLDING HEADINGS — the outline's \`## Opening\`, \`## Body\`, \`## Closing\` are scaffolding, NOT document headings. If the prose contains a literal heading named "Opening", "Body", or "Closing" (or a synonym like "Conclusion to Part ${'X'}"), report it as a MAJOR finding ("scaffolding label emitted as a heading"): the section must end in an UNHEADED bridging paragraph, not a "Closing"/"Conclusion" heading.${continuous ? ` ALSO — this is an INTRODUCTION/CONCLUSION, which is CONTINUOUS UNHEADED prose: if the draft contains ANY lettered subsection heading (\`## A.\`, \`## B.\`, … — even though the outline groups its Body as A/B/C), report it as a MAJOR finding ("lettered subsections in an Introduction/Conclusion"). Only the section title (\`#\`) is a valid heading here.` : ` Only the section title (\`#\`) and the lettered \`## A./B./C.\` subsections are valid headings in a Part.`}
 Also return boundary.firstSentence and boundary.lastSentence verbatim (for the skill's seam audit).
-Return VERIFY_SCHEMA.`,
-    { label: `verify:${t.section}`, phase: 'Verify', schema: VERIFY_SCHEMA, model: 'sonnet' }
-  )
-}))).filter(Boolean)
-const verifyByName = Object.fromEntries(verifs.map(v => [String(v.section), v]))
+Return VERIFY_SCHEMA.`
+  tasks.push(() => (async () => {
+    const t = await agent(draftPrompt, { label: String(s.name), phase: 'Transform', schema: TRANSFORM_SCHEMA })
+    if (!t) return null
+    const v = await agent(buildVerifyPrompt(t), { label: `verify:${s.name}`, phase: 'Verify', schema: VERIFY_SCHEMA, model: 'sonnet' })
+    return { transform: t, verify: v }
+  })())
+}
+const liveResults = (await parallel(tasks)).filter(Boolean)
+if (ONLY) log(`Selective re-draft: ${drafted} section(s) live, ${carriedCount} carried`)
+const liveTransforms = liveResults.map(r => r.transform)
+const verifyByName = Object.fromEntries(liveResults.filter(r => r.verify).map(r => [String(r.verify.section), r.verify]))
 
 // ── Phase 4: Gate (pure JS — substrate split: drafted + coverage + fidelity + transitions) ─
 phase('Gate')


### PR DESCRIPTION
## Ordering note

Draft PR #50 (`fix-code-review-8-findings`) is already pending and bumped the version to
5.68.1. This branch is based on `origin/main` at 5.68.0 (unaware of #50) and bumps directly
to **5.68.2**, skipping .68.1. It avoids #50's edited regions (`hooks/_gate_common.py`
extraction, `fix_footnotes.py` leading-tab/indent helpers). Whichever of the two merges
second should rebase/renumber if there's a version collision.

## Confirmed correctness fixes

1. **`workflows/writing-draft.js`** (:177, :214) — hoisted a single module-level
   `isContinuousSection(name)` helper to replace the duplicated prefix-match regex in the
   draft and verify loops. It strips a leading enumeration prefix (`Part V:`, `V.`, `IV:`,
   `2.`, `Section 3:`) and then requires a **full-title** match, fixing:
   - false negatives: "Conclusions", "Concluding Remarks", "V. Conclusion", "Part V: Conclusion"
     (previously NOT treated as continuous → wrongly lettered `## A./B./C.` subsections)
   - false positives: "Introduction to the Regime" (previously treated as continuous →
     verifier flags legitimate subsections, unsatisfiable `/goal` loop)

2. **`skills/docx-repair/scripts/fix_footnotes.py`** (:1867) — `bio_count` auto-detect now
   counts `customMarkFollows="1"` **plus** `customMarkFollows="0"` refs. The documented
   Google Docs damage (`footnotes-reference.md`) always flips `1→0`, so counting only `"1"`
   made the canonical no-flag repair silently skip all bio restoration on every damaged
   paper. A bio-less paper still has neither variant, preserving the v5.67.4
   no-spurious-bios behavior. Prints which variant was found. Also fixed the stale
   `SKILL.md:183` doc ("default: 3" → describes the auto-detect).

3. **`skills/de-ai-revise/scripts/de_ai_audit.py`** — `mask_footnotes` no longer ends a
   `[^id]:` block unconditionally at the first blank line. It now looks ahead past a run of
   blank lines: if the next non-blank line is still indented (4+ spaces/tab), the block stays
   open (multi-paragraph pandoc footnote continuation) and the blank line is masked too.
   Extended `tests/test_de_ai_footnote_masking.py` with a multi-paragraph fixture (line
   count/length preserved, paragraph 2 masked, trailing body text still flagged).

4. **`--with lxml` stragglers** — added to the 4 documented manual `check-all.py`
   invocations the v5.67.5 fix missed: `writing-review/SKILL.md:158`,
   `dev-verify/SKILL.md:232`, `workshop-revise/SKILL.md:268`,
   `dev-common-constraints.md:96` (plus `workflow-creator/SKILL.md:977`, found in the
   repo-wide grep). Confirmed no other `uv run python3 .*check-all\.py` occurrences remain.

5. **`hooks/writing-prose-check.py`** — `_run_style_lint` now masks footnotes before handing
   the draft to `style_metrics.py --lint`, using the same write-masked-temp-file pattern
   `de_ai_audit.py` already used. Masking is line/offset-preserving, so reported line numbers
   stay valid.

## Cleanup

6. **`skills/writing-outline/SKILL.md:368-369`** — deleted the two stale checklist lines
   referencing the pre-v5.67.1 POINT/EVIDENCE/LOGIC outline format.

7. **Shared masker + the writing-ai-smell constraints** — extracted the masker into
   `scripts/lib/footnote_mask.py` (stdlib-only `re`; the established
   `scripts/lib/` shared-module convention, same pattern as `plan_table_core.py`).
   `de_ai_audit.py` and `hooks/writing-prose-check.py` both import it; `de_ai_audit.py` keeps
   the same `mask_footnotes`/`_blank`/regex names as a re-export so nothing else that imports
   it breaks.

   Checked all 4 `writing-ai-smell-*.py` constraints for the inline-`^[...]`-footnote gap:
   - **`writing-ai-smell-em-dash.py`** and **`writing-ai-smell-puffery.py`** — FIXED. Both
     already skip `[^id]:` *definition* lines but never masked an inline `^[...]` footnote
     embedded mid-line, so a genuine em-dash or puffery word inside quoted case/statute text
     could trip the constraint as if the author wrote it. Now call `mask_footnotes()` on the
     full text before scanning. Verified with a fixture (quoted em-dash/puffery/"tapestry"
     inside an inline footnote) — 0 violations after the fix, and `check-all.py` still runs
     both with 0 errors.
   - **`writing-ai-smell-artifacts.py`** — left unmasked. Its patterns (ChatGPT
     `turn0search0`-style artifacts, prompt refusals, unfilled placeholders) have
     near-zero legitimate false-positive risk, and a leaked artifact inside a footnote is
     still a genuine defect worth flagging.
   - **`writing-ai-smell-structure.py`** — left unmasked. Its patterns only match at
     paragraph-**start** lines; an inline footnote essentially never opens a paragraph, so
     there's no realistic false-positive to fix.

8. **`workflows/writing-draft.js`** — composed each section's draft→verify into ONE thunk
   (`agent(draft) → agent(verify)`) run inside a single `parallel()` call, instead of two
   sequential `parallel()` barriers where every verify waited for the slowest section's
   draft. Kept exactly one `phase('Transform')` call (no separate `phase('Verify')`) —
   every other workflow in this repo (`wc-audit`, `workshop-generate`, `writing-review`) calls
   `phase()` once per phase at the top level, never interleaved per-item, so flipping it
   per-section would have been the kind of entanglement this finding's escape hatch was meant
   to avoid. Verified against the real-source driver test
   (`tests/writing-engine-discover.test.mjs`, which executes `writing-draft.js`'s actual body
   with mocked `agent`/`parallel`) — all assertions on gate outcome, drafted/verified labels,
   and score table still hold.

## Testing

- `node --check workflows/writing-draft.js`
- `isContinuousSection` REPL-tested on all 8 required cases (Conclusion, Conclusions, V.
  Conclusion, Part V: Conclusion, Concluding Remarks, Introduction, Introduction to the
  Regime → false, Part I. Background → false) — all pass
- `uv run --with pyyaml python3 tests/test_de_ai_footnote_masking.py` — 26/26 (extended
  with the multi-paragraph case)
- `mask_footnotes` REPL-tested on a synthetic multi-paragraph footnote (line count/length
  preserved)
- Every other `tests/*.py` / `tests/*.mjs` that touches an edited file: `test_de_ai_audit.py`,
  `test_law_review_footnote_symbols.py`, `test_prose_lint_hook.py`,
  `test_writing_constraint_lints.py`, `check_all_applies_to_test.py`,
  `test_mechanical_floor_gate.py`, `test_writing_mechanical_gate.py`,
  `writing_gate_probe_test.py`, `writing_guards_test.py`, `writing_section_index_test.py`,
  `writing-engine-discover.test.mjs`, `workshop-engine-discover.test.mjs`,
  `ds-grain-pause.test.mjs`, `dev-run-driver.test.mjs`, `ds-run-driver.test.mjs` — all pass
- `py_compile` on every edited `.py` file
- `check-all.py --with lxml` run end-to-end against a fixture drafts dir — 0 errors, both
  modified constraints pass clean on quoted em-dash/puffery inside an inline footnote

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3NEAUUosUHyci4iFZBH2J