### PR TITLE
chore: bump workflows to 5.70.1 so the paperpile auth fix ships

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.70.0"
+    "version": "5.70.1"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.70.0",
+      "version": "5.70.1",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.70.0",
+  "version": "5.70.1",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"


### PR DESCRIPTION
Follow-up to #57. **That fix is merged but is not reaching anyone — including this machine.**

## Why merging was not enough

The plugin cache is **version-keyed**: `~/.claude/plugins/cache/edwinhu-plugins/workflows/5.70.0/`. #57 changed the skill script but left the version at `5.70.0`, so the installer sees that version already cached and skips re-copying from the marketplace source. `/reload-plugins` then faithfully reloads the **stale** copy.

Verified directly after a reload on this machine:

```
STALE    ~/.claude/plugins/cache/edwinhu-plugins/workflows/5.70.0/skills/paperpile/scripts/refresh-auth-from-dia.sh
UPDATED  ~/.claude/plugins/marketplaces/edwinhu-plugins/skills/paperpile/scripts/refresh-auth-from-dia.sh
```

The cached script still lacks `Storage.getCookies` — i.e. it is still the old `Network.getCookies` version that hangs indefinitely on a wedged tab, which is exactly the bug #57 set out to fix.

## Change

Bump `5.70.0` → `5.70.1` across all three version fields, so the installer materializes a fresh `5.70.1` cache from source:

- `.claude-plugin/plugin.json` → `version`
- `.claude-plugin/marketplace.json` → `metadata.version`
- `.claude-plugin/marketplace.json` → `plugins[].version`

Patch-level is right: the only change since 5.70.0 is a bugfix.

Both files re-validated as parseable JSON, and no stray `5.70.0` remains under `.claude-plugin/`.

## Note on convention

The repo pairs the bump with the substantive commit (e.g. 7839ae8). This is a separate commit only because #57 omitted it — my miss. Worth remembering that for a versioned plugin, "merged" and "shipped" are different things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZvrft29zMGgks5abHVtVK