### PR TITLE
paperpile: fix auth refresh hanging on an unrelated wedged tab

### DIFF
--- a/skills/paperpile/SKILL.md
+++ b/skills/paperpile/SKILL.md
@@ -20,7 +20,8 @@ If the CLI fails, it is almost always stale auth — refresh cookies (below), do
 - `paperpile` binary at `~/.local/bin/paperpile` (Bun-compiled from `~/projects/paperpile-cli`)
 - Valid auth cookies. If `paperpile auth` fails, **refresh them automatically** (no manual
   Cookie-Editor export needed): `${CLAUDE_SKILL_DIR}/scripts/refresh-auth-from-dia.sh` pulls the
-  cookies from the logged-in Dia browser over CDP (:9222), imports them, and verifies.
+  cookies from the logged-in browser over CDP (:9222 — Dia on macOS, Chromium on Linux),
+  imports them, and verifies.
 - For PDF resolution: Chrome running with CDP on port 9250 (dedicated instance at `~/.config/chrome-cdp`)
 
 ## Library Management
@@ -196,8 +197,9 @@ Paperpile (this skill) → cite-check (upload PDFs to Gemini)
 - Paperpile All Papers: `~/Library/CloudStorage/GoogleDrive-eddyhu@gmail.com/My Drive/resources/Paperpile/All Papers/`
 - Cookies expire (~30 days for Paperpile, ~8-12h for Shibboleth hard expiry). To refresh, run
   `${CLAUDE_SKILL_DIR}/scripts/refresh-auth-from-dia.sh` — it extracts the live cookies from the
-  logged-in Dia browser via CDP (:9222) and `paperpile auth import`s them (no Cookie-Editor export).
-  Requires being logged into Paperpile in Dia; if not, log in there first.
+  logged-in browser via CDP (:9222 — Dia on macOS, Chromium on Linux) and `paperpile auth import`s
+  them (no Cookie-Editor export). Requires being logged into Paperpile in that browser; if not, log
+  in there first.
 
 ## Red Flags
 

--- a/skills/paperpile/scripts/refresh-auth-from-dia.sh
+++ b/skills/paperpile/scripts/refresh-auth-from-dia.sh
@@ -1,19 +1,27 @@
 #!/usr/bin/env bash
-# Refresh `paperpile` CLI auth by pulling cookies from the logged-in Dia browser
+# Refresh `paperpile` CLI auth by pulling cookies from the logged-in browser
 # over CDP — no manual Cookie-Editor export needed.
 #
-# Usage: refresh-auth-from-dia.sh [CDP_PORT]   (default 9222 = Dia)
-# Prereq: Dia is on CDP (port 9222) and logged into Paperpile in some tab.
+# Usage: refresh-auth-from-dia.sh [CDP_PORT]   (default 9222)
+# Prereq: the browser is on CDP (port 9222) and logged into Paperpile.
+#         macOS: Dia. Linux: Chromium. Same port either way.
 #
 # Flips the path of least resistance: when `paperpile auth` fails, this is the
 # one command to run — there is never a reason to drive the Paperpile web UI.
+#
+# Cookies are read from the BROWSER-level CDP target via Storage.getCookies,
+# not from a page target. Page targets route through a renderer, and a wedged
+# tab (a playing YouTube tab reproduces this) never answers Network.getCookies —
+# which used to hang this script forever, since it attached to whichever page
+# happened to be listed first. The browser target has no renderer to wedge.
 set -euo pipefail
 
 PORT="${1:-9222}"
 BASE="http://localhost:${PORT}"
 
 if ! curl -sf --connect-timeout 2 "${BASE}/json/version" >/dev/null; then
-  echo "error: no CDP browser on :${PORT} (Dia). Bring it up (browser-automation skill) and retry." >&2
+  echo "error: no CDP browser on :${PORT} (Dia on macOS, Chromium on Linux)." >&2
+  echo "       Bring it up (browser-automation skill) and retry." >&2
   exit 1
 fi
 
@@ -22,27 +30,54 @@ trap 'rm -f "$TMP"' EXIT
 
 OUT="$TMP" CDP_BASE="$BASE" node - <<'NODE'
 const base = process.env.CDP_BASE;
-const list = await (await fetch(`${base}/json/list`)).json();
-const t = list.find(x => x.type === 'page' && x.webSocketDebuggerUrl);
-if (!t) { console.error('error: no page target to attach to'); process.exit(1); }
-const ws = new WebSocket(t.webSocketDebuggerUrl);
+
+// Browser-level target: immune to a wedged page renderer.
+const ver = await (await fetch(`${base}/json/version`)).json();
+if (!ver.webSocketDebuggerUrl) {
+  console.error('error: CDP gave no browser-level webSocketDebuggerUrl');
+  process.exit(1);
+}
+const ws = new WebSocket(ver.webSocketDebuggerUrl);
+
+let nextId = 1;
 const cmd = (method, params = {}) => {
-  const id = Math.floor(Math.random() * 1e9);
+  const id = nextId++;
   return new Promise((res, rej) => {
-    const h = (e) => { const m = JSON.parse(e.data); if (m.id === id) { ws.removeEventListener('message', h); m.error ? rej(new Error(JSON.stringify(m.error))) : res(m.result); } };
+    // Never wait forever: a hang here is what this script is fixing.
+    const timer = setTimeout(() => rej(new Error(`timed out waiting for ${method}`)), 10000);
+    const h = (e) => {
+      const m = JSON.parse(e.data);
+      if (m.id !== id) return;
+      clearTimeout(timer);
+      ws.removeEventListener('message', h);
+      m.error ? rej(new Error(JSON.stringify(m.error))) : res(m.result);
+    };
     ws.addEventListener('message', h);
     ws.send(JSON.stringify({ id, method, params }));
   });
 };
-await new Promise(r => ws.addEventListener('open', r));
-const { cookies } = await cmd('Network.getCookies', { urls: ['https://app.paperpile.com', 'https://paperpile.com', 'https://www.paperpile.com'] });
-ws.close();
-if (!cookies.some(c => c.name === 'plack_session')) {
-  console.error('error: no Paperpile session cookie found — log into Paperpile in Dia first.');
-  process.exit(2);
+
+const fail = (msg, code) => { console.error(msg); try { ws.close(); } catch {} process.exit(code); };
+
+await new Promise((r, j) => {
+  ws.addEventListener('open', r);
+  ws.addEventListener('error', () => j(new Error('CDP websocket failed')));
+});
+
+let all;
+try {
+  ({ cookies: all } = await cmd('Storage.getCookies'));
+} catch (e) {
+  fail(`error: could not read cookies over CDP — ${e.message}`, 1);
 }
+
+const cookies = all.filter((c) => /(^|\.)paperpile\.com$/.test(c.domain));
+if (!cookies.some((c) => c.name === 'plack_session')) {
+  fail('error: no Paperpile session cookie found — log into Paperpile in the browser first.', 2);
+}
+
 const ss = { None: 'no_restriction', Lax: 'lax', Strict: 'strict' };
-const out = cookies.map(c => ({
+const out = cookies.map((c) => ({
   domain: c.domain, name: c.name, value: c.value, path: c.path || '/',
   secure: !!c.secure, httpOnly: !!c.httpOnly, sameSite: ss[c.sameSite] || 'no_restriction',
   expirationDate: (c.expires && c.expires > 0) ? c.expires : undefined,
@@ -50,6 +85,8 @@ const out = cookies.map(c => ({
 }));
 (await import('node:fs')).writeFileSync(process.env.OUT, JSON.stringify(out, null, 2));
 console.error(`extracted ${out.length} cookies`);
+ws.close();
+process.exit(0);
 NODE
 
 paperpile auth import "$TMP"


### PR DESCRIPTION
Found while sweeping for CDP credential paths across the `-cli` repos (companion to superhuman-cli / morgen-cli / readwise-cli work). **This is a real, reproduced hang in the Paperpile auth-refresh path — not a portability nit.**

## The bug

`refresh-auth-from-dia.sh` attached to the **first** page target the browser listed:

```js
const t = list.find(x => x.type === 'page' && x.webSocketDebuggerUrl);
```

The `type === 'page'` filter is correct as far as it goes, but *which* page you get is arbitrary — and `Network.getCookies` routes through that page's renderer.

Reproduced on Linux: the first page target was a playing `music.youtube.com` tab, and `Network.getCookies` **never answered**. The script had no timeout anywhere, so it hung indefinitely and `paperpile auth import` never ran. Auth simply could not be refreshed, with no error explaining why.

Probing all six live page targets:

| target | `Network.getCookies` | after `Network.enable` |
|---|---|---|
| `music.youtube.com/playlist` | **TIMEOUT** | **TIMEOUT** |
| `chrome://newtab/` | ok(8) | ok(8) |
| `www.youtube.com/watch` | **TIMEOUT** | **TIMEOUT** |
| `read.readwise.io/later` | ok(8) | ok(8) |
| `web.morgen.so/` | ok(8) | ok(8) |
| `mail.superhuman.com/…` | ok(8) | ok(8) |

`Network.enable` does not help. Whether a refresh works comes down to which tab happens to be listed first — i.e. it silently depends on unrelated browsing.

## The fix

Read from the **browser-level** target via `Storage.getCookies`. It has no renderer, so no tab can wedge it, and it requires no page target to exist at all — which also removes the old `no page target to attach to` failure mode. The result is filtered to `paperpile.com` domains rather than passing per-URL filters.

Also added a **10s per-command timeout** so any future stall surfaces an error instead of hanging forever, plus a websocket error handler.

## On the "Dia" naming

The mechanism was never macOS-specific — the script only ever *attaches* to whatever is on `:9222` and never launches a browser, so it already worked on Linux. But the prose named Dia, which is macOS-only. Reworded here and in `SKILL.md`: Dia on macOS, Chromium on Linux, same port. **Filename kept** so existing `SKILL.md` references and muscle memory still resolve.

## Verification

Live on Linux against the real browser:

- extracts **12 cookies** across `.paperpile.com` / `search.paperpile.com` / `api.paperpile.com`
- `plack_session` present; every cookie has a value; correct Cookie-Editor shape (`hostOnly`/`session`/`sameSite`)
- returns immediately, where the old script hung until killed
- `bash -n` clean; mode `755` preserved

I ran the **extraction half only** — deliberately not `paperpile auth import` — to avoid mutating the real credential store. Cookie values were never printed; only names/domains/presence were checked.

## Note for the reviewer

This also corrects something I reported earlier in the session: I said paperpile-cli has "no refresh path at all." That was wrong about the system as a whole — the CLI has none, but **the refresh lives here in the skill layer**. This script *is* the Paperpile auth refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZvrft29zMGgks5abHVtVK