### PR TITLE
docs(wrds): add PROC CONTENTS/DATASETS/PRINT probing to SAS references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.70.1"
+    "version": "5.71.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.70.1",
+      "version": "5.71.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.70.1",
+  "version": "5.71.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/phase-gate-guard.py
+++ b/hooks/phase-gate-guard.py
@@ -84,14 +84,56 @@ verified in tests/phase_gate_guard_test.py:
     `APPROVED`. Same for quoted scalars with escapes or trailing junk.
   - STRICTER: duplicate keys now block instead of resolving to one of them.
     Ambiguous evidence is not evidence.
+  - STRICTER (bug fix): `status:APPROVED` no longer matches. A block mapping
+    needs whitespace after the colon, so YAML reads that line as the plain
+    scalar "status:APPROVED" — the document has no `status` key at all, and the
+    old reader handed back `APPROVED` from it.
   - LOOSER (YAML correctness): `status: APPROVED # signed off` now passes. YAML
     says that value is `APPROVED`; the old reader compared the whole string
     including the comment and blocked. A quoted `'APPROVED # invalid'` still
     blocks — inside quotes the '#' is literal text, not a comment.
+
+  - STRICTER: the frontmatter must be a FLAT mapping of scalars. If any
+    top-level line opens a flow collection or leaves a quote unterminated, the
+    whole block is refused — such a construct captures the lines beneath it, so
+    `broken: [` followed by `status: APPROVED` has no top-level `status` at all,
+    yet a line-wise reader would find one. Indented content (block scalars,
+    nested mappings) is fine: it cannot masquerade as a top-level key.
+
+Decorated YAML — anchors (`&a`), tags (`!!str`), aliases (`*a`), flow
+collections (`[x]`, `{k: v}`) — is not a plain scalar and fails closed. Gate
+artifacts never legitimately use them, and a resolver for them is surface to get
+subtly wrong. One accepted leniency: a stray trailing tab (`status: APPROVED\t`)
+is read as `APPROVED` where PyYAML rejects the document outright; it cannot
+smuggle a different value (`status: APPROVED\tx` still blocks).
+
+tests/phase_gate_guard_differential_test.py pins all of this against PyYAML over
+a generated corpus: the reader must never accept a value PyYAML disagrees with.
+
+KNOWN RESIDUAL — the reader can accept a gate value from a document that is
+malformed SOMEWHERE ELSE. Its checks cover every column-0 line, but indented
+lines are skipped by design (they belong to a parent key), so:
+
+    status: APPROVED
+    prior:
+      broken: 'x' junk        <- invalid YAML; PyYAML rejects the whole document
+
+still reads `status: APPROVED`. Closing this means validating the entire
+document — i.e. a real YAML parser, which is the dependency this hook avoids on
+purpose (it fires on every tool call; a gate that must resolve a package before
+answering can fail OPEN, which is strictly worse than this).
+
+The residual is bounded and does not fabricate verdicts. Everything that could
+make a line MEAN something other than what it says — capture by a multi-line
+construct, quoting, escapes, comments, duplicate keys — fails closed. What
+remains is only: a gate line that genuinely says `APPROVED`, in a file whose
+unrelated line is corrupt. It cannot smuggle a value the artifact does not
+contain, which is what the gate exists to prevent.
 """
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -175,9 +217,9 @@ def _yaml_scalar(raw: str) -> str:
                 return ''
             if ch == quote:
                 # Closing quote: only whitespace and an optional comment may
-                # follow. Anything else means this isn't the scalar we think.
-                rest = raw[i + 1:].strip()
-                if rest and not rest.startswith('#'):
+                # follow, and YAML needs whitespace before that comment.
+                # Anything else means this isn't the scalar we think.
+                if not _rest_is_clean(raw[i + 1:]):
                     return ''
                 return ''.join(chars)
             chars.append(ch)
@@ -192,12 +234,138 @@ def _yaml_scalar(raw: str) -> str:
     return raw
 
 
+def _quote_scan(value: str):
+    """(closed, raw_text_after_closing_quote) for a quoted scalar.
+
+    The remainder is returned UNSTRIPPED: whether whitespace separated the
+    closing quote from what follows is load-bearing (see _rest_is_clean).
+    """
+    quote = value[0]
+    i = 1
+    while i < len(value):
+        if quote == "'" and value[i] == "'" and value[i + 1:i + 2] == "'":
+            i += 2          # '' escape
+            continue
+        if quote == '"' and value[i] == '\\':
+            i += 2          # \x escape
+            continue
+        if value[i] == quote:
+            return True, value[i + 1:]
+        i += 1
+    return False, ''
+
+
+def _rest_is_clean(rest: str) -> bool:
+    """May this text follow a closing quote — i.e. nothing, or a real comment?
+
+    YAML requires whitespace before a trailing `#`, so `'APPROVED'#x` is not a
+    value plus a comment: it's a syntax error, and PyYAML rejects the document
+    rather than reading `APPROVED` out of it. Accepting the `#` as a comment
+    would open a gate on a file YAML refuses to parse.
+    """
+    if rest == '':
+        return True
+    if rest[:1] not in (' ', '\t'):
+        return False
+    tail = rest.strip()
+    return tail == '' or tail.startswith('#')
+
+
+# A gate artifact's top-level line is `key: scalar`. Anything outside that
+# subset is refused rather than interpreted — see supported_line().
+_KEY_RE = re.compile(r'^[A-Za-z0-9_.\-]+$')
+_BLOCK_HEADER_RE = re.compile(r'^[|>][+-]?\d*\s*(#.*)?$')
+# Indicators that start something other than a plain scalar: flow collections,
+# properties/aliases, complex keys, directives, and YAML's reserved characters.
+_NOT_PLAIN = set('!&*[]{}?%@`,>|')
+
+
+def supported_line(line: str) -> bool:
+    """Is this column-0 line inside the narrow `key: scalar` subset we support?
+
+    An ALLOWLIST, deliberately. Enumerating dangerous constructs is endless —
+    each new YAML feature is another hole. Enumerating the *supported* ones is
+    closed: anything unrecognized fails closed, including syntax that makes the
+    document invalid outright (`broken: 'x' junk`, `broken: foo: bar`), because
+    a gate must not read a value out of a file YAML itself rejects.
+    """
+    if ':' not in line:
+        return False                       # not a mapping entry at all
+    key, value = line.split(':', 1)
+    if not _KEY_RE.match(key):
+        return False                       # exotic key, or a `%TAG ...` directive
+    if value and value[:1] not in (' ', '\t'):
+        return False                       # `key:value` — YAML needs the space
+
+    v = value.strip()
+    if not v or v.startswith('#'):
+        return True                        # empty value, or value-less + comment
+    if _BLOCK_HEADER_RE.match(v):
+        return True                        # `|`, `>-`: content is indented, safe
+
+    if v[0] in ('"', "'"):
+        closed, rest = _quote_scan(v)
+        if not closed:
+            return False                   # captures the lines below
+        if v[0] == '"' and '\\' in v:
+            return False                   # escapes we deliberately don't decode
+        return _rest_is_clean(rest)        # no trailing tokens, no `'x'#unspaced`
+
+    if v[0] in _NOT_PLAIN:
+        return False
+    plain = v.split(' #', 1)[0].rstrip()   # drop a trailing comment
+    if ': ' in plain or plain.endswith(':'):
+        return False                       # `foo: bar` as a value — invalid here
+    return True
+
+
+def frontmatter_is_flat(frontmatter: str) -> bool:
+    """Is this frontmatter a flat mapping of scalars — i.e. safe to read line by line?
+
+    Reading a gate field line-by-line is only sound when no line can be captured
+    by a construct opened on an earlier one. An unterminated flow collection or
+    quote swallows the lines beneath it, so
+
+        broken: [
+        status: APPROVED
+
+    has NO top-level `status` — the line belongs to `broken` — yet a line-wise
+    reader sees `status: APPROVED` and opens the gate. Rather than re-implement
+    YAML to find out, refuse the whole block: a gate that cannot trust its own
+    evidence must not pass on it.
+
+    Enforced by supported_line(), which is an ALLOWLIST — that is what makes
+    this closed rather than whack-a-mole. Rejecting known-dangerous constructs
+    invites an endless series of "one more syntax": a flow collection captures
+    the lines below it, a tag hides the quote that captures them, and so on.
+    Accepting only `key: scalar` inverts the burden — unrecognized syntax fails
+    closed by default, including syntax that makes the document invalid outright,
+    which YAML would refuse to read at all.
+
+    Block scalars (`|`, `>`) are allowed and are not a hole: their content must
+    be INDENTED, so they can never capture a column-0 line (verified against
+    PyYAML). Plain scalars can continue, but only onto INDENTED lines, which
+    frontmatter_value() fails closed on.
+    """
+    for line in frontmatter.splitlines():
+        if not line.strip() or line.lstrip().startswith('#'):
+            continue
+        if line[:1] in (' ', '\t'):
+            continue            # indented: belongs to a parent key, not our level
+        if not supported_line(line):
+            return False
+    return True
+
+
 def frontmatter_value(frontmatter: str, key: str) -> str:
     """Return the top-level scalar for `key`, or '' when absent or ambiguous.
 
     Fails closed: an absent, nested, duplicated, or non-scalar key all yield ''
     so the caller blocks. A gate that cannot read its own evidence must not pass.
     """
+    if not frontmatter_is_flat(frontmatter):
+        return ''
+
     lines = frontmatter.splitlines()
     matches = []
     for i, line in enumerate(lines):
@@ -208,6 +376,15 @@ def frontmatter_value(frontmatter: str, key: str) -> str:
         if line.lstrip().startswith('#'):
             continue
         if not line.startswith(f'{key}:'):
+            continue
+
+        # A block mapping needs whitespace (or EOL) after the colon: `status:X`
+        # is NOT a key/value pair, it's the plain scalar "status:X", so the
+        # document has no `status` key at all. Matching it anyway would read
+        # `APPROVED` out of `status:APPROVED` and open a gate on a document
+        # that never recorded a status.
+        after = line[len(key) + 1:]
+        if after and after[:1] not in (' ', '\t'):
             continue
 
         # A YAML plain scalar continues onto indented following lines, so
@@ -328,6 +505,20 @@ def main():
             f"This phase cannot proceed without the gate artifact from the "
             f"previous phase. The artifact proves the gate actually ran — "
             f"instructional text alone is not enforcement.\n\n"
+            f"**Remedy:** {gate_remedy}"
+        )
+
+    if (required_status or required_fields) and not frontmatter_is_flat(read_frontmatter(artifact_path)):
+        deny(
+            tool_name, file_path,
+            f"GATE BLOCKED: {gate_description} — artifact is not readable.\n\n"
+            f"`{artifact_path}` does not parse as a flat YAML mapping of simple "
+            f"values: a line opens a flow collection (`[`, `{{`) or leaves a quote "
+            f"unterminated, which captures the lines beneath it. The gate cannot "
+            f"tell what this file actually records, and evidence it cannot read "
+            f"is not evidence.\n\n"
+            f"Fix the frontmatter so every top-level line is a plain `key: value` "
+            f"pair, then re-run the phase.\n\n"
             f"**Remedy:** {gate_remedy}"
         )
 

--- a/hooks/phase-gate-guard.py
+++ b/hooks/phase-gate-guard.py
@@ -7,9 +7,25 @@ artifact path and a human-readable gate description via environment variables:
 
   GATE_ARTIFACT=.planning/PLAN_REVIEWED.md
   GATE_STATUS=APPROVED           (optional: required frontmatter status value)
+  GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable
+                                 (optional: frontmatter keys that must be present,
+                                  optionally constrained to an allowed value set)
   GATE_DESCRIPTION=Plan review   (human-readable name for error messages)
   GATE_REMEDY=Return to dev-design and run dev-plan-reviewer
   GATE_BLOCKED_TOOLS=Write,Edit,Bash,Agent  (optional: default Write|Edit)
+
+GATE_REQUIRE_FIELDS syntax: comma-separated entries, each either `name` (key must
+be present and non-empty) or `name:v1|v2` (must also be one of the listed values).
+It answers a question GATE_STATUS cannot: "was this decision *recorded*, or
+silently skipped?" A phase can legitimately end in several dispositions, so
+pinning one `status:` value is wrong — but leaving the field absent entirely
+means the phase never ran and nobody noticed.
+
+Constraining the value set also catches the copy-paste failure: SKILL.md YAML
+templates are written as `field: a | b | c`, and an agent that pastes the
+template verbatim without substituting leaves a literal `a | b | c` that matches
+no single allowed value — so the gate blocks instead of accepting a placeholder
+as a real answer.
 
 Scoped to individual phase skills via frontmatter hooks. The skill sets env vars
 in the hook command, making this one script reusable across all workflow phases.
@@ -28,6 +44,17 @@ Usage in SKILL.md frontmatter:
               GATE_BLOCKED_TOOLS=Agent
               uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
 
+LANDMINE: GATE_REQUIRE_FIELDS values contain `|`, which bash reads as a PIPE. The
+assignment MUST be quoted in the hook command:
+
+    GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"   # correct
+    GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable     # BROKEN
+
+Unquoted, bash parses it as a pipeline, the env var is never set, this script sees
+no field requirement, and the gate silently allows everything — a phantom gate that
+looks wired but never blocks. `tests/phase_gate_guard_test.py` executes the real
+command strings out of the SKILL.md frontmatter to catch exactly this.
+
 LANDMINE: the `matcher` alone does NOT block a tool — it only decides which tool calls invoke this
 script. Blocking is decided here, by GATE_BLOCKED_TOOLS, which DEFAULTS to Write,Edit only (see
 DEFAULT_BLOCKED_TOOLS below). A matcher of "Write|Edit|Agent" with no GATE_BLOCKED_TOOLS=...,Agent
@@ -38,6 +65,29 @@ its matcher. Always list every tool named in `matcher` in GATE_BLOCKED_TOOLS too
 Grounded in: April 2026 meta-audit — workflow-creator found that advisory gates
 ("you must run X first") were systematically skipped under context pressure.
 Hooks are runtime-enforced by Claude Code; Claude cannot rationalize past them.
+
+FRONTMATTER READING — behavior notes for the skills already wiring this hook:
+
+The reader is hand-rolled and fails closed: absent, nested, duplicated, or
+non-scalar keys all read as '' and the gate blocks. Three consequences, all
+verified in tests/phase_gate_guard_test.py:
+
+  - STRICTER (bug fix): a nested `status: APPROVED` no longer satisfies the
+    status gate. The previous reader stripped every line before matching, so any
+    indented `status:` under any parent key passed the gate — a real bypass in
+    every skill that wires it.
+  - STRICTER (bug fix): `---` is a delimiter only as a standalone line. The
+    previous `text.split('---', 2)` cut on any occurrence, so the scalar
+    `status: APPROVED---nope` was truncated to a passing `APPROVED`.
+  - STRICTER: a plain scalar's indented continuation lines (`status: APPROVED`
+    / `  nope` — one value, `APPROVED nope`) now block instead of reading as
+    `APPROVED`. Same for quoted scalars with escapes or trailing junk.
+  - STRICTER: duplicate keys now block instead of resolving to one of them.
+    Ambiguous evidence is not evidence.
+  - LOOSER (YAML correctness): `status: APPROVED # signed off` now passes. YAML
+    says that value is `APPROVED`; the old reader compared the whole string
+    including the comment and blocked. A quoted `'APPROVED # invalid'` still
+    blocks — inside quotes the '#' is literal text, not a comment.
 """
 
 import json
@@ -58,29 +108,168 @@ def check_artifact_exists(artifact_path: str) -> bool:
     return Path(artifact_path).is_file()
 
 
-def check_artifact_status(artifact_path: str, required_status: str) -> bool:
-    """Check if the artifact's frontmatter contains the required status."""
+def read_frontmatter(artifact_path: str) -> str:
+    """Return the artifact's YAML frontmatter block, or '' if there isn't one.
+
+    A delimiter is a LINE that is exactly `---`, not any `---` substring: the
+    latter truncates scalars that merely contain the sequence, so
+    `status: APPROVED---nope` would be cut down to a passing `APPROVED` when
+    YAML says the value is `APPROVED---nope`.
+    """
     try:
         text = Path(artifact_path).read_text()
     except Exception:
-        return False
+        return ''
 
-    # Parse YAML frontmatter (between --- delimiters)
-    if not text.startswith('---'):
-        return False
-    parts = text.split('---', 2)
-    if len(parts) < 3:
-        return False
-    frontmatter = parts[1]
+    # rstrip, not strip: trailing whitespace after `---` is still a delimiter,
+    # but an INDENTED `  ---` is a plain-scalar continuation line — YAML reads
+    # `status: APPROVED` + `  ---` as the single value `APPROVED ---`, so
+    # treating it as the closing delimiter would pass a gate on a value the
+    # document doesn't contain.
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != '---':
+        return ''
+    for i in range(1, len(lines)):
+        if lines[i].rstrip() == '---':
+            return '\n'.join(lines[1:i])
+    return ''  # unterminated frontmatter — no readable evidence
 
-    # Simple status check — look for "status: VALUE" line
-    for line in frontmatter.strip().splitlines():
-        line = line.strip()
-        if line.startswith('status:'):
-            value = line.split(':', 1)[1].strip().strip('"').strip("'")
-            return value.upper() == required_status.upper()
 
-    return False
+def _yaml_scalar(raw: str) -> str:
+    """Extract the scalar from a YAML `key:` right-hand side.
+
+    Deliberately hand-rolled: every hook here is dependency-free, and this one
+    fires on every tool call — a hook that must resolve a package before it can
+    answer is a hook that can fail open. Handles exactly what gate fields are:
+    short quoted-or-bare scalars. Anything else returns '' and the gate blocks.
+    """
+    raw = raw.strip()
+    if not raw:
+        return ''
+
+    # Quoted scalar: the value is what's between the quotes. A '#' inside is
+    # literal text, NOT a comment — `'enabled # error'` is one value, not
+    # `enabled` with a note. Quotes are not merely delimiters to scan past:
+    # YAML escapes a quote by doubling it ('' inside '...') or with a backslash
+    # (\" inside "..."), so `'APPROVED'' # invalid'` is the single value
+    # `APPROVED' # invalid` — reading it as `APPROVED` would pass a gate the
+    # artifact does not actually satisfy.
+    if raw[0] in ('"', "'"):
+        quote = raw[0]
+        chars = []
+        i = 1
+        while i < len(raw):
+            ch = raw[i]
+            if quote == "'" and ch == "'" and raw[i + 1:i + 2] == "'":
+                chars.append("'")          # '' -> literal '
+                i += 2
+                continue
+            if quote == '"' and ch == '\\':
+                # A double-quoted YAML scalar can escape a newline (\n), a tab,
+                # a codepoint (✓)... Decoding that table by hand is a way to
+                # be subtly wrong: naively dropping the backslash turns
+                # "decli\ned" into `declined`, when YAML says it contains a
+                # newline and is NOT `declined`. Gate values are short enums —
+                # `APPROVED`, `enabled` — that never legitimately need an escape,
+                # so refuse the whole scalar instead of decoding it.
+                return ''
+            if ch == quote:
+                # Closing quote: only whitespace and an optional comment may
+                # follow. Anything else means this isn't the scalar we think.
+                rest = raw[i + 1:].strip()
+                if rest and not rest.startswith('#'):
+                    return ''
+                return ''.join(chars)
+            chars.append(ch)
+            i += 1
+        return ''                          # unterminated quote
+
+    # Bare scalar: YAML only starts a comment at a '#' preceded by whitespace,
+    # so `enabled#1` is a value while `enabled # note` is a value + comment.
+    for i, ch in enumerate(raw):
+        if ch == '#' and (i == 0 or raw[i - 1] in ' \t'):
+            return raw[:i].strip()
+    return raw
+
+
+def frontmatter_value(frontmatter: str, key: str) -> str:
+    """Return the top-level scalar for `key`, or '' when absent or ambiguous.
+
+    Fails closed: an absent, nested, duplicated, or non-scalar key all yield ''
+    so the caller blocks. A gate that cannot read its own evidence must not pass.
+    """
+    lines = frontmatter.splitlines()
+    matches = []
+    for i, line in enumerate(lines):
+        # Top-level keys only — an indented `codex_second_pass:` belongs to some
+        # nested mapping and must not satisfy a top-level requirement.
+        if not line[:1].strip():
+            continue
+        if line.lstrip().startswith('#'):
+            continue
+        if not line.startswith(f'{key}:'):
+            continue
+
+        # A YAML plain scalar continues onto indented following lines, so
+        #     status: APPROVED
+        #       nope
+        # is the single value `APPROVED nope` — reading only the first line
+        # would pass a gate on a value the document doesn't contain. Any
+        # indented continuation makes this unreadable here: fail closed.
+        nxt = lines[i + 1] if i + 1 < len(lines) else ''
+        if nxt.strip() and nxt[:1] in (' ', '\t'):
+            return ''
+
+        matches.append(_yaml_scalar(line.split(':', 1)[1]))
+
+    # Duplicate keys are ambiguous (real YAML rejects them) — block, don't guess.
+    if len(matches) != 1:
+        return ''
+    return matches[0]
+
+
+def check_artifact_status(artifact_path: str, required_status: str) -> bool:
+    """Check if the artifact's frontmatter contains the required status."""
+    frontmatter = read_frontmatter(artifact_path)
+    if not frontmatter:
+        return False
+    value = frontmatter_value(frontmatter, 'status')
+    return bool(value) and value.upper() == required_status.upper()
+
+
+def parse_required_fields(spec: str) -> list:
+    """Parse GATE_REQUIRE_FIELDS into [(key, allowed_values_or_None), ...].
+
+    `name` -> presence only; `name:v1|v2` -> presence + membership.
+    """
+    requirements = []
+    for entry in spec.split(','):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ':' in entry:
+            key, values = entry.split(':', 1)
+            allowed = {v.strip().lower() for v in values.split('|') if v.strip()}
+            requirements.append((key.strip(), allowed or None))
+        else:
+            requirements.append((entry, None))
+    return requirements
+
+
+def check_required_fields(artifact_path: str, spec: str) -> list:
+    """Return human-readable problems for each unmet field requirement."""
+    frontmatter = read_frontmatter(artifact_path)
+    problems = []
+    for key, allowed in parse_required_fields(spec):
+        value = frontmatter_value(frontmatter, key) if frontmatter else ''
+        if not value:
+            problems.append(f"`{key}` is missing or empty")
+        elif allowed and value.lower() not in allowed:
+            expected = ' | '.join(sorted(allowed))
+            problems.append(
+                f"`{key}: {value}` is not one of: {expected}"
+            )
+    return problems
 
 
 def is_allowed_path(file_path: str) -> bool:
@@ -93,6 +282,7 @@ def main():
     # Read hook configuration from environment
     artifact_path = os.environ.get('GATE_ARTIFACT', '')
     required_status = os.environ.get('GATE_STATUS', '')
+    required_fields = os.environ.get('GATE_REQUIRE_FIELDS', '')
     gate_description = os.environ.get('GATE_DESCRIPTION', 'Phase gate')
     gate_remedy = os.environ.get('GATE_REMEDY', 'Complete the previous phase first')
     blocked_tools_str = os.environ.get('GATE_BLOCKED_TOOLS', '')
@@ -149,6 +339,21 @@ def main():
             f"The file exists but does not have the required status.\n\n"
             f"**Remedy:** {gate_remedy}"
         )
+
+    if required_fields:
+        problems = check_required_fields(artifact_path, required_fields)
+        if problems:
+            detail = '\n'.join(f"- {p}" for p in problems)
+            deny(
+                tool_name, file_path,
+                f"GATE BLOCKED: {gate_description} — required decision not recorded.\n\n"
+                f"In `{artifact_path}`:\n{detail}\n\n"
+                f"The status says this phase passed, but a decision it was required "
+                f"to record is missing or unrecognized. A phase that reports success "
+                f"without recording what it decided cannot be audited afterwards — "
+                f"'it probably ran' is not evidence that it ran.\n\n"
+                f"**Remedy:** {gate_remedy}"
+            )
 
     # Gate passed — allow the tool call
     sys.exit(0)

--- a/references/codex-availability.md
+++ b/references/codex-availability.md
@@ -75,13 +75,81 @@ Codex when present, not to onboard it.
 
 ## Invoke adversarial review
 
-```bash
-# Foreground (small diffs, < ~3 files)
-node "$CODEX_SCRIPT" adversarial-review --wait
+Always `--json`, always redirected to a file:
 
-# Background (anything bigger or unclear)
-node "$CODEX_SCRIPT" adversarial-review --background
+```bash
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
+
+The handle is **per-iteration** and is `rm -f`'d before the state records
+`requested`. A single reused path can be joined while it still holds the
+*previous* pass's verdict — the redirect only truncates it at launch, so a stop
+between the state write and the invocation leaves last iteration's `approve`
+sitting there to be parsed as this one's answer.
+
+**`--json` is not optional.** It is the only form carrying `confidence`; the
+rendered text prints `[high]` with no number, so the >= 0.8 iron law below has
+nothing to read without it.
+
+**The redirect is not optional either.** It is what makes a detached run
+joinable: the file is the handle, and it survives an interruption that a
+terminal buffer or transcript does not.
+
+**Background is the harness's job, not the companion's.** `--background` is a
+no-op for reviews — `adversarial-review` always runs in the foreground (only the
+`task` subcommand enqueues a tracked job), so nothing is holding a result for a
+later `/codex:status` fetch. To detach, run the SAME `--wait --json` command
+through `Bash(..., run_in_background: true)` and join via the file.
+
+### The join (this step is mandatory)
+
+A launch is not a verdict. Clear the per-iteration handle **and verify the clear
+worked**, record `codex_second_pass: requested` + `codex_output_file:` (the exact
+path), invoke, then join by resolving that recorded path — never a hardcoded one:
+
+```bash
+OUT=.planning/codex-second-pass-iter[N].json
+rm -f "$OUT"
+[ -e "$OUT" ] && { echo "BLOCKED: cannot clear $OUT"; exit 1; }
+```
+
+`rm -f` is quiet both when the file never existed and when it could not be
+removed, and nothing checks its exit status by default. A silently-failed clear
+means the launch redirect fails too and the previous envelope survives to be
+joined as this pass's answer — so successful invalidation is a *precondition* for
+recording `requested`, not a hope. If it fails, record `error` / `status:
+BLOCKED` instead.
+
+```bash
+uv run python3 - <<'PY'
+import json, pathlib
+import re
+state = pathlib.Path('.planning/REVIEW_STATE.md')
+m = re.search(r'^codex_output_file:\s*(\S+)\s*$', state.read_text(), re.M) if state.exists() else None
+if not m:
+    print('ERROR: no codex_output_file recorded'); raise SystemExit(0)
+p = pathlib.Path(m.group(1))          # the handle THIS pass owns
+if not p.exists() or not p.stat().st_size:
+    print('PENDING'); raise SystemExit(0)
+try:
+    envelope = json.loads(p.read_text())
+    if envelope.get('codex', {}).get('status') != 0:
+        print('ERROR: exit', envelope.get('codex', {}).get('status')); raise SystemExit(0)
+    v = json.loads(envelope['codex']['stdout'])
+except Exception as e:
+    print('ERROR:', e); raise SystemExit(0)
+print(v['verdict'], [(f['confidence'], f['title']) for f in v.get('findings', [])])
+PY
+```
+
+The payload is an envelope — `{review, target, threadId, codex: {status, stdout}}`
+— and `codex.stdout` is the schema-validated verdict **as a JSON string**, so it
+takes a second parse. Only after a verdict is parsed may the skill move
+`SECOND_PASS_PENDING` to a terminal state, in ONE write.
+
+`PENDING` on a resumed session means the run never finished: relaunch. The gate
+stays shut throughout, because `requested` does not admit verify.
 
 Scope flags mirror `/codex:adversarial-review`:
 
@@ -172,8 +240,11 @@ use Codex when present, not to onboard it.
 `phase-gate-guard.py` gate with:
 
 ```
-GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable
+GATE_REQUIRE_FIELDS="codex_second_pass:completed|declined|unavailable"
 ```
+
+(The quotes are load-bearing: unquoted, bash reads `|` as a pipe, the env var
+never reaches the hook, and the gate silently allows everything.)
 
 so Agent dispatch in the verify phase is blocked until `.planning/REVIEW_STATE.md`
 records one of those three values. This puts the second pass on the top tier of
@@ -197,14 +268,22 @@ template is not a recorded decision.
 
 The consuming skill records what happened in `.planning/REVIEW_STATE.md`:
 
-| `codex_second_pass:` | Meaning |
-|----------------------|---------|
-| `enabled` | Codex ran and returned a verdict |
-| `declined` | Offered; user chose to approve without it |
-| `unavailable` | No script, probe not ready, or no git repo |
-| `error` | Codex ran but failed (non-zero exit / unparseable output) |
+| `codex_second_pass:` | Meaning | Admits verify? |
+|----------------------|---------|----------------|
+| `requested` | Launched; no verdict parsed yet | **No** — a launch is not an answer |
+| `completed` | Codex ran and returned a verdict | Yes |
+| `declined` | Offered; user chose to approve without it | Yes |
+| `unavailable` | No script, probe not ready, or no git repo | Yes |
+| `error` | Codex ran but failed (non-zero exit / unparseable output) | **No** |
 
-Three rules keep this field honest:
+Four rules keep this field honest:
+
+- **A launch is not a verdict.** Record `requested` when you invoke Codex, and
+  only `completed` once you have parsed its output. Writing the terminal value
+  up front is the bug that makes the whole gate ornamental: combined with a
+  `status: APPROVED` left over from an earlier task, it opens verify while Codex
+  is still running — or after it crashed. Write a non-approved `status` BEFORE
+  invoking, so the window never exists.
 
 - **Never write `enabled` unless a Codex run actually returned a verdict.** The
   field's whole purpose is to distinguish "Codex approved this" from "Codex

--- a/references/codex-availability.md
+++ b/references/codex-availability.md
@@ -1,7 +1,40 @@
-# Codex Availability Probe & Adversarial Review Invocation
+# Codex Availability Probe & Second-Pass Review Invocation
 
-Shared reference for skills that delegate adversarial review to the Codex plugin
-when available, with graceful fallback to in-process Claude reviewers.
+Shared reference for review skills that run an optional **Codex second pass** —
+an independent adversarial review that runs *after* the primary Claude reviewer
+approves, and *before* the phase writes its APPROVED verdict.
+
+Consumed by `skills/dev-review/SKILL.md` and `skills/ds-review/SKILL.md`.
+
+## The second pass is additive, never a substitute
+
+Codex does not replace the Claude reviewer. A Codex-instead-of-Claude review
+leaves the diff reviewed exactly once, which is the single-reviewer blind spot
+the second pass exists to close. The order is fixed:
+
+```
+primary Claude review (single | parallel)
+        │
+        ├── CHANGES_REQUIRED / ESCALATE / BLOCKED → fix loop (no second pass)
+        │
+        └── APPROVED (candidate verdict)
+                 │
+                 └── Codex second pass  ← optional, opt-in, this reference
+                          │
+                          ├── approve → write status: APPROVED → verify phase
+                          └── needs-attention (≥0.8) → CHANGES_REQUIRED → fix loop
+```
+
+**Why a different model family:** this is `skills/audit-fix-loop/SKILL.md` Iron
+Law 1 — "the auditor must not be the fixer" — applied to the model itself. A
+Claude reviewer auditing Claude's code shares its training and therefore its
+blind spots. Codex runs out-of-process on a different model family, so its
+misses are uncorrelated. Two reviewers that fail the same way are one reviewer.
+
+**Where it sits relative to the gate:** `.planning/REVIEW_STATE.md`'s
+`status: APPROVED` is the structural gate that dev-verify / ds-verify hook on.
+The second pass therefore runs BEFORE that line is written. A second pass that
+ran after the gate was already open would be decorative.
 
 ## Locate the Codex companion script
 
@@ -89,16 +122,24 @@ The companion emits a structured payload validated against
 | `findings[]` | Each has `severity`, `title`, `body`, `file`, `line_start`, `line_end`, `confidence` (0-1), `recommendation` |
 | `next_steps[]` | Suggested follow-ups                               |
 
-### Mapping to dev-review verdicts
+### Mapping to review verdicts
+
+Identical in dev-review and ds-review; the implement/verify phase names differ.
 
 | Codex verdict     | Map to               | Notes                                                                          |
 |-------------------|----------------------|--------------------------------------------------------------------------------|
-| `approve`         | `APPROVED`           | Proceed to dev-verify                                                          |
-| `needs-attention` with any finding `confidence >= 0.8` | `CHANGES_REQUIRED` | Forward findings to dev-implement                       |
-| `needs-attention` with all findings `confidence < 0.8` | `APPROVED` (with note) | Below the dev-review iron-law threshold — log findings to LEARNINGS.md as advisory |
+| `approve`         | `APPROVED`           | Write `status: APPROVED`, proceed to the verify phase                          |
+| `needs-attention` with any finding `confidence >= 0.8` | `CHANGES_REQUIRED` | Forward findings to the implement phase             |
+| `needs-attention` with all findings `confidence < 0.8` | `APPROVED` (with note) | Below the iron-law threshold — log findings to LEARNINGS.md as advisory |
 
 This preserves the **iron law of review**: only issues with confidence ≥ 80
 block. Codex reports confidence as 0-1 floats; multiply by 100 when displaying.
+
+**A Codex `CHANGES_REQUIRED` overrides the primary reviewer's APPROVED.** The
+primary does not get a veto over the second pass — if it did, the second pass
+would be decorative. This is the one place a later reviewer outranks an earlier
+one, and it is deliberate: the second pass exists precisely to catch what the
+primary missed.
 
 ### Trace findings to requirements
 
@@ -109,20 +150,58 @@ receiving the JSON, the calling skill is responsible for:
 2. Tagging each finding with the most likely REQ-ID (or `OUT-OF-SPEC`)
 3. Treating `OUT-OF-SPEC` findings as advisory unless the user opts in
 
-## Fallback Decision Tree
+## Availability Decision Tree
+
+The primary Claude review has already run and approved at this point — so an
+unavailable Codex means "no second opinion," never "no review."
 
 ```
 Codex script located?
-├── No  → Fallback: Single or Parallel Claude reviewer (existing flow)
+├── No  → record codex_second_pass: unavailable → write status: APPROVED (silently)
 └── Yes → Probe `setup --json`
-          ├── ready: false → Fallback (silently)
-          └── ready: true  → Offer Codex adversarial as RECOMMENDED option
-                              (user can still pick Claude path if preferred)
+          ├── ready: false → same as above (silently)
+          └── ready: true  → ask the user once (opt-in), then run or record `declined`
 ```
+
+Never prompt the user to install or authenticate Codex. The skill's job is to
+use Codex when present, not to onboard it.
+
+## Recording the outcome
+
+The consuming skill records what happened in `.planning/REVIEW_STATE.md`:
+
+| `codex_second_pass:` | Meaning |
+|----------------------|---------|
+| `enabled` | Codex ran and returned a verdict |
+| `declined` | Offered; user chose to approve without it |
+| `unavailable` | No script, probe not ready, or no git repo |
+| `error` | Codex ran but failed (non-zero exit / unparseable output) |
+
+Three rules keep this field honest:
+
+- **Never write `enabled` unless a Codex run actually returned a verdict.** The
+  field's whole purpose is to distinguish "Codex approved this" from "Codex
+  never ran"; a fabricated `enabled` makes the record worse than absent.
+- **`error` is not an approval.** An unrun reviewer is not a passing reviewer.
+  `error` is an absence of evidence — neither approval nor rejection — so it is
+  **not a legal value under `status: APPROVED`**. Only `enabled`, `declined`,
+  and `unavailable` are. An `error` sets `status: BLOCKED` and asks the user to
+  retry or explicitly decline; only that decision reopens the path forward.
+- **`unavailable` and `error` are different facts.** `unavailable` means Codex
+  was never reachable (not installed, probe not ready, no git repo) and is
+  benign — the primary review stands. `error` means Codex was reached and
+  failed, which is a broken reviewer, not an absent one. Collapsing the two
+  hides failures behind a silent skip.
 
 ## Iteration tracking
 
-Codex adversarial review participates in the same `REVIEW_STATE.md` loop as
-Claude reviewers — increment iteration on `CHANGES_REQUIRED`, escalate at
-iteration 3. Re-runs go through Codex again (not a swap to Claude mid-loop)
-unless Codex becomes unavailable between runs.
+The second pass participates in the same `REVIEW_STATE.md` loop as Claude
+reviewers — increment iteration on `CHANGES_REQUIRED`, escalate at iteration 3.
+
+**Decide once per loop, not once per iteration.** The opt-in answer is stored in
+`codex_second_pass:` and honored on subsequent iterations without re-asking;
+only `unavailable` is re-probed (Codex may have been installed since). Asking on
+every fix iteration turns an opt-in into nagging.
+
+On each iteration the full order repeats: primary review first, second pass only
+if the primary approves.

--- a/references/codex-availability.md
+++ b/references/codex-availability.md
@@ -168,6 +168,33 @@ use Codex when present, not to onboard it.
 
 ## Recording the outcome
 
+**This field is hook-enforced.** `dev-verify` / `ds-verify` declare a PreToolUse
+`phase-gate-guard.py` gate with:
+
+```
+GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable
+```
+
+so Agent dispatch in the verify phase is blocked until `.planning/REVIEW_STATE.md`
+records one of those three values. This puts the second pass on the top tier of
+PHILOSOPHY's enforcement gradient (`hook-enforced > artifact check > advisory
+text`) — the review skill's prose can be compacted away or rationalized past, but
+the hook fires on every tool call.
+
+What the hook can and cannot prove:
+
+- **It can prove a disposition was recorded** rather than silently skipped.
+- **It cannot prove Codex ran** — `declined` and `unavailable` are legal, because
+  the second pass is opt-in and Codex is optional. That is the intended ceiling:
+  the gate enforces *honesty about what happened*, not *that Codex was used*.
+- **`error` is excluded from the allowed set**, so an errored second pass
+  structurally cannot reach verify. That is the "error is not an approval" rule,
+  enforced rather than narrated.
+
+Write **one** value, never the `a | b | c` template line — a literal placeholder
+matches no allowed value and the gate blocks it, which is the point: a pasted
+template is not a recorded decision.
+
 The consuming skill records what happened in `.planning/REVIEW_STATE.md`:
 
 | `codex_second_pass:` | Meaning |

--- a/skills/dev-review/SKILL.md
+++ b/skills/dev-review/SKILL.md
@@ -50,9 +50,9 @@ If the message could be EITHER a new topic OR part of the review, ask before ass
 ## Contents
 
 - [Prerequisites - Test Output Gate](#prerequisites---test-output-gate)
-- [Review Strategy Choice](#review-strategy-choice)
-- [Codex Adversarial Review](#codex-adversarial-review) (default when Codex is installed)
-- [Parallel Review (Thorough)](#parallel-review-thorough) (Claude-only fallback)
+- [Review Strategy Choice](#review-strategy-choice) (picks the primary reviewer)
+- [Codex Second Pass](#codex-second-pass) (optional second opinion before any APPROVED verdict)
+- [Parallel Review (Thorough)](#parallel-review-thorough)
 - [The Iron Law of Review](#the-iron-law-of-review) (single Claude reviewer path)
 - [Review Focus Areas](#review-focus-areas)
 - [Confidence Scoring](#confidence-scoring)
@@ -132,7 +132,14 @@ If no test output is found, STOP and return to /dev-implement.
 
 ## Review Strategy Choice
 
-After verifying test output in LEARNINGS.md, choose review strategy.
+After verifying test output in LEARNINGS.md, choose the **primary reviewer**.
+
+This choice picks who reviews FIRST. It is not a choice about whether Codex
+runs — Codex is a *second pass* over whatever the primary reviewer approves
+(see [Codex Second Pass](#codex-second-pass)). The two are additive, never
+alternatives: a Codex pass that replaced Claude would leave the diff reviewed
+exactly once, which is the single-reviewer blind spot the second pass exists
+to close.
 
 **Skip this choice when:**
 - Trivial changes (< 50 LOC, single file)
@@ -140,47 +147,7 @@ After verifying test output in LEARNINGS.md, choose review strategy.
 - Automated refactoring (rename, extract)
 - Internal utility functions (not user-facing or security-sensitive)
 
-### Step 1: Probe Codex availability (silent)
-
-Codex provides an out-of-process adversarial reviewer that uses a different
-model family than Claude — the diversity catches issues a Claude-reviewing-Claude
-loop would miss. When installed and authenticated, it is the **default**
-adversarial path. When unavailable, fall back to the existing Claude-based
-flow without prompting the user about installation.
-
-Read `${CLAUDE_SKILL_DIR}/../../references/codex-availability.md` for the full
-probe and invocation contract. Execute the probe before asking the user:
-
-```bash
-CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-if [ -n "$CODEX_SCRIPT" ]; then
-  node "$CODEX_SCRIPT" setup --json 2>/dev/null | jq -r '.ready // false'
-else
-  echo "false"
-fi
-```
-
-Set `CODEX_READY=true` only when the probe prints `true`. Otherwise
-`CODEX_READY=false` and skip Codex entirely — do not announce its absence.
-
-### Step 2: Ask the user
-
-**If `CODEX_READY=true`:**
-
-```python
-AskUserQuestion(questions=[{
-  "question": "How should we review this implementation?",
-  "header": "Review Strategy",
-  "options": [
-    {"label": "Codex adversarial review (Recommended)", "description": "Out-of-process adversarial review via Codex. Different model family from Claude — catches issues a Claude-on-Claude loop misses. Default for adversarial review."},
-    {"label": "Single Claude reviewer", "description": "Combined Claude review covering spec compliance and code quality. Faster, lower overhead. Use when Codex is overkill."},
-    {"label": "Parallel Claude review (Thorough)", "description": "Spawn 3 specialized Claude reviewers (Security, Performance, Tests). Use when Codex is unavailable or you want multi-perspective Claude review."}
-  ],
-  "multiSelect": false
-}])
-```
-
-**If `CODEX_READY=false`:**
+**Ask the user:**
 
 ```python
 AskUserQuestion(questions=[{
@@ -198,34 +165,89 @@ AskUserQuestion(questions=[{
 
 | Choice | Go to |
 |--------|-------|
-| Codex adversarial review | [Codex Adversarial Review](#codex-adversarial-review) |
 | Single (Claude) reviewer | [The Iron Law of Review](#the-iron-law-of-review) |
 | Parallel (Claude) review | [Parallel Review (Thorough)](#parallel-review-thorough) |
 
+Both paths converge on [Phase Complete](#phase-complete), which runs the Codex
+second pass before any APPROVED verdict is written.
+
 ---
 
-## Codex Adversarial Review
+## Codex Second Pass
 
-Use this section when the user chose **Codex adversarial review**.
+**When this runs:** after the primary reviewer (single or parallel) returns
+APPROVED, and BEFORE `status: APPROVED` is written to `.planning/REVIEW_STATE.md`.
+It never runs on CHANGES_REQUIRED, ESCALATE, or BLOCKED — there is nothing to
+second-guess when the primary reviewer already found blocking issues; fix those
+first and the second pass runs on the next iteration.
+
+**Why it exists:** the primary reviewer is Claude reviewing Claude's code. Codex
+is a different model family in a different process, so its blind spots are not
+correlated with the implementer's. This is the audit-fix-loop Iron Law ("the
+auditor must not be the fixer") applied to the model itself.
 
 > **Reference:** See `references/codex-availability.md` for the full invocation
 > contract, JSON schema, and verdict mapping table.
 
-### 1. Prerequisites Check
+### 1. Decide once per review loop, not once per iteration
 
-Before invoking Codex, verify (same as the other review paths):
+Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
+value, honor it and do NOT re-ask:
 
-1. **Test evidence exists** — LEARNINGS.md contains actual test output
-2. **E2E evidence for UI changes** — user-facing changes have E2E test output
-3. **SPEC.md exists** — for REQ-ID tagging of findings post-hoc
-4. **Git repo present** — Codex adversarial review is git-diff scoped
+| Stored value | Action |
+|--------------|--------|
+| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
+| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | Probe, then ask (steps 2-3) |
 
-If any prerequisite fails, STOP and return BLOCKED to /dev-implement.
+Asking on every fix iteration turns an opt-in into nagging, and a user who
+answers "no" three times has been asked three times too many.
 
-### 2. Estimate Scope and Choose Wait vs Background
+Probe on every iteration even when the answer is stored — `enabled` records a
+user's consent, not Codex's continued availability.
+
+### 2. Probe Codex availability (silent)
 
 ```bash
-# Working-tree review
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
+if [ -n "$CODEX_SCRIPT" ]; then
+  node "$CODEX_SCRIPT" setup --json 2>/dev/null | jq -r '.ready // false'
+else
+  echo "false"
+fi
+```
+
+If the probe does not print `true`: record `codex_second_pass: unavailable` and
+proceed to Phase Complete's APPROVED write. Do **not** announce Codex's absence
+and do **not** prompt the user to install it — this skill's job is to use Codex
+when present, not to onboard it.
+
+### 3. Ask the user (only when the probe printed `true`)
+
+```python
+AskUserQuestion(questions=[{
+  "question": "Primary review passed. Run a Codex second pass before verify?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Run Codex second pass (Recommended)", "description": "Independent adversarial review via Codex — a different model family in a separate process, so its blind spots don't overlap with Claude's. Findings at >=80 confidence re-enter the fix loop."},
+    {"label": "Skip — approve now", "description": "Accept the primary review's APPROVED verdict and proceed to dev-verify. Faster; the diff is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
+or `codex_second_pass: declined` before acting on it.
+
+### 4. Prerequisites
+
+Codex adversarial review is **git-diff scoped**. If there is no git repo, record
+`codex_second_pass: unavailable` and proceed — do not fabricate a scope.
+
+### 5. Estimate scope and choose wait vs background
+
+```bash
 git status --short --untracked-files=all
 git diff --shortstat --cached
 git diff --shortstat
@@ -234,7 +256,10 @@ git diff --shortstat
 Wait when the diff is clearly tiny (1-2 files, no untracked dir-sized changes).
 Otherwise launch in background.
 
-### 3. Invoke Codex
+### 6. Invoke Codex
+
+Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
+survive — re-resolve it in the same command that uses it.
 
 **Foreground (small diff):**
 
@@ -245,18 +270,19 @@ node "$CODEX_SCRIPT" adversarial-review --wait
 
 **Background (anything bigger):**
 
-Launch with `Bash(..., run_in_background: true)` and tell the user:
-"Codex adversarial review started in the background. Check `/codex:status` for progress."
+Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
+"Codex second pass started in the background. Check `/codex:status` for progress."
 
-Then await completion notification before proceeding to step 4.
+Then await completion before proceeding to step 7.
 
 **Optional focus text** — append SPEC.md context to weight the review:
 
 ```bash
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
 node "$CODEX_SCRIPT" adversarial-review --wait "focus: REQ-AUTH-01 token rotation under retry"
 ```
 
-### 4. Parse Verdict
+### 7. Parse verdict
 
 Codex returns JSON validated against its review-output schema. Top-level fields:
 `verdict` (`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`.
@@ -266,47 +292,45 @@ Each finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
 **Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
 when displaying alongside Claude-style scores.
 
-| Codex result | dev-review verdict |
-|--------------|--------------------|
-| `verdict: approve` | APPROVED |
-| `needs-attention` + any finding ≥ 0.8 confidence | CHANGES_REQUIRED |
-| `needs-attention` + all findings < 0.8 confidence | APPROVED (log advisory findings to LEARNINGS.md) |
+| Codex result | Second-pass outcome |
+|--------------|---------------------|
+| `verdict: approve` | APPROVED — proceed to Phase Complete's APPROVED write |
+| `needs-attention` + any finding ≥ 0.8 confidence | CHANGES_REQUIRED — overrides the primary reviewer's APPROVED |
+| `needs-attention` + all findings < 0.8 | APPROVED (log advisory findings to LEARNINGS.md) |
 
-### 5. Tag Findings to Requirements
+**A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
+reviewer does not get a veto over the second pass — if it did, the second pass
+would be decorative.
+
+If Codex fails to run (non-zero exit, unparseable output): record
+`codex_second_pass: error` and report the failure to the user. Do **not**
+silently treat a broken second pass as an approval — an unrun reviewer is not a
+passing reviewer.
+
+### 8. Tag findings to requirements
 
 Codex doesn't know SPEC.md REQ-IDs. For each blocking finding:
 
 1. Read `.planning/SPEC.md`
 2. Tag the finding with the most likely REQ-ID (or `OUT-OF-SPEC`)
-3. `OUT-OF-SPEC` findings are advisory unless user opts in
+3. `OUT-OF-SPEC` findings are advisory unless the user opts in
 
-### 6. Report
+### 9. Report
 
 Use the same output structure as `## Required Output Structure` below, with
-**Reviewer: Codex (adversarial)** in the header. Each issue includes the
-Codex confidence (×100) and the REQ-ID you tagged in step 5.
+**Reviewer: Codex (second pass)** in the header. Each issue includes the Codex
+confidence (×100) and the REQ-ID you tagged in step 8.
 
-### 7. Iteration & Re-Review
+### 10. Iteration & re-review
 
-Codex adversarial review participates in the same `REVIEW_STATE.md` loop as
-Claude reviewers — increment iteration on CHANGES_REQUIRED, escalate at
-iteration 3. **Re-runs stay on Codex** unless it becomes unavailable between
-runs (re-probe each iteration).
+The second pass participates in the same `REVIEW_STATE.md` loop as Claude
+reviewers — a blocking second pass increments iteration and returns
+CHANGES_REQUIRED, escalating at iteration 3 like any other verdict.
 
-The "Iron Law of Re-Review" still applies: implementer claims "fixed" → main
-chat re-invokes Codex via the same command — no spot-checks.
-
-### Phase Complete (Codex Adversarial)
-
-After Codex review completes:
-
-**If APPROVED:** Immediately invoke the dev-verify skill:
-
-Read `${CLAUDE_SKILL_DIR}/../../skills/dev-verify/SKILL.md` and follow its instructions.
-
-**If CHANGES_REQUIRED:** Return to `/dev-implement` with the parsed findings.
-
-**If BLOCKED (test evidence missing):** Return to `/dev-implement` to collect test evidence.
+On the next iteration the order repeats in full: primary review runs first, and
+the second pass runs again only if the primary approves. The "Iron Law of
+Re-Review" applies to Codex too — the implementer claims "fixed", main chat
+re-invokes the full review, no spot-checks.
 
 ---
 
@@ -513,17 +537,18 @@ All 3 reviewers approved with no issues >= 80 confidence.
 X critical and Y important issues must be addressed. Return to /dev-implement.
 ```
 
-## Phase Complete (Parallel Review)
+## After Parallel Review
 
-After parallel review completes:
+Parallel review produces a *primary* verdict — it is not a terminal state. Do
+NOT invoke dev-verify or write `status: APPROVED` from here.
 
-**If APPROVED:** Immediately invoke the dev-verify skill:
+Go to [Phase Complete](#phase-complete) and follow it for every verdict.
+Phase Complete is the single authority that runs the Codex second pass, writes
+`.planning/REVIEW_STATE.md`, and invokes dev-verify.
 
-Read `${CLAUDE_SKILL_DIR}/../../skills/dev-verify/SKILL.md` and follow its instructions.
-
-**If CHANGES REQUIRED:** Return to `/dev-implement` to fix reported issues.
-
-**If BLOCKED (test evidence missing):** Return to `/dev-implement` to collect test evidence.
+A branch-local "APPROVED → dev-verify" shortcut would let the parallel path
+reach verification without the second pass ever running, being declined, or
+being recorded — which is exactly the bypass the second pass exists to prevent.
 
 ---
 
@@ -789,12 +814,25 @@ affects: []             # read-only review; fixes happen in dev-implement
 verdict: APPROVED | CHANGES_REQUIRED | ESCALATE | BLOCKED
 iterations: N
 issues-found: X (Y critical, Z important)
+codex-second-pass: enabled | declined | unavailable | error
 ---
 ```
 
 After review completes, handle verdict-specific transitions:
 
 ### If APPROVED (no issues >= 80 confidence)
+
+**STOP — run the [Codex Second Pass](#codex-second-pass) first.** A primary
+APPROVED is a candidate verdict, not a final one. Writing `status: APPROVED`
+before the second pass runs would hand dev-verify a gate that no second reviewer
+ever saw — the second pass would be decorative, and the diff would ship reviewed
+once by the same model family that wrote it.
+
+Order of operations:
+
+1. Run the Codex second pass (it self-skips when Codex is unavailable or declined).
+2. If it returns **CHANGES_REQUIRED**, follow [If CHANGES REQUIRED](#if-changes-required-issues--80-confidence-found-iteration--3) instead of this section.
+3. Only if it returns **APPROVED** (or self-skipped), write the state below.
 
 Mark review complete in `.planning/REVIEW_STATE.md`:
 
@@ -805,15 +843,66 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
+codex_second_pass: enabled | declined | unavailable
 verdict: APPROVED
 ---
 ```
+
+`codex_second_pass` records what actually happened, so a later reader can tell
+"Codex approved this" from "Codex never ran." Never write `enabled` unless a
+Codex run actually returned a verdict.
+
+**`error` is not a valid value under `status: APPROVED`** — those three are the
+only ones. A failed second pass has no verdict, so it cannot support an
+approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 The `status: APPROVED` line is the structural gate dev-verify checks — only an APPROVED review admits verification. On non-approved paths (CHANGES_REQUIRED / ESCALATE / BLOCKED) set `status:` to that verdict so the gate correctly blocks.
 
 Immediately invoke dev-verify:
 
 Read `${CLAUDE_SKILL_DIR}/../../skills/dev-verify/SKILL.md` and follow its instructions.
+
+### If the Codex second pass errored
+
+Codex ran but produced no verdict (non-zero exit, unparseable output). **This is
+not an approval and not a rejection — it is an absence of evidence.** Do NOT
+write `status: APPROVED` and do NOT invoke dev-verify.
+
+Record the attempt and leave the gate closed:
+
+```yaml
+---
+status: BLOCKED
+iteration: [N]          # unchanged — no review verdict was produced
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: error
+verdict: BLOCKED
+---
+```
+
+Report the failure to the user and ask how to proceed:
+
+```python
+AskUserQuestion(questions=[{
+  "question": "The Codex second pass failed to produce a verdict. How should we proceed?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Retry the second pass", "description": "Re-run Codex. Transient failures (auth expiry, a dropped thread) usually clear on a retry."},
+    {"label": "Approve without it", "description": "Record codex_second_pass: declined and proceed to dev-verify on the primary review alone. The diff is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+- **Retry** → return to [Codex Second Pass](#codex-second-pass) step 2.
+- **Approve without it** → rewrite `codex_second_pass: declined` and follow
+  [If APPROVED](#if-approved-no-issues--80-confidence) from the top.
+
+Only an explicit user decision converts an `error` into a path forward. Silently
+downgrading it to an approval is the fabricated-verdict failure this skill exists
+to prevent.
 
 ### If CHANGES REQUIRED (issues >= 80 confidence found, iteration < 3)
 
@@ -826,11 +915,19 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
+codex_second_pass: enabled | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```
 
+Carry `codex_second_pass` forward unchanged — the decision is made once per
+review loop, not re-asked on each iteration.
+
 Return to `/dev-implement` with specific issues. **Implementer MUST re-invoke /dev-review after fixes.**
+
+When the blocking findings came from the second pass, say so in the handoff
+("Codex second pass, REQ-AUTH-01, confidence 92") — the implementer needs to
+know which reviewer to satisfy.
 
 **Critical:** When implementer returns claiming "fixed", you MUST re-run the FULL review. No shortcuts.
 
@@ -874,7 +971,8 @@ Return immediately to `/dev-implement` to collect test evidence. Do NOT incremen
 
 | Verdict | Next Action | Iteration Counter |
 |---------|-------------|-------------------|
-| APPROVED | Invoke /dev-verify immediately, mark task `[x]` in PLAN.md | Reset to 1 for next task |
+| APPROVED (primary) | Run the [Codex Second Pass](#codex-second-pass) before writing `status: APPROVED` | No change (not a terminal verdict) |
+| APPROVED (second pass done/skipped) | Invoke /dev-verify immediately, mark task `[x]` in PLAN.md | Reset to 1 for next task |
 | CHANGES REQUIRED | Return to /dev-implement, implementer fixes then re-invokes /dev-review | Increment |
 | ESCALATE | Ask user for direction | Keep at max |
 | BLOCKED | Return to /dev-implement for test evidence | No change (no review ran) |

--- a/skills/dev-review/SKILL.md
+++ b/skills/dev-review/SKILL.md
@@ -50,6 +50,7 @@ If the message could be EITHER a new topic OR part of the review, ask before ass
 ## Contents
 
 - [Prerequisites - Test Output Gate](#prerequisites---test-output-gate)
+- [Invalidate the previous verdict FIRST](#invalidate-the-previous-verdict-first) (first write of the phase)
 - [Review Strategy Choice](#review-strategy-choice) (picks the primary reviewer)
 - [Codex Second Pass](#codex-second-pass) (optional second opinion before any APPROVED verdict)
 - [Parallel Review (Thorough)](#parallel-review-thorough)
@@ -130,6 +131,34 @@ If no test output is found, STOP and return to /dev-implement.
 "It should work" is NOT evidence. Test output IS evidence.
 </EXTREMELY-IMPORTANT>
 
+## Invalidate the previous verdict FIRST
+
+**Before any reviewing starts — the first write of this phase:** if
+`.planning/REVIEW_STATE.md` exists and carries `status: APPROVED`, that approval
+belongs to the *previous* task or iteration. Overwrite it now:
+
+```yaml
+---
+status: IN_REVIEW
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+verdict: IN_REVIEW
+---
+```
+
+Drop any `codex_second_pass:` and `codex_output_file:` from the prior task at the
+same time — a second pass over last task's diff says nothing about this one.
+
+The loop resets `iteration` for a new task but not `status`, so a stale APPROVED
+otherwise sits on disk for the whole review — and `status: APPROVED` is exactly
+what dev-verify's gate hooks on. Every intermediate state after this point
+(`IN_REVIEW`, `SECOND_PASS_PENDING`) keeps that gate shut until this phase
+genuinely re-approves. A gate that was already open before the reviewer started
+is not a gate.
+
+---
+
 ## Review Strategy Choice
 
 After verifying test output in LEARNINGS.md, choose the **primary reviewer**.
@@ -194,18 +223,24 @@ auditor must not be the fixer") applied to the model itself.
 Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
 value, honor it and do NOT re-ask:
 
-| Stored value | Action |
-|--------------|--------|
-| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
-| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
-| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
-| absent | Probe, then ask (steps 2-3) |
+| Stored value | Meaning | Action |
+|--------------|---------|--------|
+| `requested` | consented and launched; no verdict yet | **Rejoin it** — go to step 7 and read `codex_output_file`. Relaunch (step 6) only if that file is missing or unparseable. Do NOT re-ask. |
+| `completed` | Codex returned a verdict this iteration | Probe (step 2), then run again for the new fixes — skip step 3 |
+| `declined` | user opted out of the loop | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | never reachable / ran and failed | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | not yet decided | Probe, then ask (steps 2-3) |
 
 Asking on every fix iteration turns an opt-in into nagging, and a user who
 answers "no" three times has been asked three times too many.
 
-Probe on every iteration even when the answer is stored — `enabled` records a
-user's consent, not Codex's continued availability.
+Probe on every iteration even when consent is stored — it records the user's
+answer, not Codex's continued availability.
+
+**`requested` and `completed` are different facts, and conflating them is a
+bypass.** `requested` means "we asked Codex"; only `completed` means "Codex
+answered". A launched-but-unjoined pass has produced no evidence, so the verify
+gate accepts `completed`, `declined`, and `unavailable` — never `requested`.
 
 ### 2. Probe Codex availability (silent)
 
@@ -237,15 +272,80 @@ AskUserQuestion(questions=[{
 }])
 ```
 
-Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
-or `codex_second_pass: declined` before acting on it.
+If the user declines, record `codex_second_pass: declined` and continue to Phase
+Complete. If the user opts in, do NOT record `enabled`/`completed` here — nothing
+has run yet. Go to step 4; step 5 writes the pending state.
 
 ### 4. Prerequisites
 
 Codex adversarial review is **git-diff scoped**. If there is no git repo, record
 `codex_second_pass: unavailable` and proceed — do not fabricate a scope.
 
-### 5. Estimate scope and choose wait vs background
+### 5. Close the gate BEFORE launching
+
+First clear the handle, and **verify the clear worked**. It is
+**per-iteration**, and it is emptied *before* the state says `requested`:
+
+```bash
+# substitute this iteration's N
+OUT=.planning/codex-second-pass-iter[N].json
+rm -f "$OUT"
+if [ -e "$OUT" ]; then
+  echo "BLOCKED: cannot clear $OUT — refusing to request a pass that could join a stale verdict"
+  exit 1
+fi
+```
+
+**A clear that silently failed is worse than no clear.** `rm -f` reports success
+for a file that never existed and stays quiet about one it could not remove (a
+read-only `.planning/`, wrong ownership, an immutable bit). The launch redirect
+would then fail for the same reason, leaving the *old* envelope in place for the
+join to read as this pass's answer. Checking that the path is actually gone turns
+that assumption into a precondition.
+
+If the clear fails: do NOT record `requested`. Record `codex_second_pass: error`
+with `status: BLOCKED` and report it — see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored). An
+environment that cannot give the pass a clean handle cannot give it an honest
+verdict either.
+
+Then write this to `.planning/REVIEW_STATE.md` **before** invoking Codex:
+
+```yaml
+---
+status: SECOND_PASS_PENDING
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: requested
+codex_output_file: .planning/codex-second-pass-iter[N].json
+verdict: SECOND_PASS_PENDING
+---
+```
+
+**A previous pass's verdict is not this pass's answer.** The shell redirect only
+truncates the file when Codex is actually invoked, so a single reused path leaves
+a window: stop between this state write and the launch — or resume into the join —
+and step 7 would read the *last* iteration's envelope, parse its `approve`, and
+write `completed`. The requested pass never ran. Both halves close that: a fresh
+name per iteration means last iteration's answer is never at this iteration's
+path, and the `rm -f` means a re-launch within an iteration cannot join its own
+stale output either. Absent file → `PENDING` → relaunch, which is correct.
+
+**Why before, not after.** `status: APPROVED` may still be sitting in this file
+from an earlier task or iteration — the loop resets `iteration`, not `status`.
+If you launch Codex while a stale APPROVED is on disk, the verify gate is open
+for the entire time Codex is running: a crash, an interruption, or a resumed
+session walks straight into dev-verify on a second pass that never returned.
+Writing a non-approved status first means the window never exists — the gate is
+shut before the reviewer is even asked, and only its verdict reopens it.
+
+`codex_output_file` is the join handle (step 7). It is a path, not a promise:
+if the session dies here, the state on disk still says PENDING and the gate
+stays shut.
+
+### 6. Estimate scope and choose wait vs background
 
 ```bash
 git status --short --untracked-files=all
@@ -256,38 +356,106 @@ git diff --shortstat
 Wait when the diff is clearly tiny (1-2 files, no untracked dir-sized changes).
 Otherwise launch in background.
 
-### 6. Invoke Codex
+### 6b. Invoke Codex
 
 Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
 survive — re-resolve it in the same command that uses it.
 
-**Foreground (small diff):**
+**Always pass `--json`, and always redirect to `codex_output_file`.** Both are
+load-bearing:
+
+- `--json` is the ONLY form that carries `confidence`. The default rendered text
+  prints `[high]` but no number, and the iron law below thresholds on
+  confidence ≥ 0.8 — applied to rendered output it would be a rule with nothing
+  to read.
+- The redirect turns the verdict into a **file on disk**, which is what makes
+  the background path joinable (step 7). Output that exists only in a terminal
+  or a transcript is lost to any interruption.
+
+Redirect to the **exact path recorded in `codex_output_file`** — the state file
+is the authority on which handle this pass owns:
 
 ```bash
 CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-node "$CODEX_SCRIPT" adversarial-review --wait
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
 
-**Background (anything bigger):**
+**Foreground (small diff):** run the command above and go to step 7.
 
-Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
-"Codex second pass started in the background. Check `/codex:status` for progress."
+**Background (anything bigger):** run the **same** command via
+`Bash(..., run_in_background: true)`, then tell the user: "Codex second pass
+started in the background." Do not advance past step 7's join check until the
+background task reports completion — an unjoined launch is not a verdict.
 
-Then await completion before proceeding to step 7.
+`--background` on the companion is a no-op for reviews: `adversarial-review`
+always runs in the foreground (only `task` enqueues a job), so the harness's
+`run_in_background` is what actually detaches it. That is exactly why the
+redirect matters — the companion is not holding a result for you to fetch later.
 
 **Optional focus text** — append SPEC.md context to weight the review:
 
 ```bash
-CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-node "$CODEX_SCRIPT" adversarial-review --wait "focus: REQ-AUTH-01 token rotation under retry"
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  "focus: REQ-AUTH-01 token rotation under retry" \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
 
-### 7. Parse verdict
+### 7. Join the run, then parse the verdict
 
-Codex returns JSON validated against its review-output schema. Top-level fields:
-`verdict` (`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`.
-Each finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
-`confidence` (0-1 float), `recommendation`.
+**The join is a real step, not a hope.** The state on disk says
+`codex_second_pass: requested`; nothing may advance until this step turns it
+into `completed` or `error`. This is also the resume path: a fresh session that
+finds `requested` starts here.
+
+Extract the verdict mechanically — do not read it off the screen:
+
+```bash
+uv run python3 - <<'PY'
+import json, pathlib, re
+state = pathlib.Path('.planning/REVIEW_STATE.md')
+m = re.search(r'^codex_output_file:\s*(\S+)\s*$', state.read_text(), re.M) if state.exists() else None
+if not m:
+    print('ERROR: no codex_output_file recorded — relaunch (step 6b)')
+    raise SystemExit(0)
+p = pathlib.Path(m.group(1))          # the handle THIS pass owns
+if not p.exists() or not p.stat().st_size:
+    print('PENDING: no output yet — the run is unfinished, failed, or was lost')
+    raise SystemExit(0)
+try:
+    envelope = json.loads(p.read_text())
+    if envelope.get('codex', {}).get('status') != 0:
+        print('ERROR: codex exited', envelope.get('codex', {}).get('status'))
+        raise SystemExit(0)
+    v = json.loads(envelope['codex']['stdout'])   # the schema-validated verdict
+except Exception as e:
+    print('ERROR: unparseable output —', e)
+    raise SystemExit(0)
+print('verdict:', v['verdict'])
+for f in v.get('findings', []):
+    print(f"  {f['confidence']:.2f}  [{f['severity']}]  {f['file']}:{f['line_start']}  {f['title']}")
+PY
+```
+
+It resolves the path from `codex_output_file` rather than hardcoding one — the
+state file names the handle this pass owns, so a verdict left at some other
+path by an earlier iteration can never be read as this one's answer.
+
+The payload is an envelope: `{review, target, threadId, codex: {status, stdout}}`,
+and `codex.stdout` is the schema-validated verdict **as a JSON string** — it
+needs a second parse, which is why this runs as a script and not as an eyeball.
+
+Route on what it printed:
+
+| Printed | Meaning | Do |
+|---------|---------|----|
+| `verdict: ...` | Codex answered | continue below; the pass is `completed` |
+| `PENDING: ...` | still running, or the output was lost | do NOT proceed. If the background task is still going, wait. If it is gone, relaunch (step 6b). The gate stays shut meanwhile. |
+| `ERROR: ...` | ran and failed | go to [If the Codex second pass errored](#if-the-codex-second-pass-errored) |
+
+The verdict object: `verdict` (`approve` | `needs-attention`), `summary`,
+`findings[]`, `next_steps[]`. Each finding has `severity`, `title`, `body`,
+`file`, `line_start`, `line_end`, `confidence` (0-1 float), `recommendation`.
 
 **Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
 when displaying alongside Claude-style scores.
@@ -301,6 +469,11 @@ when displaying alongside Claude-style scores.
 **A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
 reviewer does not get a veto over the second pass — if it did, the second pass
 would be decorative.
+
+**Move `SECOND_PASS_PENDING` to its terminal state in ONE write** — the same
+edit sets `status:` and flips `codex_second_pass: requested` → `completed`. Two
+writes means a window where the file claims a verdict it hasn't recorded, or
+records a disposition with a status that no longer matches it.
 
 If Codex fails to run (non-zero exit, unparseable output): record
 `codex_second_pass: error` and report the failure to the user. Do **not**
@@ -814,7 +987,7 @@ affects: []             # read-only review; fixes happen in dev-implement
 verdict: APPROVED | CHANGES_REQUIRED | ESCALATE | BLOCKED
 iterations: N
 issues-found: X (Y critical, Z important)
-codex-second-pass: enabled | declined | unavailable | error
+codex-second-pass: completed | declined | unavailable | error | error
 ---
 ```
 
@@ -843,23 +1016,24 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: APPROVED
 ---
 ```
 
 `codex_second_pass` records what actually happened, so a later reader can tell
-"Codex approved this" from "Codex never ran." Never write `enabled` unless a
-Codex run actually returned a verdict.
+"Codex approved this" from "Codex never ran." Never write `completed` unless a
+Codex run actually returned a verdict you parsed in step 7.
 
-**`error` is not a valid value under `status: APPROVED`** — those three are the
-only ones. A failed second pass has no verdict, so it cannot support an
-approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
+**`requested` and `error` are not valid under `status: APPROVED`** — those three
+are the only ones. `requested` is a launch, not an answer; `error` is a failure,
+not an answer. Neither supports an approval; see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 **This is hook-enforced, not advisory.** dev-verify gates Agent dispatch on
-`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+`GATE_REQUIRE_FIELDS=codex_second_pass:completed|declined|unavailable`, so verify
 cannot start until this field records one of those three. Substitute a single
-value — pasting the `enabled | declined | unavailable` line verbatim matches
+value — pasting the `completed | declined | unavailable` line verbatim matches
 nothing and the gate blocks it.
 
 The `status: APPROVED` line is the structural gate dev-verify checks — only an APPROVED review admits verification. On non-approved paths (CHANGES_REQUIRED / ESCALATE / BLOCKED) set `status:` to that verdict so the gate correctly blocks.
@@ -921,7 +1095,7 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```

--- a/skills/dev-review/SKILL.md
+++ b/skills/dev-review/SKILL.md
@@ -856,6 +856,12 @@ Codex run actually returned a verdict.
 only ones. A failed second pass has no verdict, so it cannot support an
 approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
+**This is hook-enforced, not advisory.** dev-verify gates Agent dispatch on
+`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+cannot start until this field records one of those three. Substitute a single
+value — pasting the `enabled | declined | unavailable` line verbatim matches
+nothing and the gate blocks it.
+
 The `status: APPROVED` line is the structural gate dev-verify checks — only an APPROVED review admits verification. On non-approved paths (CHANGES_REQUIRED / ESCALATE / BLOCKED) set `status:` to that verdict so the gate correctly blocks.
 
 Immediately invoke dev-verify:

--- a/skills/dev-verify/SKILL.md
+++ b/skills/dev-verify/SKILL.md
@@ -15,10 +15,10 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
-            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
+            GATE_REQUIRE_FIELDS="codex_second_pass:completed|declined|unavailable"
             GATE_BLOCKED_TOOLS=Agent
             GATE_DESCRIPTION="Code review approved"
-            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
+            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify. REVIEW_STATE.md must also record codex_second_pass: completed (Codex returned a verdict) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). codex_second_pass: requested means the second pass was launched but has not returned — join it (read the file named by codex_output_file) before verifying; a launched-but-unjoined pass is not a completed one. codex_second_pass: error is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
         - type: command
           command: "FLOOR=dev uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/mechanical-floor-gate.py"

--- a/skills/dev-verify/SKILL.md
+++ b/skills/dev-verify/SKILL.md
@@ -15,9 +15,10 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
+            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
             GATE_BLOCKED_TOOLS=Agent
             GATE_DESCRIPTION="Code review approved"
-            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify."
+            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
         - type: command
           command: "FLOOR=dev uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/mechanical-floor-gate.py"

--- a/skills/ds-implement/references/sas-enforcement.md
+++ b/skills/ds-implement/references/sas-enforcement.md
@@ -12,6 +12,13 @@ Read `${CLAUDE_SKILL_DIR}/../../skills/wrds/references/sas-etl.md` and follow it
 
 Before writing ANY SAS code, validate against these rules:
 
+### Probe Inputs First (metadata only — seconds)
+- `proc contents data=lib.x varnum;` on EVERY input — variables, types, lengths, formats, and the index section
+- Compare key lengths across datasets you will merge — a `$6` vs `$8` gvkey matches zero rows silently
+- `proc sql; select memname, nobs from dictionary.tables where libname='LIB';` — know the row scale before committing
+- `proc print data=lib.x(obs=20); var ...;` — always `obs=`, always `var`. NEVER print an unbounded WRDS table
+- `proc datasets library=scratch;` to inventory/delete intermediates (metadata op; end with `quit;`)
+
 ### WHERE Clauses
 - **NEVER** wrap indexed columns in functions: year(date), month(date), datepart(dt), upcase(), substr()
 - **ALWAYS** use range-based date filters: `where date between "01jan&year."d and "31dec&year."d`
@@ -33,6 +40,7 @@ Before writing ANY SAS code, validate against these rules:
 - Assign hash methods to temp vars before put statements
 
 ### Self-Check Before Submitting Code
+- [ ] Inputs probed with PROC CONTENTS (lengths + indexes) and PROC PRINT (obs=20) before any ETL was written
 - [ ] No function-wrapped WHERE clauses on indexed columns
 - [ ] Hash used for all lookup merges
 - [ ] SGE array for multi-year processing

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -984,6 +984,12 @@ Codex run actually returned a verdict.
 only ones. A failed second pass has no verdict, so it cannot support an
 approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
+**This is hook-enforced, not advisory.** ds-verify gates Agent dispatch on
+`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+cannot start until this field records one of those three. Substitute a single
+value — pasting the `enabled | declined | unavailable` line verbatim matches
+nothing and the gate blocks it.
+
 **`status: APPROVED` is the structural gate field** — ds-verify declares a PreToolUse `phase-gate-guard.py` hook that blocks Agent dispatch until `.planning/REVIEW_STATE.md` shows `status: APPROVED`. While the review loop is unresolved (CHANGES_REQUIRED / ESCALATE), `status` is NOT `APPROVED`, so verification is structurally blocked.
 
 Immediately discover and load ds-verify:

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -60,6 +60,35 @@ Announce: "Using ds-review (Phase 4) to check methodology and quality."
 | Warning | 25-35% | Complete current review cycle, then trigger ds-handoff |
 | Critical | ≤25% | Immediately trigger ds-handoff — do not start new review cycles |
 
+## Invalidate the previous verdict FIRST
+
+**Before any reviewing starts — the first write of this phase:** if
+`.planning/REVIEW_STATE.md` exists and carries `status: APPROVED`, that approval
+belongs to the *previous* analysis or iteration. Overwrite it now:
+
+```yaml
+---
+status: IN_REVIEW
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+verdict: IN_REVIEW
+---
+```
+
+Drop any `codex_second_pass:` and `codex_output_file:` from the prior analysis at
+the same time — a second pass over last analysis's diff says nothing about this
+one.
+
+The loop resets `iteration` for a new analysis but not `status`, so a stale
+APPROVED otherwise sits on disk for the whole review — and `status: APPROVED` is
+exactly what ds-verify's gate hooks on. Every intermediate state after this point
+(`IN_REVIEW`, `SECOND_PASS_PENDING`) keeps that gate shut until this phase
+genuinely re-approves. A gate that was already open before the reviewer started
+is not a gate.
+
+---
+
 ## Review Strategy Choice
 
 After announcing phase, choose the **primary reviewer**.
@@ -125,16 +154,22 @@ A Codex approval is not evidence the methodology is sound.
 Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
 value, honor it and do NOT re-ask:
 
-| Stored value | Action |
-|--------------|--------|
-| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
-| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
-| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
-| absent | Probe, then ask (steps 2-3) |
+| Stored value | Meaning | Action |
+|--------------|---------|--------|
+| `requested` | consented and launched; no verdict yet | **Rejoin it** — go to step 7 and read `codex_output_file`. Relaunch (step 6b) only if that file is missing or unparseable. Do NOT re-ask. |
+| `completed` | Codex returned a verdict this iteration | Probe (step 2), then run again for the new fixes — skip step 3 |
+| `declined` | user opted out of the loop | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | never reachable / ran and failed | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | not yet decided | Probe, then ask (steps 2-3) |
 
 Asking on every fix iteration turns an opt-in into nagging. Probe on every
-iteration even when the answer is stored — `enabled` records a user's consent,
-not Codex's continued availability.
+iteration even when consent is stored — it records the user's answer, not
+Codex's continued availability.
+
+**`requested` and `completed` are different facts, and conflating them is a
+bypass.** `requested` means "we asked Codex"; only `completed` means "Codex
+answered". A launched-but-unjoined pass has produced no evidence, so the verify
+gate accepts `completed`, `declined`, and `unavailable` — never `requested`.
 
 ### 2. Probe Codex availability (silent)
 
@@ -165,8 +200,9 @@ AskUserQuestion(questions=[{
 }])
 ```
 
-Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
-or `codex_second_pass: declined` before acting on it.
+If the user declines, record `codex_second_pass: declined` and continue to Phase
+Complete. If the user opts in, do NOT record `enabled`/`completed` here — nothing
+has run yet. Go to step 4; step 5 writes the pending state.
 
 ### 4. Prerequisites
 
@@ -177,7 +213,67 @@ Notebooks: review the paired text representation (`.py` via jupytext) when one
 exists. A diff of `.ipynb` JSON is mostly execution-count and output noise, and
 a reviewer reading noise finds nothing.
 
-### 5. Estimate scope and choose wait vs background
+### 5. Close the gate BEFORE launching
+
+First clear the handle, and **verify the clear worked**. It is
+**per-iteration**, and it is emptied *before* the state says `requested`:
+
+```bash
+# substitute this iteration's N
+OUT=.planning/codex-second-pass-iter[N].json
+rm -f "$OUT"
+if [ -e "$OUT" ]; then
+  echo "BLOCKED: cannot clear $OUT — refusing to request a pass that could join a stale verdict"
+  exit 1
+fi
+```
+
+**A clear that silently failed is worse than no clear.** `rm -f` reports success
+for a file that never existed and stays quiet about one it could not remove (a
+read-only `.planning/`, wrong ownership, an immutable bit). The launch redirect
+would then fail for the same reason, leaving the *old* envelope in place for the
+join to read as this pass's answer. Checking that the path is actually gone turns
+that assumption into a precondition.
+
+If the clear fails: do NOT record `requested`. Record `codex_second_pass: error`
+with `status: BLOCKED` and report it — see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored). An
+environment that cannot give the pass a clean handle cannot give it an honest
+verdict either.
+
+Then write this to `.planning/REVIEW_STATE.md` **before** invoking Codex:
+
+```yaml
+---
+status: SECOND_PASS_PENDING
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: requested
+codex_output_file: .planning/codex-second-pass-iter[N].json
+verdict: SECOND_PASS_PENDING
+---
+```
+
+**A previous pass's verdict is not this pass's answer.** The shell redirect only
+truncates the file when Codex is actually invoked, so a single reused path leaves
+a window: stop between this state write and the launch — or resume into the join —
+and step 7 would read the *last* iteration's envelope, parse its `approve`, and
+write `completed`. The requested pass never ran. A fresh name per iteration plus
+the `rm -f` closes both halves; an absent file gives `PENDING` → relaunch.
+
+**Why before, not after.** `status: APPROVED` may still be sitting in this file
+from an earlier analysis or iteration — the loop resets `iteration`, not
+`status`. If you launch Codex while a stale APPROVED is on disk, the verify gate
+is open for the entire time Codex is running: a crash, an interruption, or a
+resumed session walks straight into ds-verify on a second pass that never
+returned. Writing a non-approved status first means the window never exists.
+
+`codex_output_file` is the join handle (step 7). If the session dies here, the
+state on disk still says PENDING and the gate stays shut.
+
+### 6. Estimate scope and choose wait vs background
 
 ```bash
 git status --short --untracked-files=all
@@ -187,35 +283,99 @@ git diff --shortstat
 
 Wait when the diff is clearly tiny (1-2 files). Otherwise launch in background.
 
-### 6. Invoke Codex
+### 6b. Invoke Codex
 
 Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
 survive — re-resolve it in the same command that uses it.
 
-**Foreground (small diff):**
+**Always pass `--json`, and always redirect to `codex_output_file`.** Both are
+load-bearing:
+
+- `--json` is the ONLY form that carries `confidence`. The default rendered text
+  prints `[high]` but no number, and the iron law below thresholds on
+  confidence >= 0.8 — applied to rendered output it would be a rule with nothing
+  to read.
+- The redirect turns the verdict into a **file on disk**, which is what makes
+  the background path joinable (step 7). Output that exists only in a terminal
+  or a transcript is lost to any interruption.
+
+Redirect to the **exact path recorded in `codex_output_file`** — the state file
+is the authority on which handle this pass owns:
 
 ```bash
 CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-node "$CODEX_SCRIPT" adversarial-review --wait
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  "focus: data leakage between train/test, join row-count fan-out, filters applied after the split, parameters that contradict .planning/SPEC.md" \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
 
-**Background (anything bigger):**
+**Foreground (small diff):** run the command above and go to step 7.
 
-Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
-"Codex second pass started in the background. Check `/codex:status` for progress."
+**Background (anything bigger):** run the **same** command via
+`Bash(..., run_in_background: true)`, then tell the user: "Codex second pass
+started in the background." Do not advance past step 7's join check until the
+background task reports completion — an unjoined launch is not a verdict.
 
-**Focus text** — carry the analysis question and the DS failure modes:
+`--background` on the companion is a no-op for reviews: `adversarial-review`
+always runs in the foreground (only `task` enqueues a job), so the harness's
+`run_in_background` is what actually detaches it. That is exactly why the
+redirect matters — the companion is not holding a result for you to fetch later.
+
+### 7. Join the run, then parse the verdict
+
+**The join is a real step, not a hope.** The state on disk says
+`codex_second_pass: requested`; nothing may advance until this step turns it
+into `completed` or `error`. This is also the resume path: a fresh session that
+finds `requested` starts here.
+
+Extract the verdict mechanically — do not read it off the screen:
 
 ```bash
-node "$CODEX_SCRIPT" adversarial-review --wait "focus: data leakage between train/test, join row-count fan-out, filters applied after the split, parameters that contradict .planning/SPEC.md"
+uv run python3 - <<'PY'
+import json, pathlib, re
+state = pathlib.Path('.planning/REVIEW_STATE.md')
+m = re.search(r'^codex_output_file:\s*(\S+)\s*$', state.read_text(), re.M) if state.exists() else None
+if not m:
+    print('ERROR: no codex_output_file recorded — relaunch (step 6b)')
+    raise SystemExit(0)
+p = pathlib.Path(m.group(1))          # the handle THIS pass owns
+if not p.exists() or not p.stat().st_size:
+    print('PENDING: no output yet — the run is unfinished, failed, or was lost')
+    raise SystemExit(0)
+try:
+    envelope = json.loads(p.read_text())
+    if envelope.get('codex', {}).get('status') != 0:
+        print('ERROR: codex exited', envelope.get('codex', {}).get('status'))
+        raise SystemExit(0)
+    v = json.loads(envelope['codex']['stdout'])   # the schema-validated verdict
+except Exception as e:
+    print('ERROR: unparseable output —', e)
+    raise SystemExit(0)
+print('verdict:', v['verdict'])
+for f in v.get('findings', []):
+    print(f"  {f['confidence']:.2f}  [{f['severity']}]  {f['file']}:{f['line_start']}  {f['title']}")
+PY
 ```
 
-### 7. Parse verdict
+It resolves the path from `codex_output_file` rather than hardcoding one — the
+state file names the handle this pass owns, so a verdict left at some other
+path by an earlier iteration can never be read as this one's answer.
 
-Codex returns JSON validated against its review-output schema: `verdict`
-(`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`. Each
-finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
-`confidence` (0-1 float), `recommendation`.
+The payload is an envelope: `{review, target, threadId, codex: {status, stdout}}`,
+and `codex.stdout` is the schema-validated verdict **as a JSON string** — it
+needs a second parse, which is why this runs as a script and not as an eyeball.
+
+Route on what it printed:
+
+| Printed | Meaning | Do |
+|---------|---------|----|
+| `verdict: ...` | Codex answered | continue below; the pass is `completed` |
+| `PENDING: ...` | still running, or the output was lost | do NOT proceed. If the background task is still going, wait. If it is gone, relaunch (step 6b). The gate stays shut meanwhile. |
+| `ERROR: ...` | ran and failed | go to [If the Codex second pass errored](#if-the-codex-second-pass-errored) |
+
+The verdict object: `verdict` (`approve` | `needs-attention`), `summary`,
+`findings[]`, `next_steps[]`. Each finding has `severity`, `title`, `body`,
+`file`, `line_start`, `line_end`, `confidence` (0-1 float), `recommendation`.
 
 **Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
 when displaying alongside Claude-style scores.
@@ -229,6 +389,10 @@ when displaying alongside Claude-style scores.
 **A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
 reviewer does not get a veto over the second pass — if it did, the second pass
 would be decorative.
+
+**Move `SECOND_PASS_PENDING` to its terminal state in ONE write** — the same
+edit sets `status:` and flips `codex_second_pass: requested` -> `completed`. Two
+writes means a window where the file claims a verdict it hasn't recorded.
 
 If Codex fails to run (non-zero exit, unparseable output): record
 `codex_second_pass: error` and report the failure to the user. Do **not**
@@ -971,23 +1135,24 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: APPROVED
 ---
 ```
 
 `codex_second_pass` records what actually happened, so a later reader can tell
-"Codex approved this" from "Codex never ran." Never write `enabled` unless a
-Codex run actually returned a verdict.
+"Codex approved this" from "Codex never ran." Never write `completed` unless a
+Codex run actually returned a verdict you parsed in step 7.
 
-**`error` is not a valid value under `status: APPROVED`** — those three are the
-only ones. A failed second pass has no verdict, so it cannot support an
-approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
+**`requested` and `error` are not valid under `status: APPROVED`** — those three
+are the only ones. `requested` is a launch, not an answer; `error` is a failure,
+not an answer. Neither supports an approval; see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 **This is hook-enforced, not advisory.** ds-verify gates Agent dispatch on
-`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+`GATE_REQUIRE_FIELDS=codex_second_pass:completed|declined|unavailable`, so verify
 cannot start until this field records one of those three. Substitute a single
-value — pasting the `enabled | declined | unavailable` line verbatim matches
+value — pasting the `completed | declined | unavailable` line verbatim matches
 nothing and the gate blocks it.
 
 **`status: APPROVED` is the structural gate field** — ds-verify declares a PreToolUse `phase-gate-guard.py` hook that blocks Agent dispatch until `.planning/REVIEW_STATE.md` shows `status: APPROVED`. While the review loop is unresolved (CHANGES_REQUIRED / ESCALATE), `status` is NOT `APPROVED`, so verification is structurally blocked.
@@ -1048,7 +1213,7 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -62,7 +62,12 @@ Announce: "Using ds-review (Phase 4) to check methodology and quality."
 
 ## Review Strategy Choice
 
-After announcing phase, choose review strategy.
+After announcing phase, choose the **primary reviewer**.
+
+This choice picks who reviews FIRST. It is not a choice about whether Codex
+runs — Codex is a *second pass* over whatever the primary reviewer approves
+(see [Codex Second Pass](#codex-second-pass)). The two are additive, never
+alternatives.
 
 **Skip this choice when:**
 - Exploratory analysis (one-off, not for publication)
@@ -87,6 +92,167 @@ AskUserQuestion(questions=[{
 **If Single reviewer:** Proceed to [The Iron Law of DS Review](#the-iron-law-of-ds-review) below (current behavior).
 
 **If Parallel review:** Skip to [Parallel Review (Research-Grade)](#parallel-review-research-grade).
+
+Both paths converge on [Phase Complete](#phase-complete), which runs the Codex
+second pass before any APPROVED verdict is written.
+
+---
+
+## Codex Second Pass
+
+**When this runs:** after the primary reviewer (single or parallel) returns
+APPROVED, and BEFORE `status: APPROVED` is written to `.planning/REVIEW_STATE.md`.
+It never runs on CHANGES_REQUIRED, ESCALATE, or BLOCKED — fix those findings
+first, and the second pass runs on the next iteration.
+
+**Why it exists:** the primary reviewer is Claude reviewing Claude's analysis.
+Codex is a different model family in a different process, so its blind spots are
+not correlated with the analyst's. This is the audit-fix-loop Iron Law ("the
+auditor must not be the fixer") applied to the model itself.
+
+**What it is good at, and what it is not:** Codex reviews the *code* — leakage
+between fit and evaluation, a join that silently fans out rows, a filter applied
+after the split, a hardcoded parameter contradicting SPEC.md. It cannot judge
+whether the research question is worth asking or whether a result is
+substantively interesting. Those stay with the Claude reviewers and the user.
+A Codex approval is not evidence the methodology is sound.
+
+> **Reference:** See `references/codex-availability.md` for the full invocation
+> contract, JSON schema, and verdict mapping table.
+
+### 1. Decide once per review loop, not once per iteration
+
+Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
+value, honor it and do NOT re-ask:
+
+| Stored value | Action |
+|--------------|--------|
+| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
+| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | Probe, then ask (steps 2-3) |
+
+Asking on every fix iteration turns an opt-in into nagging. Probe on every
+iteration even when the answer is stored — `enabled` records a user's consent,
+not Codex's continued availability.
+
+### 2. Probe Codex availability (silent)
+
+```bash
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
+if [ -n "$CODEX_SCRIPT" ]; then
+  node "$CODEX_SCRIPT" setup --json 2>/dev/null | jq -r '.ready // false'
+else
+  echo "false"
+fi
+```
+
+If the probe does not print `true`: record `codex_second_pass: unavailable` and
+proceed to Phase Complete's APPROVED write. Do **not** announce Codex's absence
+and do **not** prompt the user to install it.
+
+### 3. Ask the user (only when the probe printed `true`)
+
+```python
+AskUserQuestion(questions=[{
+  "question": "Primary review passed. Run a Codex second pass before verify?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Run Codex second pass (Recommended)", "description": "Independent adversarial review of the analysis code via Codex — a different model family, so its blind spots don't overlap with Claude's. Catches leakage, join fan-out, and spec drift. Findings at >=80 confidence re-enter the fix loop."},
+    {"label": "Skip — approve now", "description": "Accept the primary review's APPROVED verdict and proceed to ds-verify. Faster; the analysis is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
+or `codex_second_pass: declined` before acting on it.
+
+### 4. Prerequisites
+
+Codex adversarial review is **git-diff scoped**. If there is no git repo, record
+`codex_second_pass: unavailable` and proceed — do not fabricate a scope.
+
+Notebooks: review the paired text representation (`.py` via jupytext) when one
+exists. A diff of `.ipynb` JSON is mostly execution-count and output noise, and
+a reviewer reading noise finds nothing.
+
+### 5. Estimate scope and choose wait vs background
+
+```bash
+git status --short --untracked-files=all
+git diff --shortstat --cached
+git diff --shortstat
+```
+
+Wait when the diff is clearly tiny (1-2 files). Otherwise launch in background.
+
+### 6. Invoke Codex
+
+Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
+survive — re-resolve it in the same command that uses it.
+
+**Foreground (small diff):**
+
+```bash
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
+node "$CODEX_SCRIPT" adversarial-review --wait
+```
+
+**Background (anything bigger):**
+
+Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
+"Codex second pass started in the background. Check `/codex:status` for progress."
+
+**Focus text** — carry the analysis question and the DS failure modes:
+
+```bash
+node "$CODEX_SCRIPT" adversarial-review --wait "focus: data leakage between train/test, join row-count fan-out, filters applied after the split, parameters that contradict .planning/SPEC.md"
+```
+
+### 7. Parse verdict
+
+Codex returns JSON validated against its review-output schema: `verdict`
+(`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`. Each
+finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
+`confidence` (0-1 float), `recommendation`.
+
+**Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
+when displaying alongside Claude-style scores.
+
+| Codex result | Second-pass outcome |
+|--------------|---------------------|
+| `verdict: approve` | APPROVED — proceed to Phase Complete's APPROVED write |
+| `needs-attention` + any finding ≥ 0.8 confidence | CHANGES_REQUIRED — overrides the primary reviewer's APPROVED |
+| `needs-attention` + all findings < 0.8 | APPROVED (log advisory findings to LEARNINGS.md) |
+
+**A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
+reviewer does not get a veto over the second pass — if it did, the second pass
+would be decorative.
+
+If Codex fails to run (non-zero exit, unparseable output): record
+`codex_second_pass: error` and report the failure to the user. Do **not**
+silently treat a broken second pass as an approval — an unrun reviewer is not a
+passing reviewer.
+
+### 8. Tag findings to requirements
+
+Codex doesn't know SPEC.md REQ-IDs. For each blocking finding: read
+`.planning/SPEC.md`, tag it with the most likely REQ-ID (or `OUT-OF-SPEC`).
+`OUT-OF-SPEC` findings are advisory unless the user opts in.
+
+### 9. Report
+
+Use the same output structure as the Claude paths, with **Reviewer: Codex
+(second pass)** in the header. Each issue includes the Codex confidence (×100)
+and the REQ-ID you tagged in step 8.
+
+### 10. Iteration & re-review
+
+The second pass participates in the same `REVIEW_STATE.md` loop — a blocking
+second pass increments iteration and returns CHANGES_REQUIRED, escalating at
+iteration 3 like any other verdict. On the next iteration the order repeats in
+full: primary review first, second pass only if the primary approves.
 
 ---
 
@@ -200,11 +366,21 @@ After ALL reviewers message completion, the lead performs three passes.
    └──────────────────┘            ┌── yes ──┴── no ──┐
                                    ▼                  ▼
                           ┌────────────────┐ ┌────────────────┐
-                          │ CHANGES REQ'D →│ │ APPROVED →     │
-                          │ /ds-implement  │ │ ds-verify      │
-                          │ (max 3 cycles) │ └────────────────┘
-                          └────────────────┘
+                          │ CHANGES REQ'D →│ │ APPROVED       │
+                          │ /ds-implement  │ │ (primary only) │
+                          │ (max 3 cycles) │ └───────┬────────┘
+                          └────────────────┘         │
+                                                     ▼
+                                          ┌─────────────────────┐
+                                          │ Phase Complete      │
+                                          │ → Codex second pass │
+                                          │ → then ds-verify    │
+                                          └─────────────────────┘
 ```
+
+The primary APPROVED terminates at Phase Complete, not at ds-verify — Phase
+Complete is the only section that runs the second pass and writes
+`status: APPROVED`.
 
 <EXTREMELY-IMPORTANT>
 **Pass 1 — Deduplication:**
@@ -309,10 +485,16 @@ X critical and Y important issues must be addressed. Return to /ds-implement.
 
 After parallel review completes:
 
-**If APPROVED:** Immediately discover and load the ds-verify skill:
-Read `${CLAUDE_SKILL_DIR}/../../skills/ds-verify/SKILL.md` and follow its instructions.
+Parallel review produces a *primary* verdict — it is not a terminal state. Do
+NOT load ds-verify or write `status: APPROVED` from here.
 
-**If CHANGES REQUIRED:** Return to `/ds-implement` to fix reported issues.
+Go to [Phase Complete](#phase-complete) and follow it for every verdict. Phase
+Complete is the single authority that runs the Codex second pass, writes
+`.planning/REVIEW_STATE.md`, and invokes ds-verify.
+
+A branch-local "APPROVED → ds-verify" shortcut would let the parallel path reach
+verification without the second pass ever running, being declined, or being
+recorded — which is exactly the bypass the second pass exists to prevent.
 
 **Maximum 3 review cycles.** If issues persist after 3 rounds of review → implement → re-review, escalate to the user with a summary of unresolved issues. Do not loop indefinitely.
 
@@ -769,6 +951,17 @@ After review completes, handle verdict-specific transitions:
 
 ### If APPROVED (no issues >= 80 confidence)
 
+**STOP — run the [Codex Second Pass](#codex-second-pass) first.** A primary
+APPROVED is a candidate verdict, not a final one. Writing `status: APPROVED`
+before the second pass runs would hand ds-verify a gate that no second reviewer
+ever saw.
+
+Order of operations:
+
+1. Run the Codex second pass (it self-skips when Codex is unavailable or declined).
+2. If it returns **CHANGES_REQUIRED**, follow [If CHANGES REQUIRED](#if-changes-required-issues--80-confidence-found-iteration--3) instead of this section.
+3. Only if it returns **APPROVED** (or self-skipped), write the state below.
+
 Mark review complete in `.planning/REVIEW_STATE.md`:
 
 ```yaml
@@ -778,14 +971,65 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
+codex_second_pass: enabled | declined | unavailable
 verdict: APPROVED
 ---
 ```
+
+`codex_second_pass` records what actually happened, so a later reader can tell
+"Codex approved this" from "Codex never ran." Never write `enabled` unless a
+Codex run actually returned a verdict.
+
+**`error` is not a valid value under `status: APPROVED`** — those three are the
+only ones. A failed second pass has no verdict, so it cannot support an
+approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 **`status: APPROVED` is the structural gate field** — ds-verify declares a PreToolUse `phase-gate-guard.py` hook that blocks Agent dispatch until `.planning/REVIEW_STATE.md` shows `status: APPROVED`. While the review loop is unresolved (CHANGES_REQUIRED / ESCALATE), `status` is NOT `APPROVED`, so verification is structurally blocked.
 
 Immediately discover and load ds-verify:
 Read `${CLAUDE_SKILL_DIR}/../../skills/ds-verify/SKILL.md` and follow its instructions.
+
+### If the Codex second pass errored
+
+Codex ran but produced no verdict (non-zero exit, unparseable output). **This is
+not an approval and not a rejection — it is an absence of evidence.** Do NOT
+write `status: APPROVED` and do NOT load ds-verify.
+
+Record the attempt and leave the gate closed:
+
+```yaml
+---
+status: BLOCKED
+iteration: [N]          # unchanged — no review verdict was produced
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: error
+verdict: BLOCKED
+---
+```
+
+Report the failure to the user and ask how to proceed:
+
+```python
+AskUserQuestion(questions=[{
+  "question": "The Codex second pass failed to produce a verdict. How should we proceed?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Retry the second pass", "description": "Re-run Codex. Transient failures (auth expiry, a dropped thread) usually clear on a retry."},
+    {"label": "Approve without it", "description": "Record codex_second_pass: declined and proceed to ds-verify on the primary review alone. The analysis is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+- **Retry** → return to [Codex Second Pass](#codex-second-pass) step 2.
+- **Approve without it** → rewrite `codex_second_pass: declined` and follow
+  [If APPROVED](#if-approved-no-issues--80-confidence) from the top.
+
+Only an explicit user decision converts an `error` into a path forward. Silently
+downgrading it to an approval is the fabricated-verdict failure this skill exists
+to prevent.
 
 ### If CHANGES REQUIRED (issues >= 80 confidence found, iteration < 3)
 
@@ -798,11 +1042,19 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
+codex_second_pass: enabled | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```
 
+Carry `codex_second_pass` forward unchanged — the decision is made once per
+review loop, not re-asked on each iteration.
+
 Return to `/ds-implement` with specific issues. **Analyst MUST re-invoke /ds-review after fixes.**
+
+When the blocking findings came from the second pass, say so in the handoff
+("Codex second pass, REQ-DATA-03, confidence 91") — the analyst needs to know
+which reviewer to satisfy.
 
 **Critical:** When analyst returns claiming "fixed", you MUST re-run the FULL review. No shortcuts.
 
@@ -842,7 +1094,8 @@ Which option do you prefer?
 
 | Verdict | Next Action | Iteration Counter |
 |---------|-------------|-------------------|
-| APPROVED | Invoke /ds-verify immediately | Reset to 1 for next analysis |
+| APPROVED (primary) | Run the [Codex Second Pass](#codex-second-pass) before writing `status: APPROVED` | No change (not a terminal verdict) |
+| APPROVED (second pass done/skipped) | Invoke /ds-verify immediately | Reset to 1 for next analysis |
 | CHANGES REQUIRED | Return to /ds-implement, analyst fixes then re-invokes /ds-review | Increment |
 | ESCALATE | Ask user for direction | Keep at max |
 

--- a/skills/ds-verify/SKILL.md
+++ b/skills/ds-verify/SKILL.md
@@ -44,9 +44,9 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
-            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
+            GATE_REQUIRE_FIELDS="codex_second_pass:completed|declined|unavailable"
             GATE_DESCRIPTION="Review verdict"
-            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
+            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then. REVIEW_STATE.md must also record codex_second_pass: completed (Codex returned a verdict) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). codex_second_pass: requested means the second pass was launched but has not returned — join it (read the file named by codex_output_file) before verifying; a launched-but-unjoined pass is not a completed one. codex_second_pass: error is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             GATE_BLOCKED_TOOLS=Agent
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
 ---

--- a/skills/ds-verify/SKILL.md
+++ b/skills/ds-verify/SKILL.md
@@ -44,8 +44,9 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
+            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
             GATE_DESCRIPTION="Review verdict"
-            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then."
+            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             GATE_BLOCKED_TOOLS=Agent
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
 ---

--- a/skills/wrds/SKILL.md
+++ b/skills/wrds/SKILL.md
@@ -142,6 +142,14 @@ Writing SAS code that forces full table scans when indexes exist is NOT HELPFUL 
 
 Before EVERY SAS program execution:
 
+**For probing inputs (do this FIRST — metadata only, seconds):**
+- [ ] `PROC CONTENTS data=lib.x varnum` on every input — variables, types, **lengths**, formats
+- [ ] Index section of the CONTENTS listing read — does the WHERE column actually have an index?
+- [ ] Key lengths compared across datasets to be merged (mismatched `$6`/`$8` gvkey = silent zero matches)
+- [ ] `PROC SQL; select memname, nobs from dictionary.tables where libname='LIB';` — row counts before committing to the job
+- [ ] `PROC PRINT data=lib.x(obs=20); var ...;` — values look like the docs claim (always `obs=`, always `var`)
+- [ ] `PROC DATASETS library=scratch;` — inventory intermediates; `delete` there, not via a rewriting DATA step
+
 **For merges/joins:**
 - [ ] Small lookup + large fact table → hash object (not `PROC SORT` + `DATA` merge)
 - [ ] Hash uses `defineKey`/`defineData`/`defineDone` pattern correctly
@@ -193,6 +201,7 @@ Before EVERY SAS program execution:
 ### SAS Reference
 
 See **`references/sas-etl.md`** for complete patterns:
+- Probing data and metadata (PROC CONTENTS, PROC DATASETS, PROC PRINT, `dictionary.tables`)
 - Hash object merge (basic, multidata, accumulator)
 - Index-friendly WHERE clause quick reference table
 - SGE array job templates with memory and logging
@@ -319,7 +328,7 @@ Detailed query patterns and table documentation:
 - **`references/edgar.md`** - SEC EDGAR filings, URL construction, DCN vs accession numbers
 - **`references/connection.md`** - Connection pooling, caching, error handling
 - **`references/taq.md`** - TAQ: master files, IID, raw tick processing (NBBO, VWAP, closing auctions), CRSP–TAQ merge, era transition (legacy vs millisecond)
-- **`references/sas-etl.md`** - SAS hash objects, index-friendly WHERE, SGE array jobs, PROC SQL optimization
+- **`references/sas-etl.md`** - SAS metadata probing (PROC CONTENTS/DATASETS/PRINT), hash objects, index-friendly WHERE, SGE array jobs, PROC SQL optimization
 - **`references/postgres-vs-sas.md`** - Decision guide: when to use PostgreSQL vs SAS for WRDS ETL (benchmarks, constraints, hybrid pattern)
 - **`references/fjc.md`** - FJC Integrated Database: civil/criminal case data, NOS codes, securities litigation queries, firm linking
 - **`references/sdc-issuances.md`** - SDC New Issues: IPOs, SEOs, 144A equity, debt offerings — schema discovery, cleaning filters, CRSP/Compustat linking

--- a/skills/wrds/references/sas-etl.md
+++ b/skills/wrds/references/sas-etl.md
@@ -4,6 +4,7 @@ Reference for writing efficient SAS code on the WRDS cloud (SAS Grid / SGE clust
 
 ## Contents
 
+- [Probing Data and Metadata](#probing-data-and-metadata) - PROC CONTENTS / PROC DATASETS / PROC PRINT before you write ETL
 - [Hash Object Merge](#hash-object-merge) - O(1) lookup, no sorting required
 - [Hash Accumulator](#hash-accumulator) - Aggregate without PROC MEANS
 - [Index-Friendly WHERE Clauses](#index-friendly-where-clauses) - The #1 performance mistake
@@ -11,6 +12,148 @@ Reference for writing efficient SAS code on the WRDS cloud (SAS Grid / SGE clust
 - [Project Organization Patterns](#project-organization-patterns) - Paired scripts, stacking, shared macros
 - [PROC SQL Optimization](#proc-sql-optimization) - Indexed joins, pass-through, monotonic
 - [SAS Macro Patterns](#sas-macro-patterns) - Reserved names (never %run/%go), safe resolution, quoting, debugging
+
+---
+
+## Probing Data and Metadata
+
+**Probe before you write ETL.** Every pattern below is metadata-only or reads a handful of rows — seconds, not minutes. The mistakes they catch (wrong key length, no index on the column you filter, a date variable that is really a datetime) are the ones that cost an entire array job.
+
+| Question | Proc | Cost |
+|---|---|---|
+| What variables, types, lengths, formats? | `PROC CONTENTS` | Metadata only |
+| Is the column I filter on indexed? | `PROC CONTENTS` (index section) | Metadata only |
+| What datasets exist in this libref? | `PROC DATASETS nolist` / `PROC CONTENTS data=lib._all_ nods` | Metadata only |
+| Row counts across a whole library | `dictionary.tables` via `PROC SQL` | Metadata only |
+| What do the values actually look like? | `PROC PRINT data=... (obs=20)` | Reads 20 rows |
+| Date coverage / row counts by year | `PROC SQL` with `GROUP BY` | Full scan — filter first |
+
+### PROC CONTENTS — schema, lengths, indexes
+
+```sas
+/* Variables in creation order (varnum) rather than alphabetical */
+proc contents data=comp.funda varnum;
+run;
+
+/* Metadata to a dataset instead of the listing — programmatic checks */
+proc contents data=comp.funda out=meta(keep=name type length varnum format) noprint;
+run;
+proc print data=meta(obs=50); run;
+```
+
+The listing reports **`Observations`**, **`Engine`**, **`Sorted by`**, and an **index section**. Read the index section before writing any `WHERE` — an index on `datadate` is what makes the range filter in [Index-Friendly WHERE Clauses](#index-friendly-where-clauses) fast. No index listed means every `WHERE` is a full scan no matter how you write it.
+
+**Confirm key lengths match before a merge or hash join.** A `gvkey` that is `$6` in one dataset and `$8` in another silently produces zero matches (or a `BY` length-mismatch WARNING and `exit_status=1`):
+
+```sas
+proc contents data=lib.a(keep=gvkey permno) out=a_meta(keep=name length) noprint; run;
+proc contents data=lib.b(keep=gvkey permno) out=b_meta(keep=name length) noprint; run;
+
+proc sql;
+  select a.name, a.length as len_a, b.length as len_b
+  from a_meta a inner join b_meta b on a.name = b.name
+  where a.length ne b.length;   /* Empty result = safe to merge */
+quit;
+```
+
+### PROC DATASETS — library inventory and cheap maintenance
+
+`PROC DATASETS` is the metadata workhorse: it lists a library, shows contents, and manages datasets **without reading the data**. Deleting via `PROC DATASETS` is instant; `data lib.x; stop; run;` rewrites the file.
+
+```sas
+/* What's in the library, with sizes and dates */
+proc datasets library=scratch;
+run;
+
+/* Just the names — no per-dataset detail */
+proc datasets library=scratch nolist;
+  contents data=mf_own_2020 out=meta noprint;   /* Same output as PROC CONTENTS */
+run;
+quit;
+
+/* Housekeeping between pipeline steps */
+proc datasets library=work nolist;
+  delete stage1 stage2;                 /* Instant — metadata operation */
+  change old_name = new_name;
+  copy in=work out=scratch;             /* Move results off WORK before job exit */
+  modify mf_own_2020;
+    index create gvkey;                 /* Add an index the source lacked */
+    label ior = "Institutional ownership ratio";
+run;
+quit;
+```
+
+**Always end `PROC DATASETS` with `quit;`** — it is a RUN-group proc and stays open otherwise, so the next step's statements get swallowed.
+
+### Whole-library probes
+
+```sas
+/* Every dataset in a libref, names only — no variable detail */
+proc contents data=taqmsec._all_ nods;
+run;
+
+/* Row counts and sizes for a whole library — metadata, no table scan */
+proc sql;
+  select memname, nobs, nvar, filesize format=sizekmg10.
+  from dictionary.tables
+  where libname = 'TAQMSEC'          /* Libname MUST be uppercase */
+  order by nobs desc;
+quit;
+
+/* Which datasets contain a given variable */
+proc sql;
+  select memname, name, type, length
+  from dictionary.columns
+  where libname = 'COMP' and upcase(name) = 'GVKEY';
+quit;
+```
+
+`dictionary.tables` gives `nobs` from the header — it does not scan the table. This is the fastest way to learn the I/O scale of a job before you commit to it. In a `PROC SQL` context use `dictionary.tables`; inside a DATA step or macro, use the `sashelp.vtable` / `sashelp.vcolumn` views instead.
+
+### PROC PRINT — look at real values, never the whole table
+
+```sas
+/* GOOD — bounded peek */
+proc print data=tfn.s12(obs=20);
+  var fundno fdate cusip shares;
+run;
+
+/* GOOD — peek at the rows a filter actually selects */
+proc print data=comp.funda(obs=10
+    where=(gvkey = '001690' and datadate between "01jan2020"d and "31dec2020"d));
+  var gvkey datadate at sale;
+  format datadate date9.;
+run;
+
+/* BAD — no obs= on a 200M-row table: floods the .lst, may fill the filesystem */
+proc print data=tfn.s12;
+run;
+```
+
+Rules: **always `obs=`**, **always `var`** (a 500-column WRDS table prints unreadably otherwise), and remember `PROC PRINT` output goes to the **SAS listing**, not the log — route it with `-print logs/name.lst` (see [Log Management](#log-management)) or it lands wherever the job started.
+
+For distributions rather than raw rows, `PROC FREQ` and `PROC MEANS` are the right probes — but both scan the table, so filter or sample first:
+
+```sas
+proc freq data=lib.holdings(obs=100000);
+  tables fdate / missing;      /* Date coverage + missingness on a sample */
+run;
+
+proc means data=lib.holdings(obs=100000) n nmiss min p50 max;
+  var shares prc;
+run;
+```
+
+### Probe checklist before writing ETL
+
+- [ ] `PROC CONTENTS` on every input — variable names, types, **lengths**, formats
+- [ ] Index section read — does the `WHERE` column have an index?
+- [ ] Key lengths compared across datasets to be merged
+- [ ] `dictionary.tables` row counts — is this a 4M-row or a 200M-row job?
+- [ ] `PROC PRINT (obs=20)` — do the values look like what the docs claim?
+- [ ] Date variable is a date, not a datetime (a `datetime20.` format means `datepart()` is needed)
+
+This is Step 0 of [Profile Before Fan-Out](#workflow-profile-before-fan-out-always-for-arrays--full-scans) — the metadata probe that precedes the one timed benchmark unit.
 
 ---
 
@@ -308,6 +451,8 @@ step first:
 #   length mismatch across input datasets -> "unexpected results" + exit_status=1).
 #   proc sql; select memname,nobs from dictionary.tables where libname='TAQMSEC' ...; quit;
 #   proc contents data=lib.big(keep=key_var) out=... ;   /* confirm key var lengths match */
+#   proc print data=lib.big(obs=20); var key_var dt;      /* do the values look right? */
+#   See "Probing Data and Metadata" above for the full PROC CONTENTS / DATASETS / PRINT set.
 
 # Step 1 — ONE TIMED UNIT. Pick a REPRESENTATIVE-TO-HEAVY unit (a high-volume day /
 #   quad-witching), not the smallest, so time+RAM headroom is a real upper bound.

--- a/tests/codex_second_pass_join_test.py
+++ b/tests/codex_second_pass_join_test.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env -S uv run python3
+"""The Codex second-pass join protocol, end-to-end against the real gate hook.
+
+Two bypasses motivate this file, both found by adversarial review:
+
+  1. The skill recorded consent (`enabled`) BEFORE invoking Codex, while the
+     verify gate treated that value as proof Codex had run. Combined with a
+     `status: APPROVED` left over from a previous task — the loop resets
+     `iteration`, not `status` — verification was reachable while Codex was
+     still running, had crashed, or had never started.
+  2. The background path launched a detached run and advanced straight to
+     "parse verdict" with no defined way to retrieve it.
+
+So the states are now: `requested` (launched, no answer) -> `completed` (answer
+parsed) | `error` (ran, failed). Only terminal states admit verify, and the
+skill writes a non-approved `status` BEFORE launching so the window in (1) never
+exists.
+
+This test drives the actual verdict-extraction snippet from the SKILL.md files
+against real payload shapes, and asserts the hook blocks at every non-terminal
+point. Run: uv run python3 tests/codex_second_pass_join_test.py
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / 'hooks' / 'phase-gate-guard.py'
+FIELDS = 'codex_second_pass:completed|declined|unavailable'
+
+F = []
+
+
+def check(name, cond):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}")
+    if not cond:
+        F.append(name)
+
+
+def gate_allows(body):
+    """Would dev-verify's Agent dispatch be allowed against this REVIEW_STATE.md?"""
+    with tempfile.TemporaryDirectory() as td:
+        art = Path(td) / 'REVIEW_STATE.md'
+        art.write_text(body)
+        env = {**os.environ, 'GATE_ARTIFACT': str(art), 'GATE_STATUS': 'APPROVED',
+               'GATE_BLOCKED_TOOLS': 'Agent', 'GATE_REQUIRE_FIELDS': FIELDS}
+        proc = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps({'tool_name': 'Agent', 'tool_input': {}}),
+            capture_output=True, text=True, env=env,
+        )
+        out = proc.stdout.strip()
+        if not out:
+            return True
+        return json.loads(out)['hookSpecificOutput'].get('permissionDecision') != 'deny'
+
+
+def extraction_snippet():
+    """The verdict-extraction script that dev-review actually tells agents to run.
+
+    Pulled from the SKILL.md rather than duplicated: if the documented snippet
+    and the tested one drift apart, the test is worthless.
+    """
+    text = (REPO / 'skills' / 'dev-review' / 'SKILL.md').read_text()
+    m = re.search(r"### 7\. Join the run.*?```bash\nuv run python3 - <<'PY'\n(.*?)\nPY\n```",
+                  text, re.S)
+    assert m, "could not find the join snippet in dev-review/SKILL.md"
+    return m.group(1)
+
+
+def run_extraction(output_file, handle='codex-second-pass-iter2.json',
+                   state_handle=None, extra_files=None, omit_handle=False):
+    """Run the documented snippet against a synthetic .planning/ directory.
+
+    handle       — where the payload is actually written
+    state_handle — what REVIEW_STATE.md claims the pass owns (defaults to handle)
+    extra_files  — {name: contents} written alongside, e.g. a previous
+                   iteration's leftover verdict
+    """
+    snippet = extraction_snippet()
+    with tempfile.TemporaryDirectory() as td:
+        planning = Path(td) / '.planning'
+        planning.mkdir()
+        claimed = state_handle or handle
+        handle_line = '' if omit_handle else f"codex_output_file: .planning/{claimed}\n"
+        (planning / 'REVIEW_STATE.md').write_text(
+            "---\nstatus: SECOND_PASS_PENDING\niteration: 2\n"
+            f"codex_second_pass: requested\n{handle_line}"
+            "verdict: SECOND_PASS_PENDING\n---\n"
+        )
+        if output_file is not None:
+            (planning / handle).write_text(output_file)
+        for name, body in (extra_files or {}).items():
+            (planning / name).write_text(body)
+        proc = subprocess.run([sys.executable, '-c', snippet],
+                              cwd=td, capture_output=True, text=True)
+        return proc.stdout.strip()
+
+
+
+def clear_command():
+    """The documented handle-clearing command from dev-review, iteration 2."""
+    text = (REPO / 'skills' / 'dev-review' / 'SKILL.md').read_text()
+    m = re.search(r"```bash\n# substitute this iteration's N\n(OUT=.*?)\n```", text, re.S)
+    assert m, "could not find the handle-clear command in dev-review/SKILL.md"
+    return m.group(1).replace('[N]', '2')
+
+
+def run_clear(make_undeletable, stale=None):
+    """Run the documented clear in a .planning/ that may refuse deletion.
+
+    Returns (exit_code, stdout, stale_file_survived).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        planning = Path(td) / '.planning'
+        planning.mkdir()
+        handle = planning / 'codex-second-pass-iter2.json'
+        if stale is not None:
+            handle.write_text(stale)
+        if make_undeletable:
+            os.chmod(planning, 0o500)      # read+execute: cannot unlink entries
+        try:
+            proc = subprocess.run(['bash', '-c', clear_command()],
+                                  cwd=td, capture_output=True, text=True)
+            return proc.returncode, proc.stdout.strip(), handle.exists()
+        finally:
+            os.chmod(planning, 0o700)      # let TemporaryDirectory clean up
+
+# The real envelope shape: codex.stdout is the verdict as a JSON *string*.
+def envelope(verdict_obj, status=0):
+    return json.dumps({
+        'review': 'Adversarial Review',
+        'target': {'mode': 'branch', 'label': 'branch diff against main'},
+        'threadId': '019f-test',
+        'codex': {'status': status, 'stderr': '', 'stdout': json.dumps(verdict_obj)},
+    })
+
+
+APPROVE = {'verdict': 'approve', 'summary': 'ok', 'findings': [], 'next_steps': []}
+BLOCKING = {
+    'verdict': 'needs-attention', 'summary': 'no', 'next_steps': [],
+    'findings': [{'severity': 'high', 'title': 'real bug', 'body': 'b',
+                  'file': 'x.py', 'line_start': 1, 'line_end': 2,
+                  'confidence': 0.94, 'recommendation': 'fix'}],
+}
+ADVISORY = {
+    'verdict': 'needs-attention', 'summary': 'maybe', 'next_steps': [],
+    'findings': [{'severity': 'low', 'title': 'nit', 'body': 'b',
+                  'file': 'x.py', 'line_start': 1, 'line_end': 2,
+                  'confidence': 0.4, 'recommendation': 'consider'}],
+}
+
+# --- The gate at every point in the state machine ------------------------------
+
+# The bypass: consent recorded before the run, stale APPROVED still on disk.
+check('requested + stale APPROVED -> BLOCKED (the reported bypass)',
+      not gate_allows("---\nstatus: APPROVED\ncodex_second_pass: requested\n---\n"))
+
+# The pending status the skill writes before launching.
+check('SECOND_PASS_PENDING -> blocked',
+      not gate_allows("---\nstatus: SECOND_PASS_PENDING\ncodex_second_pass: requested\n---\n"))
+
+check('IN_REVIEW (stale verdict invalidated at phase start) -> blocked',
+      not gate_allows("---\nstatus: IN_REVIEW\nverdict: IN_REVIEW\n---\n"))
+
+check('error (ran, no verdict) -> blocked',
+      not gate_allows("---\nstatus: APPROVED\ncodex_second_pass: error\n---\n"))
+
+check('retired `enabled` -> blocked',
+      not gate_allows("---\nstatus: APPROVED\ncodex_second_pass: enabled\n---\n"))
+
+# Terminal states that legitimately admit verify.
+for value in ('completed', 'declined', 'unavailable'):
+    check(f'{value} + APPROVED -> allowed',
+          gate_allows(f"---\nstatus: APPROVED\ncodex_second_pass: {value}\n---\n"))
+
+# A completed pass that BLOCKED must not admit verify either.
+check('completed + CHANGES_REQUIRED -> blocked',
+      not gate_allows("---\nstatus: CHANGES_REQUIRED\ncodex_second_pass: completed\n---\n"))
+
+# --- The documented extraction snippet, against real payloads ------------------
+
+out = run_extraction(envelope(APPROVE))
+check('join: approve verdict extracted', out.startswith('verdict: approve'))
+
+out = run_extraction(envelope(BLOCKING))
+check('join: needs-attention extracted', out.startswith('verdict: needs-attention'))
+check('join: confidence surfaced for the iron law', '0.94' in out)
+check('join: finding located', 'x.py:1' in out)
+
+out = run_extraction(envelope(ADVISORY))
+check('join: sub-threshold confidence surfaced', '0.40' in out)
+
+# Completion is not the only outcome. Each of these must be distinguishable
+# from a verdict, or the loop advances on nothing.
+check('join: missing output file -> PENDING (not a verdict)',
+      run_extraction(None).startswith('PENDING'))
+
+check('join: empty output file -> PENDING (still running / lost)',
+      run_extraction('').startswith('PENDING'))
+
+check('join: truncated JSON -> ERROR (not a verdict)',
+      run_extraction('{"codex": {"status": 0, "stdout": "{\\"verd').startswith('ERROR'))
+
+check('join: codex non-zero exit -> ERROR',
+      run_extraction(envelope(APPROVE, status=1)).startswith('ERROR'))
+
+check('join: envelope present but stdout not JSON -> ERROR',
+      run_extraction(json.dumps({'codex': {'status': 0, 'stdout': 'boom'}})).startswith('ERROR'))
+
+# --- A previous pass's verdict is not this pass's answer -----------------------
+#
+# The redirect only truncates the output when Codex is actually invoked. With a
+# single reused path, stopping between the `requested` write and the launch left
+# last iteration's `approve` on disk for the join to parse as the current answer.
+# The handle is now per-iteration and cleared before `requested` is recorded.
+
+stale_approve = envelope({'verdict': 'approve', 'summary': 'iteration 1 said yes',
+                          'findings': [], 'next_steps': []})
+
+check("stale: iteration 1's verdict is not joinable by iteration 2",
+      run_extraction(None, extra_files={'codex-second-pass-iter1.json': stale_approve})
+      .startswith('PENDING'))
+
+check('stale: a payload at some other path is never read',
+      run_extraction(stale_approve, handle='codex-second-pass.json',
+                     state_handle='codex-second-pass-iter2.json').startswith('PENDING'))
+
+check('handle: the join reads the path the state names, not a hardcoded one',
+      run_extraction(envelope(APPROVE), handle='codex-second-pass-iter7.json',
+                     state_handle='codex-second-pass-iter7.json')
+      .startswith('verdict: approve'))
+
+check('handle: no codex_output_file recorded -> ERROR, never a verdict',
+      run_extraction(stale_approve, handle='codex-second-pass-iter1.json',
+                     omit_handle=True).startswith('ERROR'))
+
+# --- The clear must be a verified precondition, not an assumption -------------
+#
+# `rm -f` is quiet both when the file never existed and when it cannot be
+# removed. If the clear silently fails, the launch redirect fails too, and the
+# join reads the OLD envelope as this pass's answer.
+
+code, out, survived = run_clear(make_undeletable=False, stale=None)
+check('clear: succeeds on a fresh handle', code == 0)
+
+code, out, survived = run_clear(make_undeletable=False, stale=stale_approve)
+check('clear: removes a stale handle', code == 0 and not survived)
+
+code, out, survived = run_clear(make_undeletable=True, stale=stale_approve)
+check('clear: FAILS LOUDLY when the handle cannot be removed', code != 0)
+check('clear: says why it refused', 'BLOCKED' in out)
+check('clear: the stale handle is still there (so requesting would be unsafe)', survived)
+
+# --- Resume: a fresh session finds `requested` and must not walk into verify ---
+check('resume: requested with no output file -> gate still shut',
+      not gate_allows("---\nstatus: SECOND_PASS_PENDING\ncodex_second_pass: requested\n"
+                      "codex_output_file: .planning/codex-second-pass.json\n---\n"))
+
+print()
+if F:
+    print(f"{len(F)} FAILED: {F}")
+    sys.exit(1)
+print('all codex second-pass join tests passed')
+sys.exit(0)

--- a/tests/phase_gate_guard_differential_test.py
+++ b/tests/phase_gate_guard_differential_test.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env -S uv run python3
+"""Differential test: hooks/phase-gate-guard.py's frontmatter reader vs PyYAML.
+
+The reader is hand-rolled on purpose — every hook here is dependency-free, and
+this one fires on every tool call, so a gate that must resolve a package before
+it can answer is a gate that can fail open. That buys safety at the cost of
+owning YAML's edge cases, so this pins the reader against the real parser over a
+generated corpus.
+
+The oracle is `safe_load_all`: `---` is YAML's own document separator, so
+frontmatter is exactly document #1. (`safe_load` raises on a `---`-delimited
+file — it's a multi-document stream.)
+
+The bar is NOT "matches PyYAML everywhere". It is "never accepts a value PyYAML
+disagrees with":
+
+  exact       — reader and PyYAML agree.
+  fail-closed — reader returns '' (gate blocks) where PyYAML has a value. Safe:
+                a phase is blocked, never falsely approved. Decorated YAML
+                (anchors, tags, aliases, flow collections) lands here by design.
+  lenient     — reader returns the same value PyYAML *would* mean, on a document
+                PyYAML rejects outright (only: a stray trailing tab). Cannot
+                smuggle a wrong value; `status: APPROVED\tx` still blocks.
+  UNSAFE      — reader hands back something that satisfies a gate while PyYAML
+                disagrees. Must be zero.
+
+Run: uv run --with pyyaml python3 tests/phase_gate_guard_differential_test.py
+Skips cleanly when PyYAML isn't installed.
+"""
+
+import importlib.util
+import itertools
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print('SKIP: PyYAML not installed (run with: uv run --with pyyaml python3 ...)')
+    sys.exit(0)
+
+HOOK = Path(__file__).resolve().parent.parent / 'hooks' / 'phase-gate-guard.py'
+spec = importlib.util.spec_from_file_location('gate', HOOK)
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+# Values that would actually satisfy a real gate in this repo.
+GATE_VALUES = {'approved', 'enabled', 'declined', 'unavailable'}
+
+# Documents PyYAML rejects but where the gate line itself genuinely says what
+# the reader reports. Accepting them tolerates a corrupt file; it cannot
+# fabricate a value the artifact does not contain.
+#
+#   - a stray trailing tab (PyYAML rejects any trailing tab after a scalar);
+#   - malformed content in INDENTED lines, which the reader skips by design
+#     because indented content belongs to a parent key. Closing this would mean
+#     validating the whole document — a real YAML parser, the dependency this
+#     hook avoids on purpose (see its docstring's KNOWN RESIDUAL).
+#
+# Pinned here so the residual stays a known, bounded fact instead of drifting.
+LENIENT = {'---\nstatus: APPROVED\t\n---\n',
+           '---\nother: 1\nstatus: APPROVED\t\n---\n',
+           '--- \nstatus: APPROVED\t\n--- \n',
+           "---\nstatus: APPROVED\nprior:\n  broken: 'x' junk\n---\n"}
+
+
+def oracle(text):
+    """The `status` of the first YAML document, or '' when there isn't one."""
+    try:
+        docs = list(yaml.safe_load_all(text))
+    except Exception:
+        return '<invalid>'
+    if not docs or not isinstance(docs[0], dict):
+        return ''                       # not a mapping -> no status key at all
+    value = docs[0].get('status')
+    return '' if value is None else str(value)
+
+
+VALUES = [
+    # YAML needs whitespace before a trailing comment, so `'APPROVED'#x` is a
+    # syntax error, not a value plus a note.
+    "'APPROVED'#x", '"APPROVED"#x', "'APPROVED' #x", "APPROVED#x",
+    "APPROVED", "'APPROVED'", '"APPROVED"', "APPROVED # c", "'APPROVED # c'",
+    "'APPROVED'' # c'", '"APPR\\nOVED"', '"A\\PPROVED"', "APPROVED---x",
+    "&anc APPROVED", "!!str APPROVED", "{a: b}", "[APPROVED]", "APPROVED  ",
+    "'APPROVED' junk", "'APPROVED", '"APPROVED', "", "~", "null", "APPROVED\t",
+    " APPROVED", "'APPROVED '", "APPROVED#x", "APPROVED\tx",
+]
+SHAPES = [
+    "---\nstatus: {v}\n---\n",              # canonical
+    "---\nstatus:{v}\n---\n",               # no space: not a mapping at all
+    "---\nstatus: {v}\n  cont\n---\n",      # plain-scalar continuation
+    "---\nother: 1\nstatus: {v}\n---\n",    # not the first key
+    "---\nstatus: {v}\n  ---\n",            # indented delimiter = continuation
+    "--- \nstatus: {v}\n--- \n",            # trailing space on delimiters
+    "---\nstatus: {v}\nstatus: OTHER\n---\n",   # duplicate keys
+]
+DOCS = [s.format(v=v) for s, v in itertools.product(SHAPES, VALUES)] + [
+    "---\nstatus: |\n  APPROVED\n---\n",        # block scalar
+    "---\nstatus: >-\n  APPROVED\n---\n",       # folded scalar
+    "---\nx: &a APPROVED\nstatus: *a\n---\n",   # alias
+    "---\nstatus_extra: APPROVED\n---\n",       # prefix collision
+    "---\n\tstatus: APPROVED\n---\n",           # tab indent
+    "﻿---\nstatus: APPROVED\n---\n",       # BOM
+    "---\r\nstatus: APPROVED\r\n---\r\n",       # CRLF
+    "---\nSTATUS: APPROVED\n---\n",             # case
+    "---\n---\nstatus: APPROVED\n---\n",        # empty first document
+    "---\nstatus: APPROVED\n...\n",             # explicit document end
+    "---\nstatus: APPROVED",                    # unterminated frontmatter
+    "status: APPROVED\n",                       # no frontmatter
+    # A construct opened on an earlier line captures the lines below it, so
+    # `status:` is not a top-level key in any of these.
+    "---\nbroken: [\nstatus: APPROVED\n---\n",
+    "---\nbroken: {\nstatus: APPROVED\n---\n",
+    "---\nbroken: 'oops\nstatus: APPROVED\n---\n",
+    '---\nbroken: "oops\nstatus: APPROVED\n---\n',
+    "---\nitems: [\nstatus: APPROVED ]\n---\n",
+    "---\nitems: {\nstatus: APPROVED }\n---\n",
+    "---\nstatus: APPROVED\nbroken: [\n---\n",
+    # A YAML property hides the opener from a first-character check.
+    "---\nbroken: !!str 'oops\nstatus: APPROVED # close'\n---\n",
+    "---\nbroken: &a 'oops\nstatus: APPROVED # close'\n---\n",
+    "---\nbroken: !!seq [\nstatus: APPROVED\n---\n",
+    # The known residual, pinned: malformed content in an INDENTED line the
+    # reader skips by design. Lands in LENIENT, not UNSAFE.
+    "---\nstatus: APPROVED\nprior:\n  broken: 'x' junk\n---\n",
+    # Malformed siblings: PyYAML rejects the whole document, so it assigns
+    # `status` no value and neither may we.
+    "---\nstatus: APPROVED\nbroken: 'x' junk\n---\n",
+    '---\nstatus: APPROVED\nbroken: "\\q"\n---\n',
+    "---\nstatus: APPROVED\nbroken: foo: bar\n---\n",
+    "---\n%TAG !e! tag:example.com,2020:\nstatus: APPROVED\n---\n",
+    "---\nstatus: APPROVED\nbroken\n---\n",
+    "---\nstatus: APPROVED\n- item\n---\n",
+    # ...and legitimate shapes that must NOT be rejected as unreadable.
+    "---\nnotes: |\n  status: NOT_THIS\nstatus: APPROVED\n---\n",
+    "---\nprior:\n  note: x\nstatus: APPROVED\n---\n",
+    "---\nstatus: APPROVED\nsummary: it's done\n---\n",
+    "---\nstatus: APPROVED\nurl: http://example.com/x\n---\n",
+    "---\nstatus: APPROVED\nlast_review_date: 2026-03-09\n---\n",
+    "---\nstatus: APPROVED\nnote: a, b\n---\n",
+    "---\nstatus: APPROVED\niteration: 2\nissues_found_count: 0\n---\n",
+    "---\nstatus: APPROVED\nnote: 'a: b'\n---\n",
+    "---\nstatus: APPROVED\nempty:\n---\n",
+    "---\nstatus: APPROVED\n# a comment\nverdict: APPROVED\n---\n",
+]
+
+# Legitimate artifacts the gate MUST still accept — an over-strict reader that
+# blocks real REVIEW_STATE.md files is its own outage.
+MUST_ACCEPT = [
+    "---\nstatus: APPROVED\niteration: 2\nmax_iterations: 3\n"
+    "last_review_date: 2026-03-09\nissues_found_count: 0\n"
+    "codex_second_pass: enabled\nverdict: APPROVED\n---\n",
+    "---\nstatus: APPROVED\ncodex_second_pass: declined\n"
+    "summary: it's done\nurl: http://example.com/x\n---\n",
+    "---\nstatus: APPROVED\nnotes: |\n  free text\ncodex_second_pass: unavailable\n---\n",
+]
+
+buckets = {'exact': 0, 'fail-closed': 0, 'lenient': 0}
+unsafe = []
+
+with tempfile.TemporaryDirectory() as td:
+    artifact = Path(td) / 'REVIEW_STATE.md'
+    for doc in DOCS:
+        artifact.write_text(doc)
+        mine = gate.frontmatter_value(gate.read_frontmatter(str(artifact)), 'status')
+        truth = oracle(doc)
+
+        if mine == truth:
+            buckets['exact'] += 1
+        elif mine == '':
+            buckets['fail-closed'] += 1
+        elif doc in LENIENT and mine.lower() in GATE_VALUES:
+            buckets['lenient'] += 1
+        elif mine.lower() in GATE_VALUES:
+            unsafe.append((doc, mine, truth))       # would satisfy a gate
+        else:
+            buckets['fail-closed'] += 1             # junk value -> blocks anyway
+
+# An allowlist's failure mode is over-blocking. Prove the reader still accepts
+# artifacts that are unremarkable and valid.
+over_blocked = []
+with tempfile.TemporaryDirectory() as td:
+    artifact = Path(td) / 'REVIEW_STATE.md'
+    for doc in MUST_ACCEPT:
+        artifact.write_text(doc)
+        mine = gate.frontmatter_value(gate.read_frontmatter(str(artifact)), 'status')
+        if mine != oracle(doc) or mine != 'APPROVED':
+            over_blocked.append((doc, mine, oracle(doc)))
+
+print(f"corpus            : {len(DOCS)} documents")
+print(f"  exact           : {buckets['exact']}")
+print(f"  fail-closed     : {buckets['fail-closed']}  (stricter than YAML — safe)")
+print(f"  lenient         : {buckets['lenient']}  (trailing tab; same value, YAML rejects doc)")
+print(f"  UNSAFE          : {len(unsafe)}")
+
+print(f"  over-blocked    : {len(over_blocked)}  (valid artifacts wrongly refused)")
+
+if unsafe:
+    print()
+    for doc, mine, truth in unsafe:
+        print(f"  doc={doc!r}\n    hook={mine!r}  yaml={truth!r}")
+    print("\nFAILED: the reader accepted a gate value PyYAML disagrees with")
+    sys.exit(1)
+
+if over_blocked:
+    print()
+    for doc, mine, truth in over_blocked:
+        print(f"  doc={doc!r}\n    hook={mine!r}  yaml={truth!r}")
+    print("\nFAILED: the reader refused a valid artifact — over-strict is an outage")
+    sys.exit(1)
+
+print("\nno unsafe divergence from PyYAML; no valid artifact over-blocked")
+sys.exit(0)

--- a/tests/phase_gate_guard_test.py
+++ b/tests/phase_gate_guard_test.py
@@ -302,6 +302,104 @@ codex_second_pass: 'declined'   # user opted out
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
     check('unterminated frontmatter -> blocked', not allowed)
 
+    # A construct opened on an earlier line captures the lines below it, so the
+    # `status:` here is NOT a top-level key — it belongs to `broken`.
+    art = write_state(td, "---\nbroken: [\nstatus: APPROVED\n---\n")
+    allowed, reason = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unterminated flow collection swallows status -> blocked', not allowed)
+    check('unreadable artifact says so', 'not readable' in reason)
+
+    art = write_state(td, "---\nbroken: 'oops\nstatus: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unterminated quote swallows status -> blocked', not allowed)
+
+    # A YAML tag/anchor sits before the value and hides the opener from a
+    # first-character check: pyyaml reads this whole thing as `broken`.
+    art = write_state(td, "---\nbroken: !!str 'oops\nstatus: APPROVED # close'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('tag-hidden multiline quote swallows status -> blocked', not allowed)
+
+    art = write_state(td, "---\nbroken: &a 'oops\nstatus: APPROVED # close'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('anchor-hidden multiline quote swallows status -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\nbroken: [\ncodex_second_pass: enabled\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('unterminated flow before field gate -> blocked', not allowed)
+
+    # ...and the readability rule must not reject legitimate artifacts.
+    art = write_state(td, """---
+status: APPROVED
+iteration: 2
+notes: |
+  a block scalar's content is indented, so it captures nothing at top level
+codex_second_pass: declined
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('block scalar sibling -> allowed (content is indented)', allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\ncodex_second_pass: enabled\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('nested mapping sibling -> allowed', allowed)
+
+    # `status:APPROVED` (no space) is NOT a mapping — YAML reads the whole line
+    # as the plain scalar "status:APPROVED", so the document has no status key.
+    # Matching it would open the gate on a doc that never recorded a status.
+    art = write_state(td, "---\nstatus:APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status:APPROVED (no space after colon) -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus:'APPROVED'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("status:'APPROVED' (no space, quoted) -> blocked", not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass:enabled\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('codex_second_pass:enabled (no space) -> blocked', not allowed)
+
+    # YAML requires whitespace before a trailing comment: `'APPROVED'#x` is a
+    # syntax error, so PyYAML never assigns status a value here.
+    art = write_state(td, "---\nstatus: 'APPROVED'#x\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("quoted status with unspaced '#' -> blocked", not allowed)
+
+    art = write_state(td, '---\nstatus: "APPROVED"#x\n---\n')
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('double-quoted status with unspaced # -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: 'enabled'#x\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check("field with unspaced '#' -> blocked", not allowed)
+
+    # ...but a properly separated comment is still a comment.
+    art = write_state(td, "---\nstatus: 'APPROVED' #x\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("quoted status with spaced '#' -> allowed", allowed)
+
+    # A tab after the colon is valid separation, unlike a missing space.
+    art = write_state(td, "---\nstatus:\tAPPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status:<tab>APPROVED -> allowed', allowed)
+
+    # Sibling keys sharing a prefix must not collide.
+    art = write_state(td, "---\nstatus_extra: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status_extra does not satisfy status gate -> blocked', not allowed)
+
+    # Decorated YAML (anchor, tag, alias, flow collection) is not a plain
+    # scalar. The hook fails closed rather than resolving it — REVIEW_STATE.md
+    # never legitimately uses these, and a resolver is surface to get wrong.
+    for label, body in [
+        ('anchor', "---\nstatus: &a APPROVED\n---\n"),
+        ('tag', "---\nstatus: !!str APPROVED\n---\n"),
+        ('alias', "---\nx: &a APPROVED\nstatus: *a\n---\n"),
+        ('flow seq', "---\nstatus: [APPROVED]\n---\n"),
+    ]:
+        art = write_state(td, body)
+        allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+        check(f'decorated YAML ({label}) -> blocked (fail closed)', not allowed)
+
     # An INDENTED `---` is a scalar continuation, not a delimiter: pyyaml reads
     # this status as `APPROVED ---`.
     art = write_state(td, "---\nstatus: APPROVED\n  ---\n")

--- a/tests/phase_gate_guard_test.py
+++ b/tests/phase_gate_guard_test.py
@@ -65,7 +65,7 @@ verdict: APPROVED
 ---
 """
 
-FIELDS = 'codex_second_pass:enabled|declined|unavailable'
+FIELDS = 'codex_second_pass:completed|declined|unavailable'
 
 with tempfile.TemporaryDirectory() as td:
     base = {'GATE_STATUS': 'APPROVED', 'GATE_BLOCKED_TOOLS': 'Agent'}
@@ -83,7 +83,7 @@ with tempfile.TemporaryDirectory() as td:
     check('missing artifact still blocked', not allowed)
 
     # --- The new check: every legal disposition passes ---
-    for value in ('enabled', 'declined', 'unavailable'):
+    for value in ('completed', 'declined', 'unavailable'):
         art = write_state(td, APPROVED_WITH.format(value=value))
         allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
         check(f'codex_second_pass: {value} -> allowed', allowed)
@@ -98,6 +98,27 @@ with tempfile.TemporaryDirectory() as td:
     art = write_state(td, APPROVED_WITH.format(value='error'))
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
     check('codex_second_pass: error -> blocked (not an approval)', not allowed)
+
+    # --- a launch is not a verdict: `requested` must never admit verify ---
+    # This is the partial-failure/resume bypass: Codex is still running, or
+    # crashed, or the session died mid-pass. Nothing answered.
+    art = write_state(td, APPROVED_WITH.format(value='requested'))
+    allowed, reason = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('codex_second_pass: requested -> blocked (launch is not an answer)', not allowed)
+    check('requested block reason names the field', 'codex_second_pass' in reason)
+
+    # --- the old `enabled` state is retired and must not admit verify either ---
+    art = write_state(td, APPROVED_WITH.format(value='enabled'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('retired codex_second_pass: enabled -> blocked', not allowed)
+
+    # --- the pending status alone blocks, whatever the field says ---
+    # Belt and braces: dev-review writes SECOND_PASS_PENDING before launching, so
+    # even a stale APPROVED from a previous task cannot leave the gate open.
+    for pending_status in ('SECOND_PASS_PENDING', 'IN_REVIEW'):
+        art = write_state(td, f"---\nstatus: {pending_status}\ncodex_second_pass: requested\n---\n")
+        allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+        check(f'status: {pending_status} -> blocked', not allowed)
 
     # --- an un-substituted SKILL.md template is not a real answer ---
     art = write_state(td, APPROVED_WITH.format(value='enabled | declined | unavailable'))
@@ -143,7 +164,7 @@ with tempfile.TemporaryDirectory() as td:
     art = write_state(td, """---
 status: APPROVED
 prior_review:
-  codex_second_pass: enabled
+  codex_second_pass: completed
 ---
 """)
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
@@ -162,7 +183,7 @@ codex_second_pass: 'enabled # error'
     art = write_state(td, """---
 status: APPROVED
 codex_second_pass: error
-codex_second_pass: enabled
+codex_second_pass: completed
 ---
 """)
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
@@ -179,7 +200,7 @@ codex_second_pass:
     check('non-scalar codex_second_pass -> blocked', not allowed)
 
     # No frontmatter at all.
-    art = write_state(td, "status: APPROVED\ncodex_second_pass: enabled\n")
+    art = write_state(td, "status: APPROVED\ncodex_second_pass: completed\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('no frontmatter delimiters -> blocked', not allowed)
 
@@ -222,10 +243,10 @@ codex_second_pass: "decli\\ned"
     check('escape-synthesized "decli\\ned" -> blocked', not allowed)
 
     # A plain scalar continues onto indented lines: this value is
-    # `enabled nope`, not `enabled`. (Verified against pyyaml.)
+    # `completed nope`, not `completed`. (Verified against pyyaml.)
     art = write_state(td, """---
 status: APPROVED
-codex_second_pass: enabled
+codex_second_pass: completed
   nope
 ---
 """)
@@ -293,7 +314,7 @@ codex_second_pass: 'declined'   # user opted out
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
     check('embedded --- in status scalar -> blocked', not allowed)
 
-    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: enabled---nope\n---\n")
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: completed---nope\n---\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('embedded --- in codex_second_pass -> blocked', not allowed)
 
@@ -323,7 +344,7 @@ codex_second_pass: 'declined'   # user opted out
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
     check('anchor-hidden multiline quote swallows status -> blocked', not allowed)
 
-    art = write_state(td, "---\nstatus: APPROVED\nbroken: [\ncodex_second_pass: enabled\n---\n")
+    art = write_state(td, "---\nstatus: APPROVED\nbroken: [\ncodex_second_pass: completed\n---\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('unterminated flow before field gate -> blocked', not allowed)
 
@@ -339,7 +360,7 @@ codex_second_pass: declined
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('block scalar sibling -> allowed (content is indented)', allowed)
 
-    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\ncodex_second_pass: enabled\n---\n")
+    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\ncodex_second_pass: completed\n---\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('nested mapping sibling -> allowed', allowed)
 
@@ -477,7 +498,7 @@ with tempfile.TemporaryDirectory() as td:
             value = got[0].split('=', 1)[1]
             check(f'{skill}: all three dispositions reach the hook',
                   set(value.split(':', 1)[1].split('|')) ==
-                  {'enabled', 'declined', 'unavailable'})
+                  {'completed', 'declined', 'unavailable'})
         check(f'{skill}: no stray shell errors from the assignment',
               'command not found' not in proc.stderr)
 

--- a/tests/phase_gate_guard_test.py
+++ b/tests/phase_gate_guard_test.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env -S uv run python3
+"""Tests for hooks/phase-gate-guard.py.
+
+Focus: GATE_REQUIRE_FIELDS (the recorded-decision check) and the backward
+compatibility of the 12+ skills that wire this hook without it.
+
+Run: uv run python3 tests/phase_gate_guard_test.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parent.parent / 'hooks' / 'phase-gate-guard.py'
+
+F = []
+
+
+def run_hook(env_extra, tool_name='Agent', tool_input=None):
+    """Invoke the hook; return (allowed: bool, reason: str)."""
+    env = {**os.environ, **env_extra}
+    payload = json.dumps({'tool_name': tool_name, 'tool_input': tool_input or {}})
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=payload, capture_output=True, text=True, env=env,
+    )
+    out = proc.stdout.strip()
+    if not out:
+        return True, ''
+    try:
+        decision = json.loads(out)['hookSpecificOutput']
+    except Exception:
+        return True, ''
+    allowed = decision.get('permissionDecision') != 'deny'
+    return allowed, decision.get('permissionDecisionReason', '')
+
+
+def write_state(tmpdir, body):
+    p = Path(tmpdir) / 'REVIEW_STATE.md'
+    p.write_text(body)
+    return str(p)
+
+
+def check(name, cond):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}")
+    if not cond:
+        F.append(name)
+
+
+APPROVED_WITH = """---
+status: APPROVED
+iteration: 2
+codex_second_pass: {value}
+verdict: APPROVED
+---
+"""
+
+APPROVED_WITHOUT = """---
+status: APPROVED
+iteration: 2
+verdict: APPROVED
+---
+"""
+
+FIELDS = 'codex_second_pass:enabled|declined|unavailable'
+
+with tempfile.TemporaryDirectory() as td:
+    base = {'GATE_STATUS': 'APPROVED', 'GATE_BLOCKED_TOOLS': 'Agent'}
+
+    # --- Backward compatibility: no GATE_REQUIRE_FIELDS => unchanged behavior ---
+    art = write_state(td, APPROVED_WITHOUT)
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('no GATE_REQUIRE_FIELDS: approved artifact still allowed', allowed)
+
+    art = write_state(td, "---\nstatus: CHANGES_REQUIRED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('no GATE_REQUIRE_FIELDS: wrong status still blocked', not allowed)
+
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': str(Path(td) / 'nope.md')})
+    check('missing artifact still blocked', not allowed)
+
+    # --- The new check: every legal disposition passes ---
+    for value in ('enabled', 'declined', 'unavailable'):
+        art = write_state(td, APPROVED_WITH.format(value=value))
+        allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+        check(f'codex_second_pass: {value} -> allowed', allowed)
+
+    # --- The bypass this closes: APPROVED with no recorded decision ---
+    art = write_state(td, APPROVED_WITHOUT)
+    allowed, reason = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('APPROVED without codex_second_pass -> blocked', not allowed)
+    check('block reason names the missing field', 'codex_second_pass' in reason)
+
+    # --- error is an absence of evidence, not an approval ---
+    art = write_state(td, APPROVED_WITH.format(value='error'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('codex_second_pass: error -> blocked (not an approval)', not allowed)
+
+    # --- an un-substituted SKILL.md template is not a real answer ---
+    art = write_state(td, APPROVED_WITH.format(value='enabled | declined | unavailable'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('literal template placeholder -> blocked', not allowed)
+
+    # --- empty value is as good as absent ---
+    art = write_state(td, APPROVED_WITH.format(value=''))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('empty codex_second_pass -> blocked', not allowed)
+
+    # --- presence-only syntax (no allowed-value list) ---
+    art = write_state(td, APPROVED_WITH.format(value='error'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': 'codex_second_pass'})
+    check('presence-only syntax accepts any non-empty value', allowed)
+
+    # --- unrelated tools are never gated ---
+    art = write_state(td, APPROVED_WITHOUT)
+    allowed, _ = run_hook(
+        {**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS}, tool_name='Read'
+    )
+    check('non-blocked tool passes through', allowed)
+
+    # --- value matching is case-insensitive, and quotes/comments tolerated ---
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: "Declined"   # user opted out
+---
+""")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('quoted + commented + mixed-case value -> allowed', allowed)
+
+# --- Adversarial parsing: the gate must not be fooled by YAML shape ---
+#
+# The frontmatter reader is hand-rolled (hooks stay dependency-free), so each way
+# it could mis-read a value is pinned here. Every case below must BLOCK.
+
+with tempfile.TemporaryDirectory() as td:
+    base = {'GATE_STATUS': 'APPROVED', 'GATE_BLOCKED_TOOLS': 'Agent'}
+    gated = {**base, 'GATE_REQUIRE_FIELDS': FIELDS}
+
+    # A nested key must not satisfy a top-level requirement.
+    art = write_state(td, """---
+status: APPROVED
+prior_review:
+  codex_second_pass: enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('nested codex_second_pass does not satisfy top-level -> blocked', not allowed)
+
+    # A '#' inside a quoted scalar is literal text, not a comment.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled # error'
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check("quoted '#' is literal, not a comment -> blocked", not allowed)
+
+    # Duplicate keys are ambiguous — block rather than pick one.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: error
+codex_second_pass: enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('duplicate codex_second_pass keys -> blocked', not allowed)
+
+    # A key with no scalar (block/nested value) is not a recorded decision.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass:
+  - enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('non-scalar codex_second_pass -> blocked', not allowed)
+
+    # No frontmatter at all.
+    art = write_state(td, "status: APPROVED\ncodex_second_pass: enabled\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('no frontmatter delimiters -> blocked', not allowed)
+
+    # YAML doubles a quote to escape it: 'enabled'' # error' is the single value
+    # `enabled' # error`, NOT `enabled`.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled'' # error'
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check("doubled-quote escape not read as 'enabled' -> blocked", not allowed)
+
+    # Junk after a closing quote means this isn't a clean scalar.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled' and then some
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('trailing junk after closing quote -> blocked', not allowed)
+
+    # An unterminated quote is not a value.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('unterminated quote -> blocked', not allowed)
+
+    # YAML resolves \n to a newline, so "decli\ned" is NOT `declined`. A parser
+    # that just drops the backslash would let this through.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: "decli\\ned"
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('escape-synthesized "decli\\ned" -> blocked', not allowed)
+
+    # A plain scalar continues onto indented lines: this value is
+    # `enabled nope`, not `enabled`. (Verified against pyyaml.)
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: enabled
+  nope
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('multiline plain scalar continuation -> blocked', not allowed)
+
+    # A comment after a closing quote is still fine.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'declined'   # user opted out
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('comment after closing quote -> allowed', allowed)
+
+    # --- The same adversarial shapes against the EXISTING status gate ---
+    # These 12+ skills wire the hook without GATE_REQUIRE_FIELDS; the status gate
+    # must not be loosened by the parser rewrite.
+
+    art = write_state(td, "---\nnested:\n  status: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('nested status does not satisfy status gate -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: 'APPROVED # invalid'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("quoted status with literal '#' -> blocked", not allowed)
+
+    art = write_state(td, "---\nstatus: CHANGES_REQUIRED\nstatus: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('duplicate status keys -> blocked', not allowed)
+
+    # A bare inline comment IS a comment (YAML: whitespace before '#').
+    art = write_state(td, "---\nstatus: APPROVED # sign-off by RJ\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('bare status with trailing comment -> allowed (YAML semantics)', allowed)
+
+    # '#' with no leading whitespace is part of the value, not a comment.
+    art = write_state(td, "---\nstatus: APPROVED#nope\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("status 'APPROVED#nope' is not APPROVED -> blocked", not allowed)
+
+    # The doubled-quote escape must not fool the status gate either.
+    art = write_state(td, "---\nstatus: 'APPROVED'' # invalid'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('doubled-quote escape does not satisfy status gate -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: 'APPROVED' but actually not\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status with trailing junk after quote -> blocked', not allowed)
+
+    # Double-quoted with a backslash escape: the value is `APPROVED" x`.
+    art = write_state(td, '---\nstatus: "APPROVED\\" x"\n---\n')
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('backslash-escaped quote not read as APPROVED -> blocked', not allowed)
+
+    # An unknown escape must not collapse into a passing value: YAML rejects
+    # "A\PPROVED"; naive backslash-dropping would read it as APPROVED.
+    art = write_state(td, '---\nstatus: "A\\PPROVED"\n---\n')
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unknown escape "A\\PPROVED" -> blocked', not allowed)
+
+    # `---` inside a scalar is not a frontmatter delimiter: this value is
+    # `APPROVED---nope`, not `APPROVED`. (Pre-existing bug; verified vs pyyaml.)
+    art = write_state(td, "---\nstatus: APPROVED---nope\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('embedded --- in status scalar -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: enabled---nope\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('embedded --- in codex_second_pass -> blocked', not allowed)
+
+    # Unterminated frontmatter is not readable evidence.
+    art = write_state(td, "---\nstatus: APPROVED\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unterminated frontmatter -> blocked', not allowed)
+
+    # An INDENTED `---` is a scalar continuation, not a delimiter: pyyaml reads
+    # this status as `APPROVED ---`.
+    art = write_state(td, "---\nstatus: APPROVED\n  ---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('indented closing --- -> blocked', not allowed)
+
+    art = write_state(td, "  ---\nstatus: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('indented opening --- -> blocked', not allowed)
+
+    # Trailing whitespace after a delimiter is still a delimiter.
+    art = write_state(td, "--- \nstatus: APPROVED\n--- \n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('delimiter with trailing whitespace -> allowed', allowed)
+
+    # The status gate must not fall for a continuation line either: this value
+    # is `APPROVED nope`. (Verified against pyyaml.)
+    art = write_state(td, "---\nstatus: APPROVED\n  nope\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status multiline plain scalar -> blocked', not allowed)
+
+    # ...but a normal flat artifact with a following top-level key still passes.
+    art = write_state(td, "---\nstatus: APPROVED\niteration: 2\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('flat frontmatter with following key -> allowed', allowed)
+
+    # A nested block under a LATER key must not be mistaken for a continuation
+    # of an earlier one.
+    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('nested block under a later key -> allowed', allowed)
+
+
+# --- The wiring is real: execute the command strings from SKILL.md frontmatter ---
+#
+# GATE_REQUIRE_FIELDS contains `|`. Unquoted, bash reads it as a pipeline, the env
+# var never reaches the hook, and the gate silently allows everything. Parsing the
+# YAML would not catch that — only running the command as a shell does.
+
+import re
+import shlex
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def gate_command(skill_path):
+    """Extract the phase-gate-guard command string from a SKILL.md frontmatter."""
+    text = (REPO / skill_path).read_text()
+    frontmatter = text.split('---', 2)[1]
+    for block in re.findall(r'command: >-\n((?:\s{12,}.*\n)+)', frontmatter):
+        joined = ' '.join(line.strip() for line in block.strip().splitlines())
+        if 'phase-gate-guard.py' in joined:
+            return joined
+    return ''
+
+
+with tempfile.TemporaryDirectory() as td:
+    for skill in ('skills/dev-verify/SKILL.md', 'skills/ds-verify/SKILL.md'):
+        cmd = gate_command(skill)
+        check(f'{skill}: gate command found', bool(cmd))
+        if not cmd:
+            continue
+
+        check(f'{skill}: GATE_REQUIRE_FIELDS present', 'GATE_REQUIRE_FIELDS' in cmd)
+
+        # Replace the interpreter invocation with `env` so the shell reports the
+        # environment the hook would actually receive.
+        env_probe = re.sub(r'uv run python3 \S+phase-gate-guard\.py', 'env', cmd)
+        env_probe = env_probe.replace('${CLAUDE_PLUGIN_ROOT}', str(REPO))
+        proc = subprocess.run(['bash', '-c', env_probe], capture_output=True, text=True)
+
+        got = [l for l in proc.stdout.splitlines() if l.startswith('GATE_REQUIRE_FIELDS=')]
+        check(f'{skill}: GATE_REQUIRE_FIELDS survives shell parsing (quoted)', len(got) == 1)
+        if got:
+            value = got[0].split('=', 1)[1]
+            check(f'{skill}: all three dispositions reach the hook',
+                  set(value.split(':', 1)[1].split('|')) ==
+                  {'enabled', 'declined', 'unavailable'})
+        check(f'{skill}: no stray shell errors from the assignment',
+              'command not found' not in proc.stderr)
+
+print()
+if F:
+    print(f"{len(F)} FAILED: {F}")
+    sys.exit(1)
+print('all phase-gate-guard tests passed')
+sys.exit(0)


### PR DESCRIPTION
## What

The SAS references covered how to write fast ETL but never how to **look at the data first**. This adds probing guidance.

### `skills/wrds/references/sas-etl.md`
New **Probing Data and Metadata** section (before Hash Object Merge):
- **PROC CONTENTS** — `varnum`, `out=` for programmatic checks, reading the **index section** (an index is what makes the index-friendly WHERE pattern fast), and comparing key lengths across datasets before a merge (a `$6` vs `$8` gvkey matches zero rows silently).
- **PROC DATASETS** — library inventory, and metadata-only `delete`/`change`/`copy`/`index create`. Notes it's a RUN-group proc that needs `quit;`.
- **PROC PRINT** — always `obs=`, always `var`; output goes to the listing (`-print`), not the log. Plus PROC FREQ/MEANS on a sample for distributions.
- **Whole-library probes** — `_all_ nods`, `dictionary.tables` (nobs from the header, no scan), `dictionary.columns`.
- Probe checklist, cross-linked to Step 0 of Profile Before Fan-Out.

### `skills/wrds/SKILL.md`
Probing checklist added to the SAS Code Validation Checklist as the first block; reference index updated.

### `skills/ds-implement/references/sas-enforcement.md`
"Probe Inputs First" rules added to the enforcement block pasted into every SAS subagent prompt, plus a self-check line.

## Verification
- All intra-doc anchor links resolve.
- `references/constraints/check-all.py` is unchanged from baseline (65/116 pass, 8 pre-existing failures both with and without this diff).
- Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189YPdbrDFgoMPYYqyKY75c