### PR TITLE
feat(workflow-creator): gate doctrine for self-grading workflows (v5.70.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.69.1"
+    "version": "5.70.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.69.1",
+      "version": "5.70.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.69.1",
+  "version": "5.70.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/references/constraints/wc-gate-contract.md
+++ b/references/constraints/wc-gate-contract.md
@@ -1,0 +1,22 @@
+---
+name: wc-gate-contract
+description: Any self-grading gate (JS overallPass + findings + re-run selector) is a 3-way contract that must stay consistent
+applies-to: [workflow-creator]
+---
+
+## Rule
+
+For any workflow whose gate is computed in JS and returns `overallPass` (or `substratePass`) + a
+`findings` list + a re-run selector (`*ThatFailed`/`reviewersThatFlagged`): `overallPass === false`
+must imply the selector is non-empty for EVERY fail path, every fail condition must emit an
+actionable finding, and the documented `returns {...}` shape must match the script's actual
+`return {...}` keys and the selector's id-namespace exactly. See
+`skills/workflow-creator/references/gate-doctrine.md` for the full doctrine (11 laws) and the
+design-time / audit-time checklists.
+
+## Rationale
+
+A mismatch in this 3-way contract never errors — it silently degrades a targeted re-run into a
+full regeneration, or a blocking gate into a display-only one. This has recurred across two
+separate audit campaigns (this repo's PRs #50-#55 and a sibling course-materials campaign),
+which is why it is durable doctrine, not a one-off fix.

--- a/skills/workflow-creator/SKILL.md
+++ b/skills/workflow-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-creator
 description: "This skill should be used when the user asks to 'create a workflow', 'design a workflow', 'edit a workflow', 'audit workflow', 'improve workflow', 'break down a task into phases', 'migrate a phase to a dynamic workflow (ultracode)', 'convert fan-out to a workflow script / ultracode', or needs to substantially create or edit any multi-phase workflow."
-version: 0.5.0
+version: 0.6.0
 hooks:
   PreToolUse:
     - matcher: "Write|Edit"
@@ -679,6 +679,8 @@ Plus two **commitment** decisions:
 
 **Do NOT put intra-level parallel-vs-sequential in the decision list** — it is **CORE, compiler-DERIVED** (parallel IFF a level's declared outputs are provably disjoint; ds's disjoint parquets qualify, dev's shared tree never does → sequential by construction). Hand-setting it is the retired `D5` proposal; a naive parallel copy corrupts a shared tree.
 
+**If the workflow is SELF-GRADING** (a JS gate that returns `overallPass`/`substratePass` + a `findings` list + a re-run selector like `*ThatFailed`/`reviewersThatFlagged` consumed by a `/goal` loop's `onlyChecks`/`priorReviews`) — this is broader than the compiled-runner case above; a pure review fan-out with no plan-table DAG (e.g. `wc-audit` itself) qualifies too. Read `${CLAUDE_SKILL_DIR}/references/gate-doctrine.md` NOW and satisfy its **design-time checklist** before generation — the 11 laws there (return-shape contract, selective-re-run integrity, the 3-way overallPass⇔findings⇔selector contract, fail-closed signals, self-report vs independent probe, and more) are cross-repo-recurring defects in exactly this gate shape.
+
 Update `.planning/wc/{name}/STATE.md`:
 ```yaml
 step: 3b-artifact-review
@@ -776,6 +778,8 @@ hooks:
 ```
 
 **Design rule:** Hook first. If the hook can't express the constraint (requires judgment, context, or semantics), fall back to prompt enforcement.
+
+**If the constraint gates a `Workflow`/`Agent` fan-out and the phase is self-grading** (see the Step 3b pointer above), don't just wire the hook — REPL a real dispatched call and confirm the `matcher` fires on what the pipeline actually emits (tool name, path position, `hook_input.cwd` vs `args.*`). This is `references/gate-doctrine.md` L7, which extends the `matcher`/`GATE_BLOCKED_TOOLS` landmine above and the P20 sub-probe to the `Workflow`-dispatch case.
 
 #### Deviation Rules for Implementation Phases
 
@@ -1340,6 +1344,8 @@ Patching files generated without proper investigation, interview, decomposition,
 
 **Review-pattern logging (self-applied P19b):** At each present-to-user checkpoint (Step 6 file presentation, Step 7 audit results), append to `.planning/wc/{name}/LEARNINGS.md` what the user attended to or changed (which findings they prioritized, what they overrode). This is the observe→record→offer loop wc prescribes for the workflows it creates, applied to wc itself — after 3+ recurring patterns, propose encoding them as defaults.
 
+**If the generated workflow is itself self-grading** (a JS gate returning `overallPass`/`substratePass` + `findings` + a re-run selector — this includes any generated `*-verify.js`/`*-audit.js`/`*-generate.js`), the wc-audit run below must additionally satisfy `references/gate-doctrine.md`'s **audit-time checklist** — its P02/P03/P04 gate/enforcement/verification scoring already folds in the gate-doctrine sub-checks (return-shape lint, ONLY-path integrity, the 3-way overallPass⇔findings⇔selector contract, fail-closed signals, self-report vs independent probe). Run `python3 tests/workflow_return_shape_test.py` on the generated files as part of this.
+
 **Context check:** Step 7 dispatches a subagent with a large prompt containing all generated file paths and audit criteria. This is one of the most context-intensive operations. Before proceeding:
 - If context is low (≤35% remaining), write `.planning/wc/{name}/HANDOFF.md` with generated file list, current step, and note that self-audit is pending. Pause.
 - If context is critical (≤25% remaining), write HANDOFF.md immediately — do not attempt the subagent dispatch.
@@ -1499,6 +1505,8 @@ It returns `{ overallPass, composite, verdict, threshold, isMetaTool, scoreTable
 **Post-workflow boundary (verification, not investigation):** after the workflow returns you may Read AUDIT.md/`result.*`, render the report, and fix gaps — you may NOT recompute or rationalize `result.composite`/`result.overallPass` (the JS owns the arithmetic), nor re-score a principle the reviewers scored.
 
 The STATE.md step-chain (1-read → 2-score → 3-enforcement → 3b-portability → 4-report) is **preserved** — the workflow performs the work each step describes; you still write each STATE.md transition so the hook chain holds. **This step-chain IS Mode 2's structural gate enforcement (P03):** `wc-step-gate-guard.py` Layer 2 BLOCKS writing `step: N` to STATE.md unless `step: N-1` shows `status: completed` — a tool-call-layer block, not advisory prose, and the reason a separate per-step marker file is unnecessary for Mode 2's linear chain (the same Layer-2 enforcement governs Mode 3's `1-initial-audit → 1-audit-loop`).
+
+**If the target workflow is self-grading** (a JS gate returning `overallPass`/`substratePass` + `findings` + a re-run selector consumed by `onlyChecks`/`priorReviews` — this covers `wc-audit` itself, any generated `*-verify.js`/`*-audit.js`, and any compiled-runner gate), Step 2's P02/P03/P04 scoring below is where `references/gate-doctrine.md`'s **audit-time checklist** gets applied — its 11 laws are folded into those three principles' scoring criteria (see the sub-bullets under each), not a separate cluster. Run `python3 tests/workflow_return_shape_test.py` against the target as part of P02 evidence-gathering.
 </EXTREMELY-IMPORTANT>
 
 ### Step 1: Read the Workflow
@@ -1549,6 +1557,7 @@ Score each principle 0-10. Use the formal ID (P01-P21) in all audit output for t
 - For subjective domains, are judgment gates explicit? (agent-assessed or human-assessed)
 - Or are they just prose? ("ensure quality is high")
 - Are there ungated transitions?
+- **If the workflow is self-grading** (a JS gate returning `overallPass` + `findings` + a re-run selector — `references/gate-doctrine.md` L1-L3): run `tests/workflow_return_shape_test.py` against it — does the documented `returns {...}` shape match the actual `return {...}` keys AND the re-run selector's id-namespace (L1)? Does `overallPass === false` imply the selector is non-empty for EVERY fail path, including whole-artifact-level failures with no single owning item, and does every fail condition emit an actionable finding (L3)? Is the field that renders the status row the SAME variable that blocks (not a display-only boolean that happens to usually agree) (L3c)? Any drift is a CRITICAL finding — it produces a silent full-regeneration loop that looks like it's working.
 
 **P03 — Structural gate enforcement (CRITICAL — this is the #1 audit gap):**
 - For every mandatory inter-phase gate, classify as STRUCTURAL or ADVISORY:
@@ -1569,6 +1578,8 @@ Score each principle 0-10. Use the formal ID (P01-P21) in all audit output for t
   - **HOOK-ENFORCED:** Skill frontmatter declares a PreToolUse hook that checks for the artifact (strongest)
   - **INSTRUCTION-ONLY:** Skill text checks for the artifact but no hook blocks tool calls (weaker — can be rationalized past under context pressure)
 - Score: count of STRUCTURAL gates / total mandatory gates. Below 80% = critical gap. Count of HOOK-ENFORCED / STRUCTURAL gates — below 50% = recommend hook migration.
+- **If a hook gates a `Workflow`/`Agent` fan-out phase** (`references/gate-doctrine.md` L7, extending the `matcher`/`GATE_BLOCKED_TOOLS` landmine above and the P20 sub-probe): trace (or dispatch) a real call and confirm `matcher` actually fires on what the pipeline emits — the tool name (`Workflow` vs `Agent`, especially after an ultracode-migration where the matcher was left on the old tool), path position in the command, and `hook_input.cwd` vs `args.*` for `projectDir`-style reads. A silent exit-0 no-op here is invisible without this trace.
+- **If the workflow's gate is self-grading, also check the ONLY/onlyChecks path as a first-class execution path, not an afterthought** (L2): does an empty selector array ever render a pass for a non-empty or skipped set? Does adversarial verification still run when `ONLY` is set, or does an `if (ONLY) continue` disable it? Is the carried-forward `reviews`/`priorReviews` a UNION (`[...live, ...carried]`) with verifier corrections written back into the carried record, or can it silently drop/re-flag phantoms? Also check for shared-core drift if the workflow splices an extracted driver across domains (L9), and whether detect/fix share one predicate rather than two hand-copied passes (L8).
 
 **P04 — Independent verification:**
 - Is verification structurally independent from implementation? (fresh subagent, not self-review)
@@ -1588,6 +1599,13 @@ Score each principle 0-10. Use the formal ID (P01-P21) in all audit output for t
 | 4 | **Functional** | Actually works end-to-end | Tests pass, feature runs |
 
 If verification only checks Level 1 (exists), it's theater. A workflow that claims "test exists" without checking the test is substantive, wired, and functional is shipping false confidence.
+
+**Self-grading gate sub-checks** (`references/gate-doctrine.md` L4-L6, L10-L11 — apply when the workflow computes its own gate in JS):
+- **Fail-closed on absent signals (L4):** for every gated dimension, grep for `.filter(Boolean)` / optional-chaining defaults that let an absent or null result read as a vacuous pass. Is there a `dispatchedPairs`-style set distinguishing a crash-drop (should fail/mark unreliable) from an intentional selective-skip (should read n/a)? Is every single (non-fan-out) `await agent()` call guarded with declared null semantics, not dereferenced directly?
+- **Self-report vs independent probe (L5):** for every field the gate reports as evidence (a self-grepped status, a self-reported `artifactsPresent`/`citedInventory`), is there an independent deterministic check or a separate low-effort probe agent — or is it decoration from the same agent whose work it certifies? Are status greps anchored (`^status: APPROVED`), not bare substring matches that false-match unrelated frontmatter?
+- **Doc-template ⇔ parser acceptance (L6):** if a parser feeds both an executable guard and the workflow, does the AUTHORING doc's example actually pass the parser (not just look plausible)? A template the parser rejects false-denies every valid spec written to it.
+- **Enforcement claims are testable (L10):** spot-check 2-3 "wired via X" / "blocks Y" claims in the target's SKILL.md against the actual hook/schema/check — a claim that only cross-references other prose is unenforced.
+- **Real eval, not just `node --check` (L11):** was the workflow smoke-tested with a bogus target and confirmed to reach its OWN arg-validation error (not a template-literal crash at `eval()`)? Is adversarial verification exercised against REAL inputs during authoring, not synthetic ones a verifier would rubber-stamp?
 
 **P05 — Artifact review:**
 - Are intermediate artifacts (specs, plans, outlines) reviewed before downstream phases consume them?

--- a/skills/workflow-creator/references/gate-doctrine.md
+++ b/skills/workflow-creator/references/gate-doctrine.md
@@ -1,0 +1,302 @@
+# Gate Doctrine — self-grading workflows
+
+## WHEN IT APPLIES
+
+Any workflow whose gate is **computed in JS** and returns:
+- `overallPass` (or `substratePass`/`gate` — a boolean the skill trusts without recomputing),
+- a `findings` list, and
+- a **re-run selector** (`*ThatFailed`, `reviewersThatFlagged`, `sectionsThatFailed`, etc.) that a
+  `/goal` fix-loop consumes as `onlyChecks` on the next iteration, alongside `priorReviews` for
+  carry-forward.
+
+This is the shape of `wc-audit.js`, `wc-generate.js`, and every compiled-runner / review-fan-out
+workflow this skill scaffolds (`workshop-verify`, `dev-verify`, teaching's exam/lecture gates,
+etc.). If a workflow you are creating or auditing matches this shape, the laws below are
+**mandatory reading** — they are lessons paid for twice, once in this repo (PRs #50-#55) and once
+in a sibling course-materials campaign, and they recur because the failure mode is structural, not
+accidental.
+
+**Cross-references, not duplicates** — these laws build on doctrine already in this SKILL.md;
+don't re-derive what's already there:
+- The `matcher` vs `GATE_BLOCKED_TOOLS` landmine (SKILL.md ~line 358) and the P20 mechanical
+  sub-probe (~line 1695) already cover hook/matcher mismatches for `Agent`/`Workflow` fan-outs. L7
+  below extends this to the `Workflow`-dispatch case explicitly — it does not restate it.
+- D1's `gateProbe` contract (~line 669) already requires `pass ⊥ artifactsPresent` as two
+  independent booleans, never trusting `pass` alone. L4/L5 below generalize this beyond the
+  compiled-runner D1 seam to every self-report field on any gate.
+- The compiled-runner principles P22-P30 (a CONDITIONAL cluster in `wc-audit.js`) already audit
+  the `gateProbe`/parser/emitter machinery for the DAG-of-mechanical-work case. This doctrine is
+  broader: it applies to ANY self-grading gate, compiled-runner or not (a pure review fan-out like
+  `wc-audit` itself is in scope and is NOT a compiled runner).
+- `tests/workflow_return_shape_test.py` already exists in this repo and mechanically checks L1's
+  return-shape contract. **Run it, don't rewrite it.**
+
+---
+
+## L1 — Return shape is a compiled contract, not hand-written
+
+**Invariant:** the SKILL's `returns { ... }` documentation line, the script's actual
+`return { ... }` keys, and the re-run selector's id-namespace must all agree.
+
+**What it prevents:** a mismatch never errors. `onlyChecks: result.<wrongKey>` evaluates to
+`undefined`, the re-run selector reads as `null`, and the loop falls back to re-running
+*everything* — a **silent full regeneration** that looks like a working incremental loop.
+
+**Evidence:**
+- This repo: a workshop SKILL documented `slidesThatFailed`; the JS actually returned
+  `sectionsThatFailed`. Every "targeted re-run" silently regenerated the full deck.
+- course-materials: the same defect, third cross-repo sighting — `lecturesThatFailed` in the doc
+  vs `sectionsThatFailed` in the return.
+
+Also round-trip the **selector namespace**, not just the key name: the ids inside
+`*ThatFailed` must be the same id-space the script's `ONLY` filter matches against (dimension
+keys, section slugs, file paths — whichever the workflow uses). A key-name match with a
+namespace mismatch is the same silent-full-regen bug wearing a different hat.
+
+**Author it right:** run `python3 tests/workflow_return_shape_test.py` against any workflow you
+generate or audit. It cross-references every `returns {...}` doc line against the workflow's real
+`return {...}` keys and fails loud on drift — this is the deterministic lint that would have
+caught all three sightings above. Do not hand-verify this; run the lint.
+
+---
+
+## L2 — The selective re-run is a second execution path — audit it as first-class
+
+`ONLY` / `onlyChecks` / `priorReviews` is not a convenience shortcut on top of the full-run code
+path — it is a **second, less-tested execution path** through the same workflow, and defects hide
+there because the full-run path is what gets eyeballed during authoring.
+
+**(a) No empty-collection vacuous pass.** `[].every(...) === true` must never render `✅` when the
+underlying set was non-empty in the full run or was skipped this time — render "skipped / carried"
+with a visibly distinct status, never a bare pass.
+
+**(b) Enforcement/verification must survive the ONLY path.** An `if (ONLY) continue` that disables
+adversarial verification on a re-audit is a convergence blocker — the loop appears to iterate but
+never re-checks the thing that mattered.
+- This repo: `wc-audit`'s own worst bug — the ONLY path disabled all verification on Mode-3
+  re-audits, meaning every re-audit after iteration 1 was unverified.
+- course-materials: `workshop-verify` skipped all diagram review under `ONLY` and passed
+  vacuously — a violating deck could ship clean simply by having survived to a re-run.
+
+**(c) Carry-forward is a union that writes verdicts back.** The returned `reviews` (which becomes
+next iteration's `priorReviews`) must be `[...live, ...carried]`, AND any verifier correction made
+during this run must be written back into the carried record.
+- This repo: without the write-back, a refuted finding phantom-reflags forever — the verifier
+  corrects it every run but the correction never sticks in the carried state.
+- course-materials (R3-H2): without the union, results from an earlier run are silently dropped on
+  the 2nd+ re-run — `priorReviews` shrinks instead of accumulating.
+
+---
+
+## L3 — The gate is a 3-way contract (overallPass ⇔ findings ⇔ selector), kept consistent
+
+**(a) Invariant:** `overallPass === false ⟺ selector non-empty`. The selector is typically read as
+`x?.length ? new Set(x) : null` — so an **empty** selector on a failing run means "re-run
+EVERYTHING," not "nothing to fix." A whole-artifact failure (compile error, alignment check) where
+every per-item row still passes yields an empty per-item selector on a `overallPass=false` run →
+full regen with no target. The selector must cover **every** path that can set `overallPass=false`,
+including whole-artifact-level failures that no single item owns (course-materials R3-H1, both
+lecture engines hit this).
+
+**(b) Every fail condition must emit an actionable finding attributed to the owning check.** A
+binary gate that can flip `overallPass` to false but pushes nothing into `findings` leaves the
+`/goal` loop with "0 findings to fix" and nothing to target (course-materials R4-J1).
+
+**(c) The boolean that renders a status row must derive from the SAME data that produces blocking
+findings.** A display-only boolean is a probe-detectable smell.
+- This repo: `workshop-verify` rendered `❌` from `constraintsPassed` but the actual gate blocked
+  on `constraintFailures`, which was always empty by construction — a violating deck shipped with
+  `overallPass=true` while the UI showed a red X nobody was blocked by.
+
+---
+
+## L4 — Fail closed on an absent/nullable signal
+
+A dimension gated as `!(x?.findings || []).some(...)` reads as vacuously clean whenever `x` is
+absent — dropped by a `.filter(Boolean)`, never dispatched, or not carried forward. Every gated
+dimension needs an explicit **presence guard** (`!!x`, `score !== null`) distinct from its
+pass/fail logic.
+
+Distinguish a **crash-drop** (an agent call threw or returned null unexpectedly → should fail or
+mark unreliable) from an **intentional selective-skip** (this dimension wasn't dispatched this
+round by design → should read `n/a`, not pass or fail). Track a `dispatchedPairs`-style set so the
+gate can tell these apart (course-materials R2-G2 / R4-J2 / R4-J3 conflated the two).
+
+Guard every **single** `await agent(...)` call (not a fan-out) with declared null semantics:
+- Discover-type calls → throw with a clear re-invoke message.
+- A pipeline leg → synthesize a critical finding and continue, don't crash the whole gate.
+
+Fan-outs (`Promise.all` over N agents) stay `.filter(Boolean)` as today — this guard is
+specifically for the single-call case, which this repo's `workshop-verify` TypeError'd on (a null
+single agent result was dereferenced directly, no guard).
+
+---
+
+## L5 — Self-report is not a gate — pair every self-certified field with an independent probe
+
+If the gate field is produced by the same agent whose work it certifies, it's decoration, not
+verification. Ground every self-certified field:
+- A **deterministic JS check** when the data is already in-context (cheapest, do this first).
+- Else a cheap `{effort: 'low'}` probe agent — not the same agent, not the same call.
+- A captured exit code (`... ; echo EXIT=$?`) plus an `rm`-stale-then-`test -s`-present probe, so
+  "compiled" means *this run* produced the artifact, not a stale one left over from a prior run.
+- `grep -q '^status: APPROVED'` (anchored), never bare `grep APPROVED` — the latter matches
+  unrelated text like `requires: [..._APPROVED]` in frontmatter and false-passes.
+
+**Evidence:** this repo's `workshop-generate` trusted a self-grepped `citedInventory` the JS never
+independently re-checked; course-materials R2-G8/G9/G10 and R1-D's `artifactsPresent` self-report
+had the same shape — a field the JS displayed but never verified.
+
+---
+
+## L6 — When a parser feeds both a guard and the workflow, the doc's authoring template must be exactly what the parser accepts
+
+"Parses ⇔ passes the guard" (already doctrine #6, emitter-canonical, in this skill) only holds if
+the **doc that teaches authors how to write the artifact** produces the form the parser actually
+accepts. Emitter-canonical is the general fix; this is the specific failure mode to check for at
+audit time.
+
+**Evidence:** course-materials shipped an `issues.md` authoring template as a **table**; the
+parser rejected tables outright. The executable guard false-denied a valid, correctly-written
+spec. The parser's own docstring even admitted the table form "false-denied the real spec" — but
+the authoring doc was never migrated to match what the parser accepted (R2-G5). The bug was
+documented in the code and shipped anyway because nobody cross-referenced doc example ⇔ parser
+acceptance.
+
+---
+
+## L7 — Hook matcher + trigger must match what the pipeline actually emits — REPL at authoring time
+
+(Extends the existing line-358 landmine and the P20 sub-probe — read those first; this adds the
+cases they don't already name.)
+
+- `matcher: Agent` while the phase actually fans out via `Workflow` (a Claude Code ultracode
+  workflow tool call, not an `Agent` tool call) → the hook never fires; ungated (course-materials
+  R2-G1). If your workflow migrated a fan-out phase to an ultracode `Workflow` per this skill's own
+  migration playbook, its gate hooks must be re-matched to `Workflow`, not left on `Agent`.
+- A check keyed on the tool string `typst compile` while the pipeline actually invokes
+  `tinymist compile` — a rename in the invoked tool silently orphans the hook.
+- A regex requiring the target path as the first token, when the real invocation is
+  `tinymist compile --input x=y file.typ` (target is not first) — the regex never matches.
+- `projectDir` read from `args.projectDir`, which `Agent` tool calls never carry — read
+  `hook_input.cwd` instead.
+
+**The failure mode is always a silent exit-0 no-op** — invisible without a REPL against the real
+emitted commands/paths/tool-input shapes. At authoring time, don't reason about what the hook
+*should* match — dispatch one real call and inspect what the hook actually receives.
+
+---
+
+## L8 — Detect and fix must share one predicate
+
+Scaffold detect/fix as one shared iterator consumed by both functions, not two independently
+written passes that are supposed to "use the same rule." A count-based fixer that re-encodes a
+detector's predicate by hand will drift the moment one sibling gets a guard the other lacks.
+
+**Evidence:** this repo — a leading-tab-stripping pass silently lacked the front-matter guard its
+sibling passes had, while the SKILL text claimed "same guard applies to all passes." The guard was
+implicit in each hand-copied predicate, not shared.
+
+---
+
+## L9 — Shared-core extractions prove zero per-domain behavior change
+
+When you extract a shared driver/core from N domain-specific copies (e.g. `run-core.js` splicing
+per-domain fragments), per-domain differences must become **explicit, compiled config** — a named
+hole the fragment fills — never something that survives implicitly because "that's the branch that
+happened to merge cleanly." Golden-lock each domain's gate semantics (a snapshot test against real
+inputs) **before** extracting, so a semantics change during extraction fails loud instead of
+shipping silently.
+
+**Evidence:** this repo — a `run-core` extraction cross-applied one domain's column-access logic
+to another domain and weakened a second domain's outputs-gate, because neither domain's exact
+pre-extraction behavior had been golden-locked first.
+
+---
+
+## L10 — Enforcement prose claims are testable assertions
+
+Every "wired via X" / "blocks Y" / "logged, never silent" claim in a SKILL.md or workflow doc
+cross-references an actual mechanism — a hook, a schema field, a JS check — not just other prose
+asserting the same thing. **Audit the exemplars in workflow-creator itself first**, since authors
+copy them verbatim into every workflow this skill generates; an unenforced claim in an exemplar
+propagates to every workflow scaffolded from it.
+
+---
+
+## L11 (meta) — put these two in both checklists below
+
+- **`node --check` is not an eval test.** A stray backtick inside a template-literal prompt string
+  passes `node --check` (it's syntactically valid JS) and then crashes the Workflow runtime at
+  `eval()` when the template literal is actually interpolated. The cheap REAL smoke test: launch
+  each workflow with a bogus `projectDir` and confirm it reaches its **own** arg-validation error
+  (not a crash inside a prompt-building template literal). Self-documenting docstring examples
+  double as free regression tests — keep them runnable.
+- **Adversarial verification is load-bearing and must itself be regression-tested.** Across both
+  campaigns it refuted roughly a quarter of plausible finder claims — it is not a rubber stamp.
+  Verify it against REAL inputs, not synthetic ones: course-materials caught 3 finder claims that
+  had used fabricated inputs, which a synthetic-input verifier would have rubber-stamped.
+
+---
+
+## DESIGN-TIME CHECKLIST (apply when scaffolding a new self-grading gate)
+
+- [ ] `returns {...}` doc, the script's `return {...}`, and the re-run selector's id-namespace are
+      the SAME contract — plan to run `tests/workflow_return_shape_test.py` on the generated file (L1).
+- [ ] The `ONLY`/`onlyChecks` path is designed as a first-class execution path: no vacuous
+      empty-set pass, verification runs on the ONLY path too, carry-forward is a union that writes
+      verifier corrections back (L2).
+- [ ] `overallPass === false ⟺ selector non-empty` holds for EVERY fail condition, including
+      whole-artifact-level failures with no single owning item; every fail condition emits a
+      finding; the rendered status boolean is the same data as the blocking boolean (L3).
+- [ ] Every gated dimension has an explicit presence guard, distinguishes crash-drop from
+      intentional-skip, and every single (non-fan-out) `await agent()` call has declared null
+      semantics (L4).
+- [ ] Every self-certified field (self-grepped status, self-reported artifactsPresent) is paired
+      with an independent deterministic check or a separate low-effort probe agent; status greps
+      are anchored (L5).
+- [ ] If a parser feeds both a guard and the workflow, the authoring doc's template is the
+      EXACT form the parser accepts — verified, not assumed (L6).
+- [ ] Hook `matcher` was checked against what the pipeline actually emits (tool name, path
+      position, `hook_input.cwd` vs `args.*`) via a real dispatched call, not reasoned about in the
+      abstract — especially after migrating a fan-out to a `Workflow` tool call (L7, extends the
+      line-358 landmine + P20).
+- [ ] Detect and fix share one predicate/iterator, not two hand-copied passes (L8).
+- [ ] If extracting a shared core across domains, each domain's gate semantics is golden-locked
+      against real inputs BEFORE extraction (L9).
+- [ ] Every enforcement-prose claim in the generated SKILL.md names the actual hook/schema/check
+      that backs it (L10).
+- [ ] Smoke-test with a bogus `projectDir`/target and confirm the workflow's own arg-validation
+      fires, not a template-literal crash; adversarial verification is planned as a permanent,
+      regression-tested layer, not a launch-time-only pass (L11).
+
+## AUDIT-TIME CHECKLIST (apply when auditing an existing self-grading gate)
+
+- [ ] Run `python3 tests/workflow_return_shape_test.py` against the target workflow — any drift
+      between documented and actual return keys is a CRITICAL finding (L1).
+- [ ] Read the `ONLY`/`onlyChecks` branch of the JS by hand: does anything short-circuit past
+      verification? does an empty array render a pass? is `reviews`/`priorReviews` a union with
+      corrections written back, or does old state get overwritten/dropped (L2)?
+- [ ] Trace every code path that can set `overallPass`/`substratePass` to false — does each one
+      have a non-empty selector entry AND an emitted finding? Is the rendered status boolean
+      literally the same variable as the blocking boolean, or two different fields that happen to
+      usually agree (L3)?
+- [ ] For every gated dimension, grep for `.filter(Boolean)` / optional-chaining defaults — does an
+      absent/null result read as pass? Is there a `dispatchedPairs`-style set distinguishing
+      crash-drop from intentional-skip? Are single `await agent()` calls guarded (L4)?
+- [ ] For every field the gate reports (status, artifactsPresent, citedInventory, etc.) — is there
+      an independent check, or is it self-reported by the same agent that produced the work?
+      Are status greps anchored (`^status: APPROVED`) (L5)?
+- [ ] If a parser/guard exists, does the shipped authoring doc's example actually PASS the parser
+      (not just look plausible) (L6)?
+- [ ] Dispatch (or trace) a real call through each gate-relevant hook and confirm `matcher` fires
+      on what the pipeline ACTUALLY emits — tool name, `Workflow` vs `Agent`, path position,
+      `hook_input.cwd` (L7).
+- [ ] Do detect and fix functions call a shared predicate, or two independently maintained ones
+      (L8)?
+- [ ] If the workflow shares an extracted core with sibling domains, is each domain's gate
+      semantics still correct post-extraction, or did one domain's logic leak into another's (L9)?
+- [ ] Spot-check 2-3 enforcement-prose claims against the actual mechanism they cite (L10).
+- [ ] Confirm `node --check` was NOT the only eval test run; check the workflow reaches its own
+      arg-validation on a bogus target; confirm adversarial verification exists as a permanent
+      layer and was exercised against real (not fabricated) inputs during authoring (L11).


### PR DESCRIPTION
## Summary

Folds lessons from **two code-review campaigns** — this repo's PRs #50-#55 and a sibling course-materials campaign — into workflow-creator so self-grading-workflow gate defects (a JS gate returning `overallPass` + `findings` + a re-run selector consumed by `/goal`'s `onlyChecks`/`priorReviews`) get caught at **authoring** and **audit** time, instead of recurring a third time.

Authored from a cross-repo review campaign; for review by the workflow-creator owner.

### New doctrine — `skills/workflow-creator/references/gate-doctrine.md`

11 laws (L1-L11), each with the invariant, the concrete cross-repo failure it prevents, and how to author it right — plus a design-time and an audit-time checklist:

- **L1** return shape is a compiled contract (doc ⇔ return keys ⇔ selector namespace)
- **L2** the ONLY/onlyChecks path is a second execution path, audited as first-class (no vacuous empty-set pass · verification survives ONLY · carry-forward is a union that writes verdicts back)
- **L3** the 3-way contract: `overallPass ⇔ findings ⇔ selector` stays consistent
- **L4** fail closed on absent/nullable signals (crash-drop vs. intentional-skip)
- **L5** self-report is not a gate — pair every self-certified field with an independent probe
- **L6** doc authoring templates must be exactly what the parser accepts
- **L7** hook matcher + trigger must match what the pipeline actually emits (REPL at authoring time)
- **L8** detect and fix share one predicate
- **L9** shared-core extractions prove zero per-domain behavior change
- **L10** enforcement prose claims are testable assertions
- **L11** (meta) `node --check` is not an eval test; adversarial verification must itself be regression-tested against real inputs

### Wiring — `skills/workflow-creator/SKILL.md` (v0.5.0 → v0.6.0)

- Step 3b / Step 4 (enforcement design): pointer to the design-time checklist for any workflow classified as self-grading
- Step 7 self-audit + Mode 2 audit: pointer to the audit-time checklist
- P02/P03/P04 principle definitions now fold in the relevant L1-L11 sub-checks directly (gate contract, hook-matcher tracing, ONLY-path integrity, fail-closed signals, self-report vs independent probe, doc⇔parser, testable claims, real-eval)
- Confirmed no other `matcher: ...Agent|Workflow...` exemplar in SKILL.md is missing its `GATE_BLOCKED_TOOLS` pairing

### Audit probes — SAFETY VALVE TAKEN

Instead of adding a dedicated `P31-P34` conditional cluster to `wc-audit.js` (cloning the `P22-P30` mechanism: schema, `executionClass`-style `applicable`/`naForDomain`, composite exclusion, a new reviewer prompt), I folded the gate-doctrine sub-checks into the **existing P02/P03/P04** principle definitions in the Mode 2 SKILL section. This gets the same reviewers scoring the same behavior with **zero risk** to the composite/verifier machinery in a 613-line JS gate computer. **`wc-audit.js` is unchanged by this PR.** A dedicated P31-P34 cluster is a reasonable, lower-risk follow-up once this fold-in has been exercised on a real audit.

### Reconciled vs. already-existing doctrine (not duplicated)

- `matcher`/`GATE_BLOCKED_TOOLS` landmine (~line 358) + P20 sub-probe (~line 1695) — cross-referenced from L7, not restated
- D1 `gateProbe` pass/artifactsPresent independence (~line 669) — L4/L5 generalize it beyond the compiled-runner D1 seam
- P22-P30 compiled-runner cluster in `wc-audit.js` — untouched; this doctrine is broader (any self-grading gate, not just DAG-of-mechanical-work runners)
- `tests/workflow_return_shape_test.py` — pointed to, not rewritten; run as part of both checklists

### New constraint

`references/constraints/wc-gate-contract.md` (MD-only, `applies-to: [workflow-creator]`) states the 3-way-contract Iron Law in a few lines and points to `gate-doctrine.md`.

## Test plan

- [x] `node --check workflows/wc-audit.js` passes (file untouched)
- [x] `python3 tests/workflow_return_shape_test.py` passes (14/14)
- [x] `node --test tests/wc-audit-verify-batch.test.mjs` passes (12/12)
- [x] All `tests/*.py` run individually (pytest can't collect this dir as a package — several scripts call `sys.exit()` at module scope, a pre-existing repo pattern) — all pass except a **pre-existing, unrelated** Python-3.9 syntax error in `constraints/typst-notes-structure.py` (`X | None` type hint needs 3.10+)
- [x] `references/constraints/check-all.py workflow-creator` confirms `wc-gate-contract` surfaces correctly; same pre-existing `typst-notes-structure` error is the only failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)