### PR TITLE
fix(dev/ds compiled-runner): pipe-safe parsing, N/A-test convention sync, ds outputsProduced forcing function (v5.68.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.68.0"
+    "version": "5.68.3"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.68.0",
+      "version": "5.68.3",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.68.0",
+  "version": "5.68.3",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/dev-plan-executable-guard.py
+++ b/hooks/dev-plan-executable-guard.py
@@ -19,7 +19,8 @@ Instructional "use the table" text was systematically ignored (a real reviewed
 PLAN — happy-clawd — used prose phase-headings and passed); the hook is the
 structural enforcement.
 
-Wired via dev-plan-reviewer frontmatter:
+Wired via dev-design frontmatter (skills/dev-design/SKILL.md — dev-plan-reviewer is a read-only
+reviewer and never writes PLAN_REVIEWED.md, so it cannot be this hook's wiring point):
   hooks:
     PreToolUse:
       - matcher: "Write|Edit"
@@ -34,20 +35,28 @@ import json
 import sys
 from pathlib import Path
 
-# Single source of truth for "what the Implementation Order table means" — the SAME tolerant
-# parser dev-compile uses to emit run.js, so a plan that COMPILES also PASSES this gate.
-# (Before reconciliation this guard used a stricter regex — `^(\d+)\.` ids, `^after\s+([\d,\s]+)$`
-# deps — whose drift the now-retired LLM discovery agent silently tolerated: a plan the workflow
-# could run could still be falsely blocked here, AND the guard's DAG check ran on a different
-# interpretation than the runner's. The shared parser closes both gaps.)
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "dev"))
-from dev_plan_table import parse_plan  # noqa: E402
-
 
 def validate_plan(plan_path: Path):
-    """Return list of human-readable violations ([] == executable)."""
+    """Return list of human-readable violations ([] == executable).
+
+    Single source of truth for "what the Implementation Order table means" — the SAME tolerant
+    parser dev-compile uses to emit run.js, so a plan that COMPILES also PASSES this gate.
+    (Before reconciliation this guard used a stricter regex — `^(\\d+)\\.` ids,
+    `^after\\s+([\\d,\\s]+)$` deps — whose drift the now-retired LLM discovery agent silently
+    tolerated: a plan the workflow could run could still be falsely blocked here, AND the guard's
+    DAG check ran on a different interpretation than the runner's. The shared parser closes both
+    gaps.)
+
+    The parser import is deliberately LAZY (done here, not at module load): this hook's
+    PreToolUse matcher fires on every Write/Edit in a session, but only a write to
+    `PLAN_REVIEWED.md` ever reaches this function — the hundreds of unrelated calls exit early
+    in main() before validate_plan runs. Importing dev_plan_table (and mutating sys.path) at
+    module scope would pay that cost on every one of them.
+    """
     if not plan_path.is_file():
         return [f"PLAN.md not found at {plan_path}"]
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "dev"))
+    from dev_plan_table import parse_plan  # noqa: E402
     return parse_plan(plan_path.read_text()).violations
 
 

--- a/hooks/ds-plan-executable-guard.py
+++ b/hooks/ds-plan-executable-guard.py
@@ -28,18 +28,26 @@ import json
 import sys
 from pathlib import Path
 
-# Single source of truth for "what the Task Breakdown table means" — the SAME tolerant
-# parser ds-compile uses to emit run.js, so a plan that COMPILES also PASSES this gate.
-# (Before reconciliation this guard used a stricter regex that rejected real plans like
-# muni's `**T1**` / bare-`T1` format, which only ran because the now-retired LLM discovery
-# agent silently tolerated the drift. The shared parser closes that gap.)
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "ds"))
-from ds_plan_table import parse_plan  # noqa: E402
-
 
 def validate_plan(plan_path: Path):
+    """Return list of human-readable violations ([] == executable).
+
+    Single source of truth for "what the Task Breakdown table means" — the SAME tolerant
+    parser ds-compile uses to emit run.js, so a plan that COMPILES also PASSES this gate.
+    (Before reconciliation this guard used a stricter regex that rejected real plans like
+    muni's `**T1**` / bare-`T1` format, which only ran because the now-retired LLM discovery
+    agent silently tolerated the drift. The shared parser closes that gap.)
+
+    The parser import is deliberately LAZY (done here, not at module load): this hook's
+    PreToolUse matcher fires on every Write/Edit in a session, but only a write to
+    `PLAN_REVIEWED.md` ever reaches this function — the hundreds of unrelated calls exit early
+    in main() before validate_plan runs. Importing ds_plan_table (and mutating sys.path) at
+    module scope would pay that cost on every one of them.
+    """
     if not plan_path.is_file():
         return [f"PLAN.md not found at {plan_path}"]
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "ds"))
+    from ds_plan_table import parse_plan  # noqa: E402
     return parse_plan(plan_path.read_text()).violations
 
 

--- a/scripts/dev/dev_compile.py
+++ b/scripts/dev/dev_compile.py
@@ -112,7 +112,10 @@ def compile_plan(plan_path: Path, out_path: Path, project_dir: Path,
              "/*__PROJECT__*/": json.dumps(str(project_dir)),
              "/*__TASKS__*/": _js_literal(specs),
              "/*__GLOBAL_CONSTRAINTS__*/": json.dumps(res.global_constraints),
-             "/*__LEVEL_MODES__*/": _js_literal(level_modes)}
+             "/*__LEVEL_MODES__*/": _js_literal(level_modes),
+             # dev has no output-first self-report (TDD uses testWritten/verifyPassed instead) —
+             # leave outputsProduced optional/advisory (ds sets this True; see ds_compile.py).
+             "/*__REQUIRE_OUTPUTS_PRODUCED__*/": _js_literal(False)}
     for hole in holes:
         n = template.count(hole)
         if n != 1:

--- a/scripts/dev/dev_plan_table.py
+++ b/scripts/dev/dev_plan_table.py
@@ -41,8 +41,11 @@ from plan_table_core import (  # noqa: E402
 REQUIRED_COLS = ("task", "deps", "files", "failing test", "verify command", "implements")
 # dev detects its table by these exact header cells; columns accessed tolerantly (prefix-aware).
 _TABLE_REQUIRED = {"task", "deps", "verify command"}
-# values that mean "no failing test required" (TDD N/A — types-only / meta tasks)
-_TEST_NA = {"", "n/a", "na", "none", "—", "-"}
+# "is a test required?" has exactly ONE owner: workflows/templates/dev-task.js's `testRequired`
+# (it decides whether gateProbe/implementerPrompt demand a Failing Test). This parser does NOT
+# duplicate that predicate — a second copy is how P2/v5.68.3 drifted (this parser's now-deleted
+# `_TEST_NA` treated `—`/`-` as N/A while dev-task.js's regex did not, so a `—` cell compiled but
+# could never satisfy the gate). Keep the N/A convention here in sync with dev-task.js by eye.
 
 
 @dataclass
@@ -58,12 +61,6 @@ class Task:
     pause_after: str | None      # decision text if the row declares a ⏸ PAUSE marker, else None
     interfaces: str              # this task's `### Task N` Consumes/Produces block, verbatim; "" if none
     task_text: str               # full task cell, verbatim (for the implementer prompt)
-
-    @property
-    def test_required(self) -> bool:
-        norm = self.failing_test.strip().lower()
-        # "N/A", "N/A (meta)", "N/A (types only)", "none" … all mean no test required
-        return norm not in _TEST_NA and not re.match(r"^(n/?a|none)\b", norm)
 
     def to_dict(self) -> dict:
         return {
@@ -170,7 +167,7 @@ def parse_plan(text: str) -> ParseResult:
         name = DONE_RE.sub("", name).strip().strip("`").strip()
         done = bool(DONE_RE.search(task_cell))
 
-        deps = parse_deps(cell(header, cells, "deps"))
+        deps = parse_deps(cell(header, cells, "deps"), res.violations, f"Task {tid}: ")
 
         files_cell = cell(header, cells, "files")
         files = [f.strip().strip("`").strip() for f in re.split(r"[;,]", files_cell) if f.strip()]

--- a/scripts/ds/ds_compile.py
+++ b/scripts/ds/ds_compile.py
@@ -148,11 +148,15 @@ def compile_plan(plan_path: Path, out_path: Path, project_dir: Path,
     template = template.replace(body_hole, fragment, 1)
 
     # 2. ds has no Global Constraints; LEVEL_MODES is the compiler-derived intraLevel flag.
+    #    ds is output-first: force the outputsProduced self-report (True, not merely !== false) —
+    #    the forcing function the pass-#9 extraction accidentally dropped when it made the field
+    #    domain-optional in the shared TRANSFORM_SCHEMA/pass logic.
     holes = {"/*__META__*/": _js_literal(meta),
              "/*__PROJECT__*/": json.dumps(str(project_dir)),
              "/*__TASKS__*/": _js_literal(specs),
              "/*__GLOBAL_CONSTRAINTS__*/": json.dumps(""),
-             "/*__LEVEL_MODES__*/": _js_literal(level_modes)}
+             "/*__LEVEL_MODES__*/": _js_literal(level_modes),
+             "/*__REQUIRE_OUTPUTS_PRODUCED__*/": _js_literal(True)}
     for hole in holes:
         n = template.count(hole)
         if n != 1:

--- a/scripts/ds/ds_plan_table.py
+++ b/scripts/ds/ds_plan_table.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 from plan_table_core import (  # noqa: E402
-    ID_RE, DONE_RE, PAUSE_RE, cell, find_table, parse_deps, check_acyclic, toposort_ids,
+    ID_RE, DONE_RE, PAUSE_RE, cell, has_col, find_table, parse_deps, check_acyclic, toposort_ids,
 )
 
 REQUIRED_COLS = ("task", "deps", "outputs", "expected output", "verify", "implements")
@@ -96,7 +96,7 @@ def parse_plan(text: str) -> ParseResult:
             "No Task Breakdown table found (need a markdown table with columns "
             "Task | Deps | Outputs | Expected Output | Verify | Implements).")
         return res
-    missing = [c for c in REQUIRED_COLS if c not in header]
+    missing = [c for c in REQUIRED_COLS if not has_col(header, c)]
     if missing:
         res.violations.append(f"Task Breakdown table missing column(s): {', '.join(missing)}.")
         return res
@@ -119,7 +119,7 @@ def parse_plan(text: str) -> ParseResult:
         kind = kind_m.group(1).lower() if kind_m else "unspecified"
         done = bool(DONE_RE.search(task_cell))
 
-        deps = parse_deps(cell(header, cells, "deps"))
+        deps = parse_deps(cell(header, cells, "deps"), res.violations, f"Task {tid}: ")
 
         outputs_cell = cell(header, cells, "outputs")
         outputs = [o.strip().strip("`").strip() for o in re.split(r"[;,]", outputs_cell) if o.strip()]

--- a/scripts/lib/plan_table_core.py
+++ b/scripts/lib/plan_table_core.py
@@ -33,16 +33,55 @@ ID_RE = re.compile(r"^\s*\**\s*((?:[A-Za-z]+)?\d+)\s*\**\.?")
 DONE_RE = re.compile(r"`?\[x\]`?", re.I)
 # tokens that mean "no dependencies"
 NO_DEPS = {"", "-", "--", "---", "—", "–", "n/a", "none"}
-# a dependency reference token inside the Deps cell: T1, 1, t10 …
-DEP_TOK_RE = re.compile(r"(?:[A-Za-z]+)?\d+")
+# a whole dep token, after splitting the cell on commas/whitespace: **T1**, T1., 1, t10 …
+_DEP_TOKEN_RE = re.compile(r"^\**((?:[A-Za-z]+)?\d+)\**\.?$")
 # an inline pause marker in any cell: ⏸ PAUSE: <text>  (also accepts "PAUSE:" without the glyph)
 PAUSE_RE = re.compile(r"(?:⏸\s*)?PAUSE:\s*(.+?)(?:\s*$)", re.I)
 
 _SEP_RE = re.compile(r"^\|?[\s:|-]+\|[\s:|-]+\|?$")
 
 
+def _split_cells(text: str) -> list[str]:
+    """Split a markdown table row's raw text on bare '|' — tolerant of (a) an escaped `\\|`
+    (unescaped to a literal '|' in the resulting cell, not treated as a separator) and (b) a
+    '|' inside a backtick code span (`` `pytest -q | tail` ``, `` `grep -E 'foo|bar'` `` — both
+    real Verify-cell content). Shared by split_row (data rows) and find_table (the header row)
+    so a Verify cell with a shell pipe or regex alternation can never shift later columns."""
+    cells: list[str] = []
+    buf: list[str] = []
+    in_code = False
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "\\" and i + 1 < n and text[i + 1] == "|":
+            buf.append("|")
+            i += 2
+            continue
+        if c == "`":
+            in_code = not in_code
+            buf.append(c)
+            i += 1
+            continue
+        if c == "|" and not in_code:
+            cells.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    cells.append("".join(buf))
+    return cells
+
+
+def _strip_outer_pipes(text: str) -> str:
+    text = text.strip()
+    text = re.sub(r"^\|+", "", text)
+    text = re.sub(r"\|+$", "", text)
+    return text
+
+
 def split_row(line: str) -> list[str]:
-    return [c.strip() for c in line.strip().strip("|").split("|")]
+    return [c.strip() for c in _split_cells(_strip_outer_pipes(line))]
 
 
 def col_index(header, name) -> int:
@@ -82,7 +121,7 @@ def find_table(text: str, required: set[str]):
         line = raw.strip()
         if not (line.startswith("|") and "|" in line[1:]):
             continue
-        header = [c.strip().lower() for c in line.strip("|").split("|")]
+        header = [c.strip().lower() for c in _split_cells(_strip_outer_pipes(line))]
         sep = lines[i + 1].strip() if i + 1 < len(lines) else ""
         is_sep = bool(_SEP_RE.match(sep)) and "-" in sep
         if is_sep and required.issubset(set(header)):
@@ -95,14 +134,35 @@ def find_table(text: str, required: set[str]):
     return None, None
 
 
-def parse_deps(deps_cell: str) -> list[str]:
+def parse_deps(deps_cell: str, violations: list[str] | None = None, ctx: str = "") -> list[str]:
     """A Deps cell → a list of canonical dependency ids. Tolerates `after T1, T2`, bare `T1, T2`,
-    and the no-deps tokens (—, ---, none, n/a, …). Plan-internal task refs only (never artifacts)."""
+    and the no-deps tokens (—, ---, none, n/a, …). Plan-internal task refs only (never artifacts).
+
+    Deliberately NOT a digit-sweep over the whole cell: free text like `T1 (needs config v2)`
+    must not turn `v2` into a phantom dep. After stripping the optional leading `after `, the
+    cell is split on commas/whitespace and each piece must FULLMATCH a dep token (optionally
+    `**bold**`-wrapped, optionally trailing `.`); non-conforming residue is dropped from the
+    deps list and, if a `violations` list is supplied, reported there (prefixed with `ctx`)
+    instead of silently becoming a dependency."""
     norm = deps_cell.strip().strip("`").strip().lower()
     if norm in NO_DEPS:
         return []
-    body = re.sub(r"^after\s+", "", deps_cell.strip(), flags=re.I)
-    return [canon_id(t) for t in DEP_TOK_RE.findall(body)]
+    # backticks are markdown formatting only (a whole cell like `` `after 0` `` or individually
+    # `` `T1`, `T2` `` ) — strip them all before the `after ` prefix-check and the token split, or
+    # a wrapped cell's leading backtick would hide the `after ` prefix from re.sub below.
+    body = re.sub(r"^after\s+", "", deps_cell.strip().replace("`", ""), flags=re.I)
+    deps: list[str] = []
+    for piece in re.split(r"[,\s]+", body.strip()):
+        if not piece:
+            continue
+        m = _DEP_TOKEN_RE.match(piece)
+        if m:
+            deps.append(canon_id(piece))
+        elif violations is not None:
+            violations.append(
+                f"{ctx}Deps cell has unparseable text '{piece}' (not a dep token like `T1`/`1`) — "
+                f"dropped, not treated as a dependency.")
+    return deps
 
 
 def check_acyclic(deps_map: dict[str, list[str]]) -> bool:

--- a/tests/dev_plan_table_test.py
+++ b/tests/dev_plan_table_test.py
@@ -35,11 +35,11 @@ r = parse_plan(tbl(
 check("canonical parses", r.ok, r.violations)
 check("task0 id", r.tasks[0].id == "0")
 check("task0 no deps (---)", r.tasks[0].deps == [])
-check("task0 N/A test → not required", r.tasks[0].test_required is False)
+check("task0 N/A test cell", r.tasks[0].failing_test == "N/A (meta)")
 check("task1 deps after 0", r.tasks[1].deps == ["0"])
 check("task2 two files", r.tasks[2].files == ["src/auth/service.ts", "src/auth/service.test.ts"])
 check("task2 two implements", r.tasks[2].implements == ["AUTH-01", "AUTH-02"])
-check("task2 test required", r.tasks[2].test_required is True)
+check("task2 test cell present", r.tasks[2].failing_test == "test_validate_session()")
 check("task2 name stripped of id", r.tasks[2].name == "Service")
 
 # 1b. toposort: 0 → 1 → {2,3} parallel level
@@ -105,6 +105,23 @@ check("missing Implements column rejected", not r.ok and any("missing required c
 # 5. ⏸ PAUSE marker lifted
 r = parse_plan(tbl("| 1. x | `---` | `a.ts` | `t()` ⏸ PAUSE: confirm API shape | `npm test` | A-01 |\n"))
 check("pause marker lifted", r.ok and r.tasks[0].pause_after == "confirm API shape", r.tasks[0].pause_after)
+
+# 6. a Verify Command cell carrying a shell pipe must NOT shift later columns (P1/v5.68.3)
+r = parse_plan(tbl(
+    "| 1. x | `---` | `a.ts` | `t()` | `pytest -q | tail` | A-01 |\n",
+))
+check("piped verify cell parses", r.ok, r.violations)
+check("piped verify cell preserved verbatim", r.tasks[0].verify == "pytest -q | tail", r.tasks[0].verify)
+check("piped verify cell doesn't shift Implements", r.tasks[0].implements == ["A-01"], r.tasks[0].implements)
+
+# 7. an em-dash/plain-dash Failing Test cell means NO test required (matches dev-task.js testRequired)
+r = parse_plan(tbl(
+    "| 1. x | `---` | `a.ts` | — | `npm test` | A-01 |\n",
+    "| 2. y | `after 1` | `b.ts` | - | `npm test` | A-02 |\n",
+))
+check("em-dash failing-test cell parses", r.ok, r.violations)
+check("em-dash failing-test cell preserved", r.tasks[0].failing_test == "—", r.tasks[0].failing_test)
+check("plain-dash failing-test cell preserved", r.tasks[1].failing_test == "-", r.tasks[1].failing_test)
 
 print(f"\n{P} passed, {F} failed")
 sys.exit(1 if F else 0)

--- a/tests/ds_plan_table_test.py
+++ b/tests/ds_plan_table_test.py
@@ -77,7 +77,16 @@ check("empty Verify flagged", any("Verify" in v for v in r.violations), r.violat
 r = parse_plan(tbl("| T1 — x | T9 | `a` | x | `true` | D-01 |\n"))
 check("dangling dep flagged", any("does not exist" in v for v in r.violations), r.violations)
 
-# 8. real muni plan
+# 8. qualified column header (prefix-tolerant, matching dev's already-tolerant column check —
+#    P3/v5.68.3: ds's exact `c not in header` check falsely rejected this before the fix)
+QUALIFIED_HEADER = ("| Task | Deps | Outputs | Expected Output (per requirement) | Verify | Implements |\n"
+                    "|---|---|---|---|---|---|\n")
+r = parse_plan("# PLAN\n\n## Task Breakdown\n\n" + QUALIFIED_HEADER +
+               "| T1 | — | `a.parquet` | non-empty | `true` | D-01 |\n")
+check("qualified 'Expected Output (per requirement)' header accepted", r.ok, r.violations)
+check("qualified header cell extracted", r.tasks[0].expected_output == "non-empty", r.tasks[0].expected_output)
+
+# 9. real muni plan
 muni = Path.home() / "projects/muni-pennying/.planning/PLAN.md"
 if muni.is_file():
     r = parse_plan(muni.read_text())

--- a/tests/plan_table_core_test.py
+++ b/tests/plan_table_core_test.py
@@ -25,6 +25,22 @@ def check(name, cond, extra=""):
 # split_row
 check("split_row strips pipes + cells", split_row("| a | b | c |") == ["a", "b", "c"])
 
+# split_row: a bare '|' shell pipe / regex-alternation inside backticks must NOT split the cell
+# (split_row does NOT strip backticks — that's the domain parser's `cell()` helper's job — so
+# the expected cells here are still backtick-wrapped, just not shifted into the wrong column)
+check("split_row: shell pipe in backticks stays one cell",
+      split_row("| 1 | `---` | `pytest -q | tail` | A-01 |")
+      == ["1", "`---`", "`pytest -q | tail`", "A-01"])
+check("split_row: regex alternation in backticks stays one cell",
+      split_row("| 1 | `---` | `grep -E 'foo|bar'` | A-01 |")
+      == ["1", "`---`", "`grep -E 'foo|bar'`", "A-01"])
+# escaped \| is a literal pipe in the cell, not a separator (unescaped in the output)
+check("split_row: escaped \\| unescaped, not a separator",
+      split_row(r"| 1 | a\|b | c |") == ["1", "a|b", "c"])
+# a plain row with no pipes/backticks/escapes is unchanged
+check("split_row: plain row unchanged",
+      split_row("| Task | Deps | Verify |") == ["Task", "Deps", "Verify"])
+
 # prefix-tolerant column access (the dev 'failing test (write first)' case)
 hdr = ["task", "deps", "failing test (write first)", "verify command"]
 check("col_index exact", col_index(hdr, "task") == 0)
@@ -53,10 +69,31 @@ check("find_table header", h == ["task", "deps", "verify command", "implements"]
 check("find_table rows", len(rows) == 2, rows)
 check("find_table miss → None", find_table(DOC, {"task", "deps", "outputs"}) == (None, None))
 
+# find_table: a data row's Verify Command cell carrying a shell pipe must not corrupt later rows
+DOC_PIPE = """| Task | Deps | Verify Command | Implements |
+|------|------|----------------|------------|
+| 1 | — | `pytest -q | tail` | R1 |
+| 2 | after 1 | `grep -E 'foo|bar'` | R2 |
+"""
+h2, rows2 = find_table(DOC_PIPE, {"task", "deps", "verify command"})
+check("find_table: piped verify cell doesn't shift columns", rows2[0] == ["1", "—", "`pytest -q | tail`", "R1"], rows2)
+check("find_table: regex-alternation verify cell doesn't shift columns", rows2[1] == ["2", "after 1", "`grep -E 'foo|bar'`", "R2"], rows2)
+
 # parse_deps: no-deps tokens, 'after' prefix, bare list, **markdown**
 check("parse_deps none", parse_deps("—") == [] and parse_deps("none") == [] and parse_deps("") == [])
 check("parse_deps after", parse_deps("after 1, 2") == ["1", "2"])
 check("parse_deps bare md", parse_deps("**T1**, T2") == ["T1", "T2"])
+
+# parse_deps: free text with an embedded digit must NOT become a phantom dep (P5/v5.68.3)
+check("parse_deps: free text doesn't sweep in a phantom dep",
+      parse_deps("T1 (needs config v2)") == ["T1"], parse_deps("T1 (needs config v2)"))
+viol = []
+deps = parse_deps("T1 (needs config v2)", viol, "Task 3: ")
+check("parse_deps: non-conforming residue reported as a violation, not silently dropped",
+      deps == ["T1"] and len(viol) >= 1 and "v2" not in deps and all("unparseable" in v for v in viol),
+      (deps, viol))
+check("parse_deps: violations is optional (default None → no crash, no reporting)",
+      parse_deps("T1 (needs config v2)") == ["T1"])
 
 # DAG: cycle detection + level toposort (deps already filtered to present ids)
 check("acyclic: clean DAG false", check_acyclic({"1": [], "2": ["1"], "3": ["1", "2"]}) is False)

--- a/workflows/templates/dev-task.js
+++ b/workflows/templates/dev-task.js
@@ -14,9 +14,13 @@
 // `artifactsPresent` — the core then ANDs pass && artifactsPresent (doctrine iii).
 // ============================================================================
 
+// SOLE owner of "is a test required?" (scripts/dev/dev_plan_table.py deliberately does not
+// duplicate this predicate — see its comment). Must stay in sync with the plan-template's N/A
+// convention: '', 'n/a', 'na', 'none', and any run of dash chars (-, –, —) all mean no test.
 const testRequired = t => {
   const n = String(t.failingTest || '').trim().toLowerCase()
-  return n !== '' && !/^(n\/?a|none)\b/.test(n)
+  if (n === '' || /^[-–—]+$/.test(n)) return false
+  return !/^(n\/?a|none)\b/.test(n)
 }
 
 // raw shape the independent probe agent returns (mapped into the canonical contract below)
@@ -108,7 +112,9 @@ function recheckTrigger(results, li) {
   const filesThisLevel = levels[li].flatMap(id => (byId[id] && byId[id].files) || [])
   if (!filesThisLevel.some(f => seenBefore.has(f))) return null
   return {
-    recheckKind: 'fullsuite', atLevel: li,
+    recheckKind: 'fullsuite',
+    // atLevel is NOT set here — it's always just an echo of `li`, so the core (run-core.js)
+    // supplies it directly from the loop variable rather than trusting the fragment to echo it back.
     payload: {
       decision: `Cross-level file overlap at level ${li}: run the full test suite before advancing. If green, resume with clearedFullSuite += ${li}; if red, fix via onlyChecks then resume.`,
       levelTasks: levels[li], filesThisLevel,

--- a/workflows/templates/run-core.js
+++ b/workflows/templates/run-core.js
@@ -31,8 +31,9 @@
 //                           (the runner-side probe is ALWAYS deterministic; the
 //                            semantic authority, if any, lives OUTSIDE run.js)
 //   implementerPrompt(t) -> string
-//   function recheckTrigger(results, li) -> { recheckKind, atLevel, payload } | null
-//                           (OPTIONAL — omit for domains with no mid-run recheck)
+//   function recheckTrigger(results, li) -> { recheckKind, payload } | null
+//                           (OPTIONAL — omit for domains with no mid-run recheck; do NOT
+//                            return atLevel — the core supplies it from `li` directly)
 //
 // Holes (each a block-comment token the compiler replaces verbatim, exactly once):
 //   __META__              meta object literal
@@ -40,6 +41,8 @@
 //   __TASKS__             array-of-task-spec literal (carries D3 columns + D4 tier)
 //   __GLOBAL_CONSTRAINTS__ verbatim Global Constraints body string literal ("" if none)
 //   __LEVEL_MODES__       per-level 'parallel'|'sequential' array (COMPILER-DERIVED intraLevel)
+//   __REQUIRE_OUTPUTS_PRODUCED__  bool literal: true forces the `outputsProduced` self-report
+//                          (ds); false leaves it optional/advisory (dev has no such field)
 //   __TASK_BODIES__       the per-domain code fragment (gateProbe/implementerPrompt/recheckTrigger)
 // ============================================================================
 
@@ -49,6 +52,7 @@ const PROJECT = /*__PROJECT__*/
 const TASKS   = /*__TASKS__*/
 const GLOBAL_CONSTRAINTS = /*__GLOBAL_CONSTRAINTS__*/
 const LEVEL_MODES = /*__LEVEL_MODES__*/   // intraLevel, derived by the compiler from declared-output disjointness + isolation-safety
+const REQUIRE_OUTPUTS_PRODUCED = /*__REQUIRE_OUTPUTS_PRODUCED__*/   // compiler-set: ds=true (output-first forcing function), dev=false
 
 // ── args (carry human decisions across pauses; Workflow scripts have no disk) ──
 let cfg = (typeof args === 'string') ? (() => { try { return JSON.parse(args) } catch { return {} } })() : (args || {})
@@ -56,7 +60,7 @@ const DECISIONS = cfg.decisions || {}                                  // { task
 const CLEARED   = new Set((cfg.clearedPauses || []).map(String))       // declared pauses already resolved
 const ONLY      = (Array.isArray(cfg.onlyChecks) && cfg.onlyChecks.length) ? new Set(cfg.onlyChecks.map(String)) : null
 const REVERIFY_DONE = !!cfg.reverifyDone                               // re-probe PLAN `[x]` tasks instead of blind-skipping (clobber-safe resume)
-const CLEARED_RECHECK = new Set((cfg.clearedFullSuite || cfg.clearedRecheck || []).map(Number))   // level indices whose yield-for-recheck the skill already passed
+const CLEARED_RECHECK = new Set((cfg.clearedFullSuite || []).map(Number))   // level indices whose yield-for-recheck the skill already passed
 
 // ── unified implementer-result schema (shared base + domain-optional fields) ──
 const TRANSFORM_SCHEMA = {
@@ -75,6 +79,10 @@ const TRANSFORM_SCHEMA = {
     verifyOutput: { type: 'string', description: 'dev: last ~25 lines of the Verify Command output you saw (proof)' },
   },
 }
+// ds forces the self-report: when REQUIRE_OUTPUTS_PRODUCED, `outputsProduced` must be present
+// AND true (not merely !== false) — restores the pre-extraction ds forcing function without
+// naming "ds" in the shared core (a compiled config hole flips it per-domain).
+if (REQUIRE_OUTPUTS_PRODUCED) TRANSFORM_SCHEMA.required.push('outputsProduced')
 
 // ── per-domain fragment (spliced ABOVE first use: gateProbe / implementerPrompt / recheckTrigger) ──
 /*__TASK_BODIES__*/
@@ -82,6 +90,11 @@ const TRANSFORM_SCHEMA = {
 // ── core helpers ──────────────────────────────────────────────────────────────
 const byId = Object.fromEntries(TASKS.map(t => [String(t.id), t]))
 
+// DEFERRED (see PR): unify this tie-breaker with scripts/lib/plan_table_core.toposort_ids's
+// Python twin (same numeric-suffix sort, independently maintained). Any change here must stay
+// ORDER-COMPATIBLE with that function — both must place the same task ids in the same levels
+// in the same order, since the compiler's LEVEL_MODES/tier decisions are computed over the
+// Python levels but the runtime driver walks these JS levels.
 function toposort(tasks) {
   const ids = new Set(tasks.map(t => String(t.id)))
   const deps = Object.fromEntries(tasks.map(t => [String(t.id), (t.deps || []).map(String).filter(d => ids.has(d))]))
@@ -112,7 +125,8 @@ async function runTask(t) {
   // 3. authoritative gate — fresh independent probe; the CORE ANDs pass && artifactsPresent
   //    (never trusts pass alone) so "gate passed but artifact missing/clobbered" stays a distinct finding.
   const gate = await gateProbe(t)
-  return { id: String(t.id), impl, gate, pass: !!gate.pass && gate.artifactsPresent !== false && impl.outputsProduced !== false }
+  const outputsOk = REQUIRE_OUTPUTS_PRODUCED ? impl.outputsProduced === true : impl.outputsProduced !== false
+  return { id: String(t.id), impl, gate, pass: !!gate.pass && gate.artifactsPresent !== false && outputsOk }
 }
 
 function scoreTable(state) {
@@ -154,7 +168,7 @@ function collect(state, extra = {}) {
     const impl = r.impl || {}
     const base = { severity: 'critical', task: t.id, summary: impl.summary || '', deviations: impl.deviations || '' }
     if (impl.status === 'blocked') findings.push({ ...base, detail: `R4 escalation: ${impl.deviations || 'blocked'}` })
-    else if (impl.outputsProduced === false) findings.push({ ...base, detail: 'declared Outputs not produced' })
+    else if (REQUIRE_OUTPUTS_PRODUCED ? impl.outputsProduced !== true : impl.outputsProduced === false) findings.push({ ...base, detail: 'declared Outputs not produced' })
     else if (r.gate && r.gate.artifactsPresent === false) {
       const miss = (r.gate.evidence && r.gate.evidence.missing) ? r.gate.evidence.missing : 'a declared artifact'
       findings.push({ ...base, detail: `gate passed but ${miss} missing/empty (stale/clobbered): ${(t.outputs || t.files || []).join(', ')}` })
@@ -188,6 +202,13 @@ for (let li = 0; li < levels.length; li++) {
   let results = []
   let levelDidWork = false
   if (todo.length) {
+    // Stamp the blind-skipped `[x]` tasks THIS layer also holds (a mixed level: some done, some
+    // todo) with the same skip-state shape the all-done branch below uses — otherwise they get
+    // no state entry at all, so collect() under-counts tasksDone/over-counts tasksRemaining and
+    // scoreTable shows '·' (never-run) for work that was already verified done.
+    layer.filter(t => !todo.includes(t)).forEach(t => {
+      state[String(t.id)] = { id: String(t.id), impl: null, gate: null, pass: true, skipped: true }
+    })
     phase(`Level ${li}`)
     log(`Level ${li}/${levels.length - 1}: [${todo.map(t => t.id).join(', ')}] (${mode})`)
     if (mode === 'parallel') {
@@ -218,11 +239,11 @@ for (let li = 0; li < levels.length; li++) {
   // RETURN-REASON 'yield-for-recheck' — an AUTOMATED cross-cutting gate (NO human decides; its own
   // channel, never muxed onto pause-human). The fragment decides whether this level needs it (dev:
   // cross-level file overlap → full suite); the core fires only when the level did real work, more
-  // levels remain, and the skill hasn't already cleared it. atLevel rides so the skill can resume
-  // with clearedFullSuite += atLevel.
+  // levels remain, and the skill hasn't already cleared it. atLevel is `li` itself — the fragment's
+  // recheckTrigger receives `li` as an argument, so it never needs to echo it back in its return.
   const rt = (typeof recheckTrigger === 'function') ? recheckTrigger(results, li) : null
   if (levelDidWork && rt && li < levels.length - 1 && !CLEARED_RECHECK.has(li)) {
-    return collect(state, { returnReason: 'yield-for-recheck', recheckKind: rt.recheckKind, atLevel: rt.atLevel, payload: rt.payload })
+    return collect(state, { returnReason: 'yield-for-recheck', recheckKind: rt.recheckKind, atLevel: li, payload: rt.payload })
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes 8 verified code-review findings on the pass-#9 shared compiled-runner core (`scripts/lib/plan_table_core.py`, `workflows/templates/run-core.js`, and the dev/ds fragments/compilers). Version bump assumes PR #50 (5.68.1) and the pending round-2 PR (5.68.2) land **before** this one — rebase/renumber if that ordering changes.

## What / why, per finding

1. **Pipe-safe cell splitting (high reachability).** `plan_table_core.split_row`/`find_table` split on bare `|`, so a Verify cell with a shell pipe (`` `pytest -q | tail` ``) or regex alternation (`` `grep -E 'foo|bar'` ``) shifted every later column — this was actively corrupting the repo's own `.planning/PLAN.md`. New `_split_cells()` helper is aware of escaped `\|` (unescaped to a literal pipe) and pipes inside backtick code spans; both split sites now share it.

2. **dev N/A-test convention drift.** `dev-task.js`'s `testRequired()` and the parser's now-deleted `_TEST_NA` disagreed on em/en-dash cells (`—`/`-`): the parser treated them as N/A, the compiled gate's predicate did not — a dash Failing-Test cell compiled but could never satisfy its own gate. `dev-task.js` is now the **sole owner** of the predicate (cross-referencing comment in both files); the parser's dead `test_required`/`_TEST_NA` are removed.

3. **ds prefix-tolerant header check.** ds's required-column check used exact `c not in header` while cell extraction is prefix-tolerant (dev already used the shared `has_col()`) — a qualified header like `Expected Output (per requirement)` was falsely rejected as missing. Now uses `plan_table_core.has_col()`.

4. **Restored ds's outputsProduced forcing function.** The run-core extraction silently weakened it from schema-required + `=== true` to optional + `!== false`. Restored via a compiled config hole `__REQUIRE_OUTPUTS_PRODUCED__`: `ds_compile.py` sets `True`, `dev_compile.py` sets `False`; `run-core.js` gates on it in both `TRANSFORM_SCHEMA.required` and the pass/collect logic — no domain names leak into the shared core.

5. **Deps-cell phantom-dep guard.** `parse_deps` swept the whole cell for digit-looking tokens, so free text like `T1 (needs config v2)` created a phantom dep on `v2`. Now splits on commas/whitespace (after stripping `after `/backticks) and requires each piece to fullmatch a dep token; non-conforming residue is dropped and, via an optional `violations` list threaded from both domain parsers, reported instead of silently becoming a dependency.

6. **Mixed-level skip stamping.** `run-core.js`'s mixed-level branch (some tasks done, some todo) never stamped a state entry for blind-skipped done tasks, so `collect()` under-reported `tasksDone`/over-reported `tasksRemaining` and `scoreTable` showed `·` for completed work. Now stamps the same skip-state shape the all-done branch uses.

7. **Cleanup.** Dropped the dead `cfg.clearedRecheck` alias (no producer exists). `recheckTrigger().atLevel` was always an echo of the `li` argument — the core now supplies `atLevel: li` directly; `dev-task.js` no longer returns the field.

8. **Guard-hook cleanup.** `dev-plan-executable-guard.py`'s docstring wrongly claimed it's wired via `dev-plan-reviewer` frontmatter (that skill is read-only, never writes `PLAN_REVIEWED.md`) — corrected to `dev-design/SKILL.md`. Both guard hooks now import their parser lazily inside `validate_plan()`, so the hundreds of unrelated Write/Edit hook firings per session skip the parser import.

## Deferred (not attempted)

- Extracting the duplicated compile driver (`dev_compile`/`ds_compile`) and guard shells into shared modules
- Dataflow (non-barrier) scheduling in run-core
- The pre-probe skip optimization
- `ds_compile._tier` keyword-sniffing → a real Tier column
- Unifying the Python/JS toposort tie-breakers — added a code comment at `run-core.js`'s `toposort` noting it must stay order-compatible with `plan_table_core.toposort_ids`

## Test plan

- [x] `uv run python3 tests/plan_table_core_test.py` — 30 passed, 0 failed (10 new)
- [x] `uv run python3 tests/dev_plan_table_test.py` — 38 passed, 0 failed (7 new)
- [x] `uv run python3 tests/ds_plan_table_test.py` — 17 passed, 0 failed (2 new)
- [x] `node tests/dev-run-driver.test.mjs` — 35 passed, 0 failed (pre-existing, unmodified — proves no regression)
- [x] `node tests/ds-run-driver.test.mjs` — 28 passed, 0 failed (pre-existing, unmodified)
- [x] `node tests/ds-grain-pause.test.mjs` — 17 passed, 0 failed (pre-existing, unmodified)
- [x] `py_compile` on all 7 edited `.py` files
- [x] `node --check` on `run-core.js`, `dev-task.js`, `ds-task.js`
- [x] End-to-end compile smoke: synthetic PLAN.md fixtures (piped verify cell, em-dash test cell, qualified ds header) compiled via both `dev_compile.py` and `ds_compile.py` — emitted `run.js` node-checks clean and contains the correctly-parsed verify strings + the compiled `REQUIRE_OUTPUTS_PRODUCED` flag (`false` for dev, `true` for ds)
- [x] Re-read every edited template-literal in `run-core.js`/`dev-task.js` for unbalanced backticks (known incident: `node --check` doesn't catch this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3NEAUUosUHyci4iFZBH2J