### PR TITLE
fix(workshop,workflow-creator): close verified code-review gaps (v5.68.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.68.0"
+    "version": "5.68.4"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.68.0",
+      "version": "5.68.4",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.68.0",
+  "version": "5.68.4",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/find-slide-page-inject.py
+++ b/hooks/find-slide-page-inject.py
@@ -24,7 +24,11 @@ from pathlib import Path
 
 
 TRIGGER_RE = re.compile(
-    r"tinymist\s+compile\b.*?\b(slides/\S+\.typ)\b",
+    # Any *.typ compile target, not just one under a literal `slides/` directory — workshop decks
+    # commonly compile `presentation/slides.typ` or a flat `slides.typ`, neither of which matched the
+    # old `slides/\S+\.typ` requirement. The find_scripts_dir() teaching-plugin lookup below stays the
+    # graceful no-op for machines without it — that part is by design, not part of this fix.
+    r"tinymist\s+compile\b.*?\b(\S+\.typ)\b",
 )
 
 

--- a/hooks/overflow-check.py
+++ b/hooks/overflow-check.py
@@ -25,6 +25,25 @@ def find_plugin_root() -> Path | None:
     return None
 
 
+TRIGGER_RE = re.compile(r'\b(?:typst|tinymist)\s+compile\b')
+
+
+def resolve_typ_target(command: str) -> str | None:
+    """Return the .typ compile target in `command`, or None if this isn't a typst/tinymist compile.
+
+    Triggers on both `typst compile` and `tinymist compile`. Tolerates flags between "compile" and
+    the target (e.g. `typst compile --input handout=true slides.typ`, `--root .`) by taking the LAST
+    `*.typ` token in the ;/&/|-delimited segment that contains the trigger, rather than requiring the
+    target to be the first token after "compile".
+    """
+    for seg in re.split(r'[;&|]+', command):
+        if TRIGGER_RE.search(seg):
+            typ_tokens = re.findall(r'([^\s]+\.typ)\b', seg)
+            if typ_tokens:
+                return typ_tokens[-1]
+    return None
+
+
 def main():
     try:
         hook_input = json.load(sys.stdin)
@@ -39,17 +58,13 @@ def main():
 
     command = tool_input.get("command", "")
 
-    # Only trigger on typst compile commands
-    if "typst compile" not in command:
+    # Trigger on both `typst compile` and `tinymist compile` (the compiler the workshop-generate
+    # ultracode workflow and visual-verify actually invoke), tolerating flags before the target —
+    # a substring check on "typst compile" alone silently skipped every tinymist-driven compile, and
+    # requiring the target as the first token after "compile" missed `--input`/`--root` forms.
+    typ_file = resolve_typ_target(command)
+    if not typ_file:
         sys.exit(0)
-
-    # Extract the .typ file being compiled
-    # Match patterns like: typst compile slides.typ, typst compile ./slides.typ
-    match = re.search(r'typst\s+compile\s+([^\s;&|]+\.typ)', command)
-    if not match:
-        sys.exit(0)
-
-    typ_file = match.group(1)
 
     # Only check slides files (not notes.typ or other .typ files)
     if "slides" not in Path(typ_file).stem:

--- a/hooks/phase-gate-guard.py
+++ b/hooks/phase-gate-guard.py
@@ -25,7 +25,15 @@ Usage in SKILL.md frontmatter:
               GATE_STATUS=APPROVED
               GATE_DESCRIPTION="Plan review"
               GATE_REMEDY="Return to dev-design and run dev-plan-reviewer"
+              GATE_BLOCKED_TOOLS=Agent
               uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
+
+LANDMINE: the `matcher` alone does NOT block a tool — it only decides which tool calls invoke this
+script. Blocking is decided here, by GATE_BLOCKED_TOOLS, which DEFAULTS to Write,Edit only (see
+DEFAULT_BLOCKED_TOOLS below). A matcher of "Write|Edit|Agent" with no GATE_BLOCKED_TOOLS=...,Agent
+fires this script on every Agent call but silently allows it through (tool_name not in blocked_tools
+=> sys.exit(0)) — a phantom gate that looks wired but never actually blocks the fan-out it names in
+its matcher. Always list every tool named in `matcher` in GATE_BLOCKED_TOOLS too.
 
 Grounded in: April 2026 meta-audit — workflow-creator found that advisory gates
 ("you must run X first") were systematically skipped under context pressure.

--- a/hooks/wc-constraint-check.py
+++ b/hooks/wc-constraint-check.py
@@ -10,7 +10,6 @@ keeping the PostToolUse hook (Layer 3) aligned with the full applicable set
 
 import importlib.util
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -27,6 +26,17 @@ CI_ONLY = {"atomic-constraints"}
 REPO_ROOT = Path(__file__).parent.parent
 CONSTRAINTS_DIR = REPO_ROOT / "references" / "constraints"
 
+# Import the SINGLE SOURCE OF TRUTH for applies-to parsing (scripts/load-constraints.py) by path,
+# rather than hand-rolling a regex here. The old hand-rolled regex only matched the bracketed list
+# form `applies-to: [a, b]` — a scalar `applies-to: workflow-creator` (no brackets) silently fell
+# through to "no frontmatter match ⇒ defaults to all", leaking wc-only constraints onto every edit
+# in the repo. parse_frontmatter/skill_matches handle both forms identically to check-all.py.
+_lc_spec = importlib.util.spec_from_file_location("load_constraints", REPO_ROOT / "scripts" / "load-constraints.py")
+_lc = importlib.util.module_from_spec(_lc_spec)
+_lc_spec.loader.exec_module(_lc)
+parse_frontmatter = _lc.parse_frontmatter
+skill_matches = _lc.skill_matches
+
 
 def applies_to_target(md_path):
     """True iff the .md's applies-to frontmatter includes workflow-creator or 'all'
@@ -35,14 +45,13 @@ def applies_to_target(md_path):
         text = md_path.read_text()
     except Exception:
         return False
-    if not text.startswith("---"):
-        return True  # no frontmatter ⇒ defaults to all
-    fm = text.split("---", 2)[1]
-    m = re.search(r'applies-to:\s*\[([^\]]*)\]', fm)
-    if not m:
-        return True
-    entries = [e.strip().strip("'\"").lower() for e in m.group(1).split(",")]
-    return "all" in entries or TARGET_SKILL in entries
+    meta, _body = parse_frontmatter(text)
+    applies_to = meta.get("applies-to", [])
+    if isinstance(applies_to, str):
+        applies_to = [applies_to]
+    if not applies_to:
+        applies_to = ["all"]
+    return skill_matches(applies_to, TARGET_SKILL)
 
 
 def applicable_checks():

--- a/hooks/workshop-phase-gate-guard.py
+++ b/hooks/workshop-phase-gate-guard.py
@@ -85,16 +85,43 @@ def deny(reason: str):
     sys.exit(0)
 
 
+def _is_workshop_generate_dispatch(tool_input: dict) -> bool:
+    """True iff this Workflow tool call dispatches workshop-generate (the Phase 2->3 fan-out that
+    actually writes slides.typ/notes.typ). The Edit|Write-only check below never saw this dispatch —
+    Workflow calls carry no file_path, so a skipped OUTLINE_APPROVED step could still start generation
+    via Workflow even though direct Edit/Write to the content files was gated."""
+    target = f"{tool_input.get('scriptPath', '')} {tool_input.get('name', '')}"
+    return "workshop-generate" in target
+
+
 def main():
     try:
         hook_input = json.load(sys.stdin)
     except Exception:
         sys.exit(0)
 
-    if hook_input.get("tool_name", "") not in {"Write", "Edit"}:
+    tool_name = hook_input.get("tool_name", "")
+    tool_input = hook_input.get("tool_input", {})
+
+    if tool_name == "Workflow":
+        if not _is_workshop_generate_dispatch(tool_input):
+            sys.exit(0)
+        if not _status_ok(GATE_ARTIFACT, GATE_STATUS):
+            deny(
+                f"GATE BLOCKED: outline not approved.\n\n"
+                f"Dispatching workshop-generate requires `{GATE_ARTIFACT}` with "
+                f"`status: {GATE_STATUS}` — the Phase 2 outline-approval gate.\n\n"
+                f"The artifact proves the user approved the outline before slide/notes "
+                f"generation. Instructional text alone is not enforcement.\n\n"
+                f"**Remedy:** Return to Phase 2 (Structure Outline), get user approval, "
+                f"and write `.planning/OUTLINE_APPROVED.md`."
+            )
         sys.exit(0)
 
-    file_path = hook_input.get("tool_input", {}).get("file_path", "")
+    if tool_name not in {"Write", "Edit"}:
+        sys.exit(0)
+
+    file_path = tool_input.get("file_path", "")
 
     # Phase 3 -> 4 gate: the VALIDATION.md verification record requires a passed
     # workshop-verify review gate. Checked before the always-allowed .planning

--- a/scripts/wc/wc_file_set.py
+++ b/scripts/wc/wc_file_set.py
@@ -68,10 +68,18 @@ def _manifest_block(text: str) -> str | None:
     return text[start: start + nxt.start()] if nxt else text[start:]
 
 
+def _strip_inline_comment(s: str) -> str:
+    """Strip a trailing ' # ...' / '\\t# ...' inline comment (the module's own docstring example
+    annotates `midpoint: fix  # one of: fix | debug | revise | none` this way — without this, the
+    docstring's own example manifest fails validation)."""
+    m = re.search(r"[ \t]#", s)
+    return (s[:m.start()] if m else s).rstrip()
+
+
 def _field(body: str, key: str) -> str | None:
     # [ \t] (not \s) so an empty value doesn't swallow the next line's content.
     m = re.search(rf"^[ \t]*{key}[ \t]*:[ \t]*(\S.*?)[ \t]*$", body, re.M | re.I)
-    return m.group(1).strip() if m else None
+    return _strip_inline_comment(m.group(1).strip()) if m else None
 
 
 def parse_design(text: str, project: Path | None = None) -> FileSet:
@@ -112,7 +120,7 @@ def parse_design(text: str, project: Path | None = None) -> FileSet:
                 if ls and not ls.startswith("#"):
                     break  # left the constraints block
                 continue
-            item = ls.lstrip("-").strip()
+            item = _strip_inline_comment(ls.lstrip("-").strip())
             parts = [x.strip() for x in item.split("|")]
             cname = parts[0]
             kind = (parts[1].lower() if len(parts) > 1 else "convention")

--- a/scripts/workshop/workshop_slide_table.py
+++ b/scripts/workshop/workshop_slide_table.py
@@ -58,7 +58,9 @@ _INV_TAIL_RE = re.compile(r'(?:→|->)?\s*\[(?P<ids>[^\]]*)\]\s*$')
 
 def section_slug(name: str) -> str:
     """Unicode-safe slug (NFC; em-dash/colon survive as separators). Mirrors
-    writing_section_index.section_slug — used to key OUTLINE rows for the verify side-table join."""
+    writing_section_index.section_slug. Public utility kept for tests/future use — the
+    Slide.title_slug field this once fed was dead code (zero downstream consumers; workshop-verify's
+    OUTLINE-row↔built-slide join stays a free semantic read, DESIGN §3a-join) and was removed."""
     s = unicodedata.normalize("NFC", name).strip()
     s = re.sub(r"[^\w]+", "-", s, flags=re.UNICODE).strip("-")
     return s
@@ -76,14 +78,13 @@ class Slide:
     inventory: list[str]        # F/T/R/A ids (literal tokens; ranges kept as endpoints)
     visual: str                 # table-only ("" in prose form)
     notes: str                  # table-only ("" in prose form)
-    title_slug: str             # section_slug(takeaway) — the join key candidate for verify
 
     def to_dict(self) -> dict:
         return {
             "num": self.num, "part": self.part, "section": self.section,
             "subsection": self.subsection, "group": self.group, "takeaway": self.takeaway,
             "bullets": self.bullets, "inventory": self.inventory, "visual": self.visual,
-            "notes": self.notes, "titleSlug": self.title_slug,
+            "notes": self.notes,
         }
 
 
@@ -183,8 +184,7 @@ def _parse_table(text: str, idx: SlideIndex) -> None:
         group = f"{sec} / {sub}" if sub else sec
         idx.slides.append(Slide(
             num=n, part="", section=sec, subsection=sub, group=group, takeaway=takeaway,
-            bullets=_cell(header, cells, "bullets"), inventory=inv, visual=visual, notes=notes,
-            title_slug=section_slug(takeaway)))
+            bullets=_cell(header, cells, "bullets"), inventory=inv, visual=visual, notes=notes))
     if not seen:
         idx.violations.append("Slide Spec table has no slide rows.")
 
@@ -228,8 +228,7 @@ def _parse_prose(text: str, idx: SlideIndex) -> None:
         inv = _inv_tokens(inv_cell)
         idx.slides.append(Slide(
             num=n, part=part, section=section, subsection=subsection, group=group,
-            takeaway=takeaway, bullets=bullets, inventory=inv, visual="", notes="",
-            title_slug=section_slug(takeaway)))
+            takeaway=takeaway, bullets=bullets, inventory=inv, visual="", notes=""))
         # Prose-form violations (4-field subset — Visual/Notes NOT required here, back-compat):
         if not takeaway:
             idx.violations.append(f"Slide {n}: no takeaway sentence parsed from prose row.")
@@ -269,6 +268,7 @@ def build_index(arg) -> SlideIndex:
     planning = outline.parent
     sources = planning / "SOURCES.md"
     idx.sources_path = str(sources) if sources.is_file() else ""
+    src = ""
     if idx.sources_path:
         src = sources.read_text(encoding="utf-8", errors="ignore")
         # first "- Path:" line (tolerate bold markers: "- **Path:**"); it is the primary paper.
@@ -298,8 +298,8 @@ def build_index(arg) -> SlideIndex:
             idx.group_order.append(sl.group)
 
     # dangling inventory ref check + the canonical ID universe (verify's whitelist; only if SOURCES present)
+    # Reuses `src` read once above — was previously read a second time here.
     if idx.sources_path:
-        src = sources.read_text(encoding="utf-8", errors="ignore")
         known = set(_INV_TOK_RE.findall(src))
         idx.sources_inventory = sorted(known, key=lambda t: (t[0], int(t[1:])))
         for sl in idx.slides:

--- a/skills/workflow-creator/SKILL.md
+++ b/skills/workflow-creator/SKILL.md
@@ -351,8 +351,11 @@ hooks:
             GATE_STATUS=APPROVED
             GATE_DESCRIPTION="Plan review"
             GATE_REMEDY="Return to dev-design and run dev-plan-reviewer"
+            GATE_BLOCKED_TOOLS=Agent
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
 ```
+
+**Landmine: `matcher` and `GATE_BLOCKED_TOOLS` are two separate lists that must agree.** `matcher` only decides which calls invoke the script; `phase-gate-guard.py` only actually blocks tools named in `GATE_BLOCKED_TOOLS` (default `Write,Edit` — Agent is NOT blocked unless you list it). A matcher of `Write|Edit|Agent` with no `GATE_BLOCKED_TOOLS=...,Agent` fires on every `Agent` call but silently lets it through — a gate that looks wired but never blocks the fan-out it names.
 
 **How it works:**
 1. Producing phase writes `.planning/X_REVIEWED.md` with `status: APPROVED` frontmatter (unchanged)

--- a/skills/workshop/SKILL.md
+++ b/skills/workshop/SKILL.md
@@ -7,7 +7,7 @@ hooks:
       hooks:
         - type: command
           command: "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/image-read-guard.py"
-    - matcher: "Edit|Write"
+    - matcher: "Edit|Write|Workflow"
       hooks:
         - type: command
           command: >-
@@ -15,8 +15,15 @@ hooks:
             GATE_STATUS=VERIFIED
             GATE_DESCRIPTION="Phase 1 sources gate"
             GATE_REMEDY="Return to Phase 1 and complete source gathering before writing any files"
+            GATE_BLOCKED_TOOLS=Write,Edit
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
         - type: command
+          # workshop-phase-gate-guard.py is bespoke (not built on the GATE_BLOCKED_TOOLS env-var
+          # pattern) — it hardcodes its own tool-name check to Write|Edit|Workflow so it can gate BOTH
+          # direct writes to slides.typ/notes.typ AND the Workflow(name="workshop-generate", ...)
+          # dispatch that actually produces them (a Workflow call carries no file_path, so the
+          # Edit|Write-only check alone never saw it — the OUTLINE_APPROVED gate could be bypassed by
+          # generation starting via Workflow before any Edit/Write landed).
           command: "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/workshop-phase-gate-guard.py"
         - type: command
           command: "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/workshop-outline-executable-guard.py"
@@ -639,11 +646,11 @@ Generation is the **`workshop-generate` ultracode workflow** — do NOT hand-wri
      "pluginRoot": "<resolve ${CLAUDE_SKILL_DIR}/../../workflows>",
      "slideIndex": <the parsed .planning/slide-index.json object, or omit to use the LLM Discover>
    })
-   → returns { overallPass, slides, compiled, findings, slidesThatFailed, assembledPaths }.
+   → returns { overallPass, sections, compiled, findings, sectionsThatFailed, assembledPaths }.
 2. Read the gate:
-   - overallPass=true (every slide fragment produced + deck compiles) → proceed to the review fan-out below.
+   - overallPass=true (every section fragment produced + deck compiles) → proceed to the review fan-out below.
    - overallPass=false → fix the cause (a missing fragment / a compile error / an out-of-inventory citation),
-     re-invoke with onlyChecks=result.slidesThatFailed. If a Slide Spec row is itself under-specified,
+     re-invoke with onlyChecks=result.sectionsThatFailed. If a Slide Spec row is itself under-specified,
      that's an R4 — return to Phase 2, fix the row, re-approve (the outline guard re-checks).
 3. The Typst conventions above are what the fragment-agents follow; the assembly agent owns the file header
    (theme import + config-info incl qr:none) and the section headings. The deck COMPILING is the workflow's

--- a/tests/overflow_check_test.py
+++ b/tests/overflow_check_test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S uv run python3
+"""overflow-check.py trigger/target-extraction regression tests. Run: uv run python3 tests/overflow_check_test.py"""
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "hooks" / "overflow-check.py"
+spec = importlib.util.spec_from_file_location("overflow_check", HOOK_PATH)
+overflow_check = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(overflow_check)  # noqa: E402
+
+P, F = 0, 0
+
+
+def check(name, cond, extra=""):
+    global P, F
+    if cond:
+        P += 1; print(f"  ok  {name}")
+    else:
+        F += 1; print(f"  FAIL {name} {extra}")
+
+
+resolve = overflow_check.resolve_typ_target
+
+# (a) both compilers trigger; (b) flags before the target don't break extraction.
+check("bare typst compile", resolve("typst compile slides.typ") == "slides.typ")
+check("typst compile with --input first", resolve("typst compile --input handout=true slides.typ") == "slides.typ")
+check("tinymist compile", resolve("tinymist compile slides.typ") == "slides.typ")
+check("tinymist compile nested path", resolve("tinymist compile presentation/slides.typ") == "presentation/slides.typ")
+check("typst compile --root form", resolve("typst compile --root . slides/lecture1.typ") == "slides/lecture1.typ")
+check("cd prefix + typst compile", resolve("cd foo && typst compile slides.typ") == "slides.typ")
+check("non-compile command: no trigger", resolve("typst watch slides.typ") is None)
+check("unrelated command: no trigger", resolve("ls -la") is None)
+
+# fail-open on malformed / non-Bash / non-triggering stdin.
+def run_hook(stdin_text):
+    return subprocess.run([sys.executable, str(HOOK_PATH)], input=stdin_text, capture_output=True, text=True, timeout=10)
+
+check("malformed JSON -> exit 0", run_hook("not json").returncode == 0)
+check("empty object -> exit 0", run_hook("{}").returncode == 0)
+check("non-Bash tool -> exit 0", run_hook(json.dumps({"tool_name": "Read", "tool_input": {}})).returncode == 0)
+check(
+    "tinymist compile via Bash tool -> exit 0 (no crash even if plugin root / check script unresolved)",
+    run_hook(json.dumps({"tool_name": "Bash", "tool_input": {"command": "tinymist compile slides.typ"}})).returncode == 0,
+)
+
+print(f"\n{P} passed, {F} failed")
+sys.exit(1 if F else 0)

--- a/tests/wc_file_set_test.py
+++ b/tests/wc_file_set_test.py
@@ -73,5 +73,21 @@ check("bad: flags non-slug constraint", any("Bad Name" in v for v in b.violation
 dup = parse_design(CANONICAL.replace("phases: explore, design, implement", "phases: a, b, a"), Path("/p"))
 check("dup phases: flagged", any("duplicate phase" in v for v in dup.violations))
 
+# the module's OWN docstring example (with an inline `# one of: ...` comment on midpoint:) must parse
+# clean — this is the module eating its own cooking; a stray inline comment previously fed straight
+# into the `midpoint` value and failed validation against _MIDPOINTS.
+DOCSTRING_EXAMPLE = """## Generation Manifest
+<!-- wc-generate enumerates the file set from this section. Keep it canonical. -->
+workflow: myflow
+midpoint: fix                 # one of: fix | debug | revise | none
+phases: explore, design, implement
+constraints:
+- no-skip-tests | testable
+- naming-convention | convention
+"""
+doc = parse_design(DOCSTRING_EXAMPLE, Path("/p"))
+check("docstring example: ok", doc.ok, doc.violations)
+check("docstring example: midpoint skill present (comment stripped)", "skill:myflow-fix" in [f["fileId"] for f in doc.files])
+
 print(f"\n{P} passed, {F} failed")
 sys.exit(1 if F else 0)

--- a/tests/workshop-engine-discover.test.mjs
+++ b/tests/workshop-engine-discover.test.mjs
@@ -61,7 +61,11 @@ const INDEX = {
   }
   const { result, trace } = await exec(genSrc, { args: { projectDir: '/p', slideIndex: INDEX }, onAgent })
   ok('gen: no LLM discover when index present', !trace.labels.includes('discover'))
-  ok('gen: one section agent per composite group (2)', trace.labels.filter(l => l.startsWith('section:')).length === 2)
+  // Exact "section:<id>" draft labels only — a probe agent "section:<id>:probe" now also chains onto
+  // each draft (independent grep re-check of citedInventory, gateProbe doctrine), so a loose
+  // startsWith('section:') match would double-count.
+  ok('gen: one section agent per composite group (2)', trace.labels.filter(l => /^section:\d+$/.test(l)).length === 2)
+  ok('gen: one probe agent per drafted section (2)', trace.labels.filter(l => /^section:\d+:probe$/.test(l)).length === 2)
   ok('gen: assemble ran', trace.labels.includes('assemble'))
   ok('gen: overallPass true (all groups drafted + compiles)', result.overallPass === true, JSON.stringify(result?.verdict))
   ok('gen: assemble prompt constructs header (fileHeader empty → instruction)',
@@ -154,7 +158,9 @@ function makeVerifyMock(extraSlides = []) {
   // D1 scope disclosure (move 2 / §4b): a clean pass discloses checked vs notChecked.
   ok('verify scope: checked lists typst compile', (result.scope?.checked || []).some(s => /typst compile/.test(s)), JSON.stringify(result.scope))
   ok('verify scope: notChecked discloses the SEMANTIC reviewers are outside the floor', (result.scope?.notChecked || []).some(s => /SEMANTIC/.test(s)))
-  ok('verify scope: notChecked discloses constraints caveat (phantom/permanently-red)', (result.scope?.checked || []).some(s => /permanently red|phantom/.test(s)))
+  // D-w-8 fix: check-all.py's JSON failed[]/errors[] split is now parsed (not a permanently-red exit
+  // code), so the caveat text changed from "phantom/permanently red" to describing the split itself.
+  ok('verify scope: checked discloses the failed[]/errors[] split (was: exit-code phantom/permanently-red)', (result.scope?.checked || []).some(s => /failed\[\]/.test(s) && /errors\[\]/.test(s)))
 }
 {
   // compile-fail short-circuit also carries scope (honest about what it skipped).

--- a/workflows/wc-audit.js
+++ b/workflows/wc-audit.js
@@ -364,7 +364,7 @@ phase('Verify')
 const gapsToVerify = []
 for (const c of ARCH_CLUSTERS) {
   const dim = byDim[c.key]
-  if (!dim || ONLY) continue // only verify freshly-reviewed clusters; carried ones keep their prior verdict
+  if (!dim || (ONLY && !ONLY.has(c.key))) continue // only verify freshly-reviewed clusters; carried ones keep their prior verdict
   for (const p of (dim.principles || [])) {
     if (p.score < 9 && p.gap && !p.domainCeiling) {
       gapsToVerify.push({ id: p.id, score: p.score, gap: p.gap, evidence: p.evidence })
@@ -384,6 +384,14 @@ Decide: is the gap REAL? Default to skepticism — if the cited evidence does no
 const correction = new Map()
 for (const v of verifyResults) if (v && v.confirmed === false) correction.set(String(v.principleId), v.correctedScore)
 if (gapsToVerify.length) log(`Verified ${gapsToVerify.length} gap(s); ${correction.size} refuted (re-scored up)`)
+// Write corrections back into the review records themselves (not just scoreById) so a future
+// selective re-audit's priorReviews carry the CORRECTED verdict — otherwise reviewersThatFlagged
+// re-flags a refuted phantom finding forever, since carried reviews would still show the raw score.
+for (const r of reviews) {
+  for (const p of (r.principles || [])) {
+    if (correction.has(p.id)) { p.score = correction.get(p.id); p.gap = '' }
+  }
+}
 
 // ── Phase 4: Gate (pure JS — composite from raw scores; NEVER trust a self-reported composite) ─
 phase('Gate')
@@ -515,7 +523,7 @@ const scoreTable = [
   `| Enforcement checklist | ${enf ? `${(enf.patterns || []).filter(p => p.status === 'Present').length}/${(enf.patterns || []).length} Present` : 'n/a'} | ${enf && (enf.patterns || []).every(p => p.status !== 'Absent') ? '✅' : '⚠️'} |`,
   `| Path portability | ${port ? port.status : 'n/a'} | ${port && port.status === 'Clean' ? '✅' : '❌'} |`,
   `| Ultracode-workflow candidacy | ${cand ? `${(cand.candidates || []).filter(c => c.recommend === 'strong' || c.recommend === 'moderate').length} open` : 'n/a'} | ${cand && !(cand.candidates || []).some(c => c.recommend === 'strong') ? '✅' : '⚠️'} |`,
-  `| Runner architecture | ${runnerApplicable ? `${executionClass} (P22-26 scored)` : `${executionClass} — N/A`} | ${executionClass === 'generic-interpreter' ? '❌' : '✅'} |`,
+  `| Runner architecture | ${runnerApplicable ? `${executionClass} (P22-30 scored)` : `${executionClass} — N/A`} | ${executionClass === 'generic-interpreter' ? '❌' : '✅'} |`,
   `| Critical findings | ${criticalCount} | ${criticalCount === 0 ? '✅' : '❌'} |`,
   `| **Substrate gate** | 0 crit / ${enfAbsent.length} enf-Absent / portability ${portStatus} | ${substratePass ? '✅' : '❌'} |`,
   `| **Overall** | substrate ${substratePass ? 'clean' : 'FAILED'} + composite ${composite} vs ${THRESHOLD} | ${overallPass ? '✅ PASS' : '❌ NEEDS WORK'} |`,

--- a/workflows/workshop-generate.js
+++ b/workflows/workshop-generate.js
@@ -25,6 +25,7 @@ const PRIOR = new Map((Array.isArray(cfg.priorReviews) ? cfg.priorReviews : []).
 // projects). The fileHeader (theme preamble) is NOT a work-list concern → the assembly agent constructs
 // it from templates + SOURCES.md, so discFromIndex stays 100% deterministic (no LLM).
 const SLIDE_INDEX = (cfg.slideIndex && Array.isArray(cfg.slideIndex.slides) && cfg.slideIndex.slides.length) ? cfg.slideIndex : null
+const SEV_RANK = { critical: 0, major: 1, minor: 2 }
 
 const SLIDE = {
   type: 'object', additionalProperties: false,
@@ -58,6 +59,18 @@ const SECTION_SCHEMA = {
     slideNums: { type: 'array', items: { type: 'string' }, description: 'the slide numbers this section file covers (must equal the section\'s spec rows)' },
     citedInventory: { type: 'array', items: { type: 'string' }, description: 'inventory ids cited across the section (⊆ the union of its slides\' allowed ids)' },
     summary: { type: 'string' },
+  },
+}
+// Independent mechanical probe (mirrors run-core's gateProbe doctrine): the section agent's
+// citedInventory is self-reported (it greps its own fragment and echoes tokens) — nothing deterministic
+// re-checked it. workshop-verify's whitelist covers OUTLINE inventoryRefs, not grepped fragment tokens.
+// This workflow has no filesystem access itself, so a second, CHEAP, low-effort agent re-runs the exact
+// grep independently and its tokens (not the section agent's self-report) are what the gate trusts.
+const PROBE_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['section', 'tokens'],
+  properties: {
+    section: { type: 'string' },
+    tokens: { type: 'array', items: { type: 'string' }, description: 'exact, verbatim output of the grep command — do not add, remove, or further dedupe' },
   },
 }
 const ASSEMBLE_SCHEMA = {
@@ -145,7 +158,17 @@ WRITE two files (mkdir -p ${disc.fragmentsDir} first):
 - ${disc.fragmentsDir}/notes-section-${sec.id}.typ — flowing speaker-notes for this section (one block per slide, with timing from each slide's Notes). Write PLAIN Typst prose + bullets ONLY — NO custom note macros (do NOT invent \`#slide-notes\`/\`#speaker-note\`/etc.; assembly adds the \`= Section\` heading + the standard notes preamble, and the gate now COMPILES notes.typ, so an invented macro breaks the build).
 GROUND citedInventory IN THE FILE (not memory): after writing, run \`grep -ohE '[FTRA][0-9]+' ${disc.fragmentsDir}/section-${sec.id}.typ | sort -u\` and set citedInventory to EXACTLY that grep output — the actual inventory ids present in the fragment you wrote. (The gate checks this ⊆ the allowed set; a memory-reported list that disagrees with the file is the fidelity bug this step closes.)
 Return SECTION_SCHEMA: slidesPath, notesPath, slideNums (must equal ${JSON.stringify(sec.slides.map(s => s.num))}), citedInventory (the grep result, ⊆ the allowed set), summary.`,
-    { label: `section:${sec.id}`, phase: 'Sections', schema: SECTION_SCHEMA })
+    { label: `section:${sec.id}`, phase: 'Sections', schema: SECTION_SCHEMA }
+  ).then(secResult => {
+    // Pipeline the independent probe onto this section's draft (no extra barrier): only probe a
+    // section that actually reports a drafted fragment file.
+    if (!secResult || secResult.status !== 'drafted' || !(secResult.slidesPath || '').trim()) return secResult
+    return agent(
+      `Run this EXACT command and report its output — do not inspect the file's content beyond running the command, do not reason about correctness, just grep and report: \`grep -ohE '[FTRA][0-9]+' ${secResult.slidesPath} | sort -u\`
+Set section="${sec.id}" verbatim. tokens = the command's stdout, one token per line, verbatim (the command already sorts + dedupes — do not add/remove/reorder). Return PROBE_SCHEMA.`,
+      { label: `section:${sec.id}:probe`, phase: 'Sections', schema: PROBE_SCHEMA, model: 'haiku', effort: 'low' }
+    ).then(probe => ({ ...secResult, probedInventory: probe ? probe.tokens : null }))
+  })
 }))).filter(Boolean)
 const secById = Object.fromEntries(liveSecs.map(s => [String(s.section), s]))
 const allSecs = sectionList.map(s => secById[s.id] || (PRIOR.has(s.id) ? PRIOR.get(s.id) : null))
@@ -187,7 +210,11 @@ for (const sec of sectionList) {
   const wrote = new Set((f?.slideNums || []).map(String))
   const completeSlides = drafted && [...expected].every(n => wrote.has(n))
   const allowed = new Set(sec.slides.flatMap(s => (s.inventory || []).map(String)))
-  const fidelityOk = !f || (f.citedInventory || []).every(id => allowed.has(String(id)))
+  // Trust the INDEPENDENT probe's grepped tokens over the section agent's self-reported citedInventory
+  // when a probe ran (gateProbe doctrine) — self-report is not ground truth. Fall back to the
+  // self-report only when no probe result exists (e.g. a carried PRIOR review from before this fix).
+  const citedTokens = (f && Array.isArray(f.probedInventory)) ? f.probedInventory : (f?.citedInventory || [])
+  const fidelityOk = !f || citedTokens.every(id => allowed.has(String(id)))
   rows.push({ section: sec.id, key: sec.key, slideCount: sec.slides.length, drafted, completeSlides, fidelityOk })
   if (!drafted) findings.push({ severity: 'critical', section: sec.id, detail: `Section "${sec.key}": fragment not produced (status=${f ? f.status : 'missing'})` })
   else if (!completeSlides) findings.push({ severity: 'major', section: sec.id, detail: `Section "${sec.key}": missing slides ${[...expected].filter(n => !wrote.has(n)).join(', ')}` })
@@ -199,7 +226,7 @@ if (haveAll && !compiled) findings.push({ severity: 'critical', section: 'deck',
 // notes.typ is a first-class teleprompter deliverable — gate it, don't ship malformed notes (opv-parity).
 if (haveAll && compiled && !notesCompiled) findings.push({ severity: 'critical', section: 'deck', detail: `notes.typ did not compile: ${(asm?.notesCompileError || 'unknown').slice(0, 300)}` })
 if (!haveAll) findings.push({ severity: 'critical', section: 'deck', detail: 'Not all sections have fragments — assembly skipped' })
-findings.sort((a, b) => ({ critical: 0, major: 1, minor: 2 }[a.severity] - { critical: 0, major: 1, minor: 2 }[b.severity]))
+findings.sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity])
 
 const allDrafted = rows.length > 0 && rows.every(r => r.drafted && r.completeSlides && r.fidelityOk)
 const overallPass = allDrafted && compiled && notesCompiled

--- a/workflows/workshop-verify.js
+++ b/workflows/workshop-verify.js
@@ -10,6 +10,8 @@ export const meta = {
   ],
 }
 
+const SEV_RANK = { critical: 0, major: 1, minor: 2 }
+
 // ── Read-only enforcement (P17) ───────────────────────────────────────────────
 // Every reviewer agent() below opens with a "You are a READ-ONLY reviewer; do NOT
 // create, edit, or overwrite any files" instruction. This is PROMPT-level, not
@@ -90,12 +92,13 @@ const DISCOVERY_SCHEMA = {
 
 const MECHANICAL_SCHEMA = {
   type: 'object', additionalProperties: false,
-  required: ['slidesCompiled', 'notesCompiled', 'compileErrors', 'constraintsPassed', 'constraintFailures', 'widows', 'overflow'],
+  required: ['slidesCompiled', 'notesCompiled', 'compileErrors', 'constraintsPassed', 'constraintFailures', 'constraintErrors', 'widows', 'overflow'],
   properties: {
     slidesCompiled: { type: 'boolean' }, notesCompiled: { type: 'boolean' },
     compileErrors: { type: 'array', items: { type: 'string' } },
-    constraintsPassed: { type: 'boolean' },
-    constraintFailures: { type: 'array', items: { type: 'string' }, description: 'raw FAIL lines from check-all.py' },
+    constraintsPassed: { type: 'boolean', description: 'true iff the parsed JSON failed[] array is empty (NOT the process exit code — exit 1 also fires on errors[]-only, which is infra, not a deck defect)' },
+    constraintFailures: { type: 'array', items: { type: 'string' }, description: 'one entry per check-all.py JSON failed[] item: "<name>: <violations summary>" — real constraint violations, blocking' },
+    constraintErrors: { type: 'array', items: { type: 'string' }, description: 'one entry per check-all.py JSON errors[] item: "<name>: <error>" — constraint-module infra failures (import/exception), NOT deck defects, non-blocking' },
     widows: { type: 'integer', description: 'widow count from detect_widows.py on slides.pdf (0 = clean)' },
     overflow: { type: 'integer', description: 'count of slides that overflow the frame (0 = clean)' },
   },
@@ -158,6 +161,7 @@ const disc = await agent(
 Return DISCOVERY_SCHEMA. Absolute paths only.`,
   { label: 'discover', phase: 'Discover', schema: DISCOVERY_SCHEMA, model: 'sonnet' }
 )
+if (!disc) throw new Error('Discover agent returned null — re-invoke')
 if (!disc.slides.length) throw new Error('No slides discovered — check slides.typ exists with #slide[ ... ] blocks')
 
 // Deterministic inventory WHITELIST (DESIGN §3a-join): the join stayed unbiased (free OUTLINE read);
@@ -181,14 +185,31 @@ const mech = await agent(
   `You are a READ-ONLY mechanical verifier. Do NOT create, edit, or overwrite any .typ files. Working directory: ${disc.presentationDir}
 
 1. Compile both decks: \`typst compile slides.typ\` and \`typst compile notes.typ\`. Record slidesCompiled/notesCompiled and any error text in compileErrors. If slides.typ fails to compile, STILL return (the gate will short-circuit) — do not attempt the steps below.
-2. Constraint checks (auto-discovers all .py): \`uv run python3 ${disc.checkAllPath} .\` — set constraintsPassed from exit code (0 = pass), and copy every "FAIL:" line into constraintFailures.
+2. Constraint checks (auto-discovers all .py): \`uv run python3 ${disc.checkAllPath} .\` — this prints a JSON object (NOT "FAIL:" lines) with keys passed/failed/conventions/errors/skipped, followed by a summary line. Parse the JSON. For each entry in failed[] (each is {name, violations}), add one string "<name>: <violations summary>" to constraintFailures — these are real constraint violations. For each entry in errors[] (each is {name, error}), add one string "<name>: <error>" to constraintErrors — these are constraint-module infra failures (import/exception), NOT deck defects; do not put them in constraintFailures. Set constraintsPassed = (failed[] is empty) — do NOT use the process exit code, which is also 1 when only errors[] is non-empty.
 3. PDF widow detection (only if slides.pdf built): ${disc.detectWidowsPath ? `\`uv run python3 ${disc.detectWidowsPath} slides.pdf\`` : 'no detector resolved — set widows=0'} — widows = number of widow lines reported (0 if exit 0).
-4. Overflow (PER-SLIDE, THEME-AGNOSTIC — do NOT use page-count arithmetic; it both over-counts theme pages and can MASK real spill): compile handout mode \`typst compile slides.typ --input handout=true slides-handout.pdf\`, then decide PER SLIDE whether its OWN content spills. Method: extract per-page text (e.g. \`pdftotext -layout -f N -l N slides-handout.pdf -\` per page, or look_at per page) and map each \`#slide[]\` block to the handout page(s) carrying its \`=== <takeaway>\` title. A slide OVERFLOWS iff its content occupies ≥2 CONSECUTIVE handout pages AND the slide block contains NO \`#pause\` (\`#pause\` legitimately produces multiple BUILD pages — that is NOT spill; grep the block for \`#pause\` and exclude those). Pages with no \`===\` title (title slide, TOC/\`#outline\`, \`=\`/\`==\` dividers) are STRUCTURAL — ignore them entirely; never infer overflow from \`handout_pages − slide_count\`. overflow = count of slides that occupy ≥2 pages with no \`#pause\`. If you genuinely cannot map a slide to its pages, set overflow=0 and say so (a false NEGATIVE that hides a clipped slide is worse than a missed warning — but a guessed page-arithmetic positive/negative is worst). Report the offending slide titles in context if overflow>0.
+4. Overflow (PER-SLIDE, THEME-AGNOSTIC — do NOT use page-count arithmetic; it both over-counts theme pages and can MASK real spill): compile handout mode \`typst compile slides.typ --input handout=true slides-handout.pdf\`, then decide PER SLIDE whether its OWN content spills. Method: extract ALL page text in ONE pass — \`pdftotext -layout slides-handout.pdf -\` (form-feed \\x0c separates pages; split on it to get per-page text) rather than N separate \`-f/-l\` invocations — and map each \`#slide[]\` block to the handout page(s) carrying its \`=== <takeaway>\` title. A slide OVERFLOWS iff its content occupies ≥2 CONSECUTIVE handout pages AND the slide block contains NO \`#pause\` (\`#pause\` legitimately produces multiple BUILD pages — that is NOT spill; grep the block for \`#pause\` and exclude those). Pages with no \`===\` title (title slide, TOC/\`#outline\`, \`=\`/\`==\` dividers) are STRUCTURAL — ignore them entirely; never infer overflow from \`handout_pages − slide_count\`. overflow = count of slides that occupy ≥2 pages with no \`#pause\`. If you genuinely cannot map a slide to its pages, set overflow=0 and say so (a false NEGATIVE that hides a clipped slide is worse than a missed warning — but a guessed page-arithmetic positive/negative is worst). Report the offending slide titles in context if overflow>0.
 
 Return MECHANICAL_SCHEMA. Report raw counts — do not soften.`,
   { label: 'mechanical', phase: 'Mechanical', schema: MECHANICAL_SCHEMA, model: 'sonnet' }
 )
 
+// Guard against a null mechanical-leg result (agent() can return null; fan-outs .filter(Boolean) this
+// away but a single agent() call does not) — synthesize a critical finding and short-circuit through the
+// same early-exit shape as a compile failure, rather than crashing on mech.slidesCompiled below.
+if (!mech) {
+  log('❌ Mechanical leg agent returned null — short-circuiting before per-slide review')
+  return {
+    overallPass: false,
+    verdict: 'ISSUES FOUND',
+    summary: { critical: 1, major: 0, minor: 0, total: 1 },
+    scoreTable: `| Leg | Result | Gate |\n|-----|--------|------|\n| Mechanical | agent returned null | ❌ |\n`,
+    findings: [{ severity: 'critical', area: 'mechanical', location: disc.presentationDir, detail: 'Mechanical leg agent returned null — re-invoke workshop-verify' }],
+    reviews: [],
+    slidesThatFlagged: disc.slides.map(s => s.id),
+    scope: { checked: [], notChecked: ['everything downstream — mechanical leg returned null, could not run compile/constraint/widow/overflow checks'] },
+    mechanical: null,
+  }
+}
 // Early-exit barrier: a deck that does not compile cannot be slide-reviewed meaningfully.
 if (!mech.slidesCompiled) {
   log('❌ slides.typ does not compile — short-circuiting before per-slide review')
@@ -264,10 +285,18 @@ for (const s of disc.slides) {
 const liveSlides = (await parallel(tasks)).filter(Boolean)
 if (ONLY) log(`Selective re-review: ${reran} slide(s) live, ${carriedCount} carried`)
 
-// Per-diagram visual-verify (only on a full review; diagrams are tied to slides).
+// Per-diagram visual-verify. On a full review, all diagrams run. On a selective re-review (ONLY set),
+// still review diagrams belonging to a slide in ONLY (a re-verify of S3 should re-check S3's diagram) —
+// otherwise a selective re-review of an edited slide vacuously passes Visual (empty .every() === true).
+// Diagrams on slides NOT in ONLY are left unreviewed this run (no carry-forward mechanism for diagram
+// reviews exists yet); the scoreTable below distinguishes that from a genuine zero-defect pass.
+const titleToSlideId = Object.fromEntries(disc.slides.map(s => [s.title, s.id]))
+const diagramsToReview = ONLY
+  ? disc.diagrams.filter(d => ONLY.has(titleToSlideId[d.slideTitle]))
+  : disc.diagrams
 let diagramReviews = []
-if (!ONLY && disc.diagrams.length && disc.lookAtPath) {
-  diagramReviews = (await parallel(disc.diagrams.map(d => () =>
+if (diagramsToReview.length && disc.lookAtPath) {
+  diagramReviews = (await parallel(diagramsToReview.map(d => () =>
     agent(
       `You are a READ-ONLY visual reviewer. Do NOT edit files. Render the slides.pdf page containing the diagram on slide "${d.slideTitle}" and score it for visual defects.
 Use: \`uv run python3 ${disc.lookAtPath} --file ${disc.presentationDir}/slides.pdf --goal "Inspect the ${d.kind} diagram on the slide titled '${d.slideTitle}' for: clipped/cut-off text, overlapping elements, bad arrow routing, label anchoring, cramped spacing, illegible text size"\`.
@@ -275,9 +304,10 @@ Set diagram="${d.id}". defectsFound = count of distinct visual defects. Each def
       { label: `${d.id}:visual`, phase: 'Review', schema: VISUAL_SCHEMA, model: 'sonnet' }
     )
   ))).filter(Boolean)
-} else if (!ONLY && disc.diagrams.length && !disc.lookAtPath) {
-  log(`⚠️ ${disc.diagrams.length} diagram(s) present but look_at.py not resolved — visual-verify skipped (NOT silently passed)`)
+} else if (diagramsToReview.length && !disc.lookAtPath) {
+  log(`⚠️ ${diagramsToReview.length} diagram(s) present but look_at.py not resolved — visual-verify skipped (NOT silently passed)`)
 }
+const visualSkippedCarryForward = ONLY && diagramReviews.length === 0 && disc.diagrams.length > 0
 
 const allSlides = [...liveSlides, ...carried]
 const order = Object.fromEntries(disc.slides.map((s, i) => [s.id, i]))
@@ -292,6 +322,12 @@ const findings = []
 for (const e of (mech.compileErrors || [])) { sev.critical++; findings.push({ severity: 'critical', area: 'compile', location: disc.slidesPath, detail: e }) }
 if (!mech.notesCompiled) { sev.critical++; findings.push({ severity: 'critical', area: 'compile', location: disc.notesPath, detail: 'notes.typ failed to compile' }) }
 for (const f of (mech.constraintFailures || [])) { sev.critical++; findings.push({ severity: 'critical', area: 'constraint', location: 'check-all.py', detail: f }) }
+// Constraint-module infra failures (errors[]) are NOT deck defects — one non-blocking minor finding
+// summarizing all of them, so a broken check-all.py module can't masquerade as (or hide) a real violation.
+if ((mech.constraintErrors || []).length) {
+  sev.minor++
+  findings.push({ severity: 'minor', area: 'constraint-infra', location: 'check-all.py', detail: `${mech.constraintErrors.length} constraint module error(s) (infra, not deck defects): ${mech.constraintErrors.join(' | ').slice(0, 400)}` })
+}
 if (mech.widows > 0) { sev.major += mech.widows; findings.push({ severity: 'major', area: 'widow', location: 'slides.pdf', detail: `${mech.widows} widow line(s) — binary gate requires 0` }) }
 if (mech.overflow > 0) { sev.major += mech.overflow; findings.push({ severity: 'major', area: 'overflow', location: 'slides.pdf', detail: `${mech.overflow} slide(s) overflow the frame` }) }
 
@@ -299,8 +335,7 @@ if (mech.overflow > 0) { sev.major += mech.overflow; findings.push({ severity: '
 for (const s of allSlides) {
   for (const f of (s.findings || [])) { if (sev[f.severity] !== undefined) sev[f.severity]++; findings.push({ ...f, area: f.source || 'slide', slide: s.slide }) }
   if (s.notesSectionFound === false) { sev.major++; findings.push({ severity: 'major', area: 'notes', slide: s.slide, location: disc.notesPath, detail: `slide ${s.slide} ("${s.title}") has no corresponding notes section` }) }
-  const ungrounded = Math.max(0, (s.claimsChecked || 0) - (s.claimsGrounded || 0))
-  if (ungrounded > 0) { /* already emitted as fidelity findings; do not double-count severity */ }
+  // Ungrounded claims are already emitted as fidelity findings above — not double-counted here.
 }
 
 // Per-diagram findings.
@@ -339,12 +374,14 @@ const scoreTable = [
   '| Leg | Measure | Result | Gate |',
   '|-----|---------|--------|------|',
   `| Compile | slides / notes | ${mech.slidesCompiled ? 'ok' : 'FAIL'} / ${mech.notesCompiled ? 'ok' : 'FAIL'} | ${mech.slidesCompiled && mech.notesCompiled ? '✅' : '❌'} |`,
-  `| Constraints | check-all.py | ${mech.constraintsPassed ? 'pass' : `${mech.constraintFailures.length} FAIL`} | ${mech.constraintsPassed ? '✅' : '❌'} |`,
+  `| Constraints | check-all.py | ${mech.constraintsPassed ? 'pass' : `${mech.constraintFailures.length} FAIL`}${(mech.constraintErrors || []).length ? ` (+${mech.constraintErrors.length} infra-error, non-blocking)` : ''} | ${mech.constraintsPassed ? '✅' : '❌'} |`,
   `| Widows | detect_widows.py | ${mech.widows} | ${mech.widows === 0 ? '✅' : '❌'} |`,
   `| Overflow | handout page count | ${mech.overflow} | ${mech.overflow === 0 ? '✅' : '❌'} |`,
   `| Source fidelity | claims grounded | ${claimsGrounded}/${claimsChecked} | ${claimsGrounded === claimsChecked ? '✅' : '❌'} |`,
   `| Notes coverage | slides with notes | ${allSlides.filter(s => s.notesSectionFound !== false).length}/${allSlides.length} | ${allSlides.every(s => s.notesSectionFound !== false) ? '✅' : '❌'} |`,
-  `| Visual | diagram defects | ${diagramReviews.reduce((a, d) => a + (d.defectsFound || 0), 0)} | ${diagramReviews.every(d => (d.defectsFound || 0) === 0) ? '✅' : '❌'} |`,
+  visualSkippedCarryForward
+    ? `| Visual | diagram defects | skipped (carry-forward — no diagrams on re-reviewed slides) | ⚠️ |`
+    : `| Visual | diagram defects | ${diagramReviews.reduce((a, d) => a + (d.defectsFound || 0), 0)} | ${diagramReviews.every(d => (d.defectsFound || 0) === 0) ? '✅' : '❌'} |`,
   `| **Overall** | blocking (crit+major) / advisory minor | ${blocking} / ${sev.minor} | ${substratePass ? (total === 0 ? '✅ CLEAN' : '✅ CLEAN (minors advisory)') : '❌ ISSUES'} |`,
 ].join('\n')
 
@@ -357,7 +394,7 @@ log(substratePass
 const scope = {
   checked: [
     'typst compile (slides + notes) — real exit code',
-    'check-all.py constraints — exit code (CAVEAT: rides cross-domain phantom + a broken module → permanently red on every deck; see DESIGN §4c / D-w-8)',
+    'check-all.py constraints — parsed JSON failed[] (real violations, blocking); errors[] reported separately as non-blocking constraint-infra minors (D-w-8: exit code alone conflated infra failures with deck defects)',
     'detect_widows.py — deterministic count',
     'overflow — handout page-count heuristic (CAVEAT: divider-naive, over-counts theme section/title pages; D-w-8)',
     SLIDE_INDEX ? 'inventoryRefs whitelist — dropped non-SOURCES ids (no-hallucination guard)' : 'inventory ids — agent-attributed (no index whitelist this run)',
@@ -377,7 +414,7 @@ return {
   scope,
   summary: { ...sev, total, blocking, advisoryMinors: sev.minor },
   scoreTable,
-  findings: findings.sort((a, b) => ({ critical: 0, major: 1, minor: 2 }[a.severity] - { critical: 0, major: 1, minor: 2 }[b.severity])),
+  findings: findings.sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity]),
   reviews: allSlides,                 // raw per-slide objects — pass back as priorReviews on a selective re-run
   diagramReviews,
   mechanical: mech,


### PR DESCRIPTION
## Summary

Fixes 16 confirmed code-review findings in the workshop + workflow-creator ultracode machinery, plus 6 low-risk cleanups. **Ordering note:** this targets v5.68.4, assuming pending PRs #50 (5.68.1), #51 (5.68.2), #52 (5.68.3) land first in that order — rebase/re-bump if the actual merge order differs.

This PR intentionally does **not** touch any file owned by those pending PRs (`hooks/mechanical-floor-gate.py`, `hooks/writing-mechanical-gate.py`, `hooks/_gate_common.py`, `skills/docx-repair/**`, `workflows/writing-draft.js`, `skills/de-ai-revise/**`, `scripts/lib/plan_table_core.py`, `scripts/dev/**`, `scripts/ds/**`, `workflows/templates/**`) or `.planning/`.

## What / why, per finding

1. **wc-audit.js** — `if (!dim || ONLY) continue` disabled ALL adversarial verification on every Mode-3 re-audit (`onlyChecks` is always set per SKILL.md's loop), letting unverified phantom criticals block `/goal` convergence forever. Fixed to `if (!dim || (ONLY && !ONLY.has(c.key))) continue` so freshly-reviewed clusters get verified. Also: verifier corrections were applied only to `scoreById` and never written back into the returned `reviews` records, so `priorReviews` on the next re-audit carried the pre-correction score and `reviewersThatFlagged` re-flagged refuted phantoms forever — corrections now mutate the review records in place.
2. **workshop-verify.js** — the Constraint leg's prompt told the agent to copy "FAIL:" lines that `check-all.py` never emits (it prints JSON `{passed,failed,conventions,errors,skipped}` + a summary), so `constraintFailures` was systematically empty and the gate never blocked on real constraint violations. Rewrote the prompt + schema to parse the JSON: `failed[]` → `constraintFailures` (blocking), `errors[]` → new `constraintErrors` field (one non-blocking minor finding, since exit-code 1 also fires on infra errors alone — conflating infra failure with deck defects). `constraintsPassed` is now `failed[] empty`, not the exit code.
3. **skills/workshop/SKILL.md:642-646** — documented `workshop-generate` returning `slides`/`slidesThatFailed`; the JS actually returns `sections`/`sectionsThatFailed`. The documented retry passed `onlyChecks=undefined`, regenerating every section on any failure. Fixed the two lines to the real keys.
4. **scripts/wc/wc_file_set.py** — `_field()` didn't strip inline `# ...` comments, so the module's own docstring example (`midpoint: fix  # one of: ...`) failed validation against `_MIDPOINTS`. Added `_strip_inline_comment()`, applied in `_field()` and the constraint-line parser. Added a regression test asserting the docstring's own example now parses clean.
5. **workshop-verify.js** — per-diagram visual review only ran when `!ONLY`, and `diagramReviews` were never carried via `priorReviews`, so a selective re-verify (workshop-revise re-checking edited slides) skipped visual review entirely and the gate vacuously passed (`[].every() === true`, 0 defects). Now, when `ONLY` is set, diagrams belonging to a slide in `ONLY` are still reviewed; the scoreTable's Visual row says "skipped (carry-forward)" instead of a false ✅ when no diagrams on the reviewed slides exist.
6. **workshop-generate.js** — `fidelityOk` trusted the section agent's self-reported `citedInventory` (it greps its own fragment and echoes the result — nothing deterministic re-checked it). Added one cheap, low-effort probe agent per drafted section, pipelined onto the draft (no extra barrier), that independently re-runs the exact grep and returns the token list; the gate now trusts the probe's tokens over the self-report (mirrors run-core's independent `gateProbe` doctrine).
7. **hooks/overflow-check.py** — (a) the trigger substring `"typst compile"` missed `tinymist compile` (what workshop-generate.js and visual-verify actually invoke); (b) the regex required the `.typ` target to be the first token after `compile`, so `typst compile --input handout=true slides.typ` never matched. Fixed to trigger on both compilers and extract the last `*.typ` token in the ;/&/|-delimited segment. Added `tests/overflow_check_test.py` covering both fixes + fail-open behavior.
8. **hooks/find-slide-page-inject.py** — `TRIGGER_RE` required a literal `slides/` directory, so `presentation/slides.typ` or flat `slides.typ` decks never triggered the heading→page injection. Broadened to any `\S+\.typ` target; REPL-verified against both forms.
9. **workshop-verify.js** — unguarded derefs (`disc.slides.length`, `!mech.slidesCompiled`) would throw `TypeError` if either single-agent call returned null. Added a hard error for `!disc` and a synthesized-critical-finding early return for `!mech` (mirrors the existing compile-failure early exit).
10. **GATE_BLOCKED_TOOLS landmine**, 3 sites: (a) workflow-creator's canonical gate exemplar (`skills/workflow-creator/SKILL.md`) now includes `GATE_BLOCKED_TOOLS=Agent` + a landmine sentence; (b) `hooks/phase-gate-guard.py`'s docstring example fixed the same way; (c) workshop's Phase 2→3 `OUTLINE_APPROVED` gate — `workshop-phase-gate-guard.py` (a bespoke script, not built on the generic env-var pattern) now also gates `Workflow(name="workshop-generate", ...)` dispatch, not just direct `Edit`/`Write` to `slides.typ`/`notes.typ`; the SKILL.md matcher now includes `Workflow`.

## Low-risk cleanups

11. `workshop_slide_table.py` — deleted dead `title_slug`/`titleSlug` (zero downstream consumers; verified with grep) and the field's two call sites; kept `section_slug()` itself since `tests/workshop_slide_table_test.py` exercises it directly. Fixed the SOURCES.md double-read (read once, reused for both the paper-path extraction and the inventory-id scan).
12. `workshop-verify.js` — deleted an empty `if (ungrounded > 0) {}` block.
13. Hoisted the inline severity-rank literal to a named `SEV_RANK` const in both `workshop-generate.js` and `workshop-verify.js` (matching the wc-* files' pattern).
14. `hooks/wc-constraint-check.py` — replaced the hand-rolled `applies-to` regex (which only matched the bracketed-list form) with `parse_frontmatter`/`skill_matches` imported by path from `scripts/load-constraints.py`; the old regex silently defaulted a scalar `applies-to: workflow-creator` to "no match → all", leaking wc-only constraints onto every repo edit.
15. `workflows/wc-audit.js` — fixed a stale "(P22-26 scored)" label to "(P22-30 scored)".
16. `workshop-verify.js` Mechanical prompt — changed the per-page `pdftotext -f N -l N` instruction to one `pdftotext -layout file -` pass split on form-feeds.

## Deferred (not attempted — listed per instructions)

3N→N per-slide reviewer consolidation; per-gap→per-cluster wc verify batching; P01-P30 rubric pre-extraction; deleting the LLM Discover fallback in workshop-generate; wc-generate content round-trip slimming; P22-P30 inline-vs-grep dual source restructure; workshop-revise SOURCES_VERIFIED lockout for pre-gate decks (needs a product decision on the escape hatch).

## Test plan

- [x] `node --check` on every edited `workflows/*.js` (wc-audit.js, workshop-verify.js, workshop-generate.js)
- [x] Backtick/`${}` re-read of every edited prompt string (no template-literal breakage — known incident class)
- [x] `py_compile` on every edited `.py` (wc_file_set.py, overflow-check.py, find-slide-page-inject.py, phase-gate-guard.py, workshop-phase-gate-guard.py, wc-constraint-check.py, workshop_slide_table.py)
- [x] Existing suites green: `tests/wc_file_set_test.py` (20/20), `tests/workshop_slide_table_test.py` (37/37), `tests/workshop_guard_test.py` (6/6), `tests/workshop-engine-discover.test.mjs` (26/26, 2 assertions updated to match the intended fix), `tests/check_all_applies_to_test.py` (13/13), `tests/dev-run-driver.test.mjs`, `tests/ds-run-driver.test.mjs`, `tests/ds-grain-pause.test.mjs`, `tests/writing-engine-discover.test.mjs`, `tests/test_mechanical_floor_gate.py`, `tests/test_writing_mechanical_gate.py`, `tests/writing_guards_test.py`, `tests/writing_section_index_test.py`, `tests/writing_gate_probe_test.py`, `tests/test_law_review_footnote_symbols.py`, `tests/test_writing_constraint_lints.py`
- [x] New `tests/overflow_check_test.py` — trigger/target regex variants (bare, `--input` first, tinymist, `--root`, cd-prefix, non-triggering) + fail-open on malformed/empty/non-Bash stdin
- [x] New wc_file_set docstring-example regression case
- [x] REPL-verified `find-slide-page-inject.py`'s `TRIGGER_RE` against both `tinymist compile presentation/slides.typ` and `tinymist compile slides/lecture1.typ`
- [x] Smoke-tested `workshop_slide_table.py` against a synthetic OUTLINE.md/SOURCES.md fixture (`--json` output, no `titleSlug`, no crash)
- [x] Manually exercised `workshop-phase-gate-guard.py`'s new `Workflow` gate: denies `workshop-generate` dispatch without `OUTLINE_APPROVED.md`, allows once `status: APPROVED`, ignores unrelated workflow names, fails open on malformed stdin
- [x] Version bumped to 5.68.4 in all 3 locations (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` metadata + plugin entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3NEAUUosUHyci4iFZBH2J