### PR TITLE
fix(hooks): the ds Iron Law guards were emitting a payload the harness discards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.70.1"
+    "version": "5.71.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.70.1",
+      "version": "5.71.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.70.1",
+  "version": "5.71.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/hooks/_gate_common.py
+++ b/hooks/_gate_common.py
@@ -22,6 +22,32 @@ def deny(reason: str):
     sys.exit(0)
 
 
+def allow():
+    """PreToolUse: silence IS the allow.
+
+    There is no `{"decision": "allow"}` in the hook contract. Emitting one gets the
+    WHOLE payload rejected ("Hook JSON output validation failed"), which is harmless
+    for an allow but means the same code path's *block* is rejected too — the guard
+    silently stops guarding. Print nothing and exit 0.
+    """
+    sys.exit(0)
+
+
+def context(event: str, text: str):
+    """Non-blocking feedback to Claude, on any event that accepts additionalContext.
+
+    `event` MUST equal the event the hook is wired to: a hookEventName that disagrees
+    with the wiring is rejected exactly like an unsupported field. Read it from the
+    payload's `hook_event_name` rather than hardcoding it when a hook is wired to more
+    than one event.
+    """
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": event,
+        "additionalContext": text,
+    }}))
+    sys.exit(0)
+
+
 def _project_from_args(tool_input: dict, hook_input: Optional[dict] = None) -> str:
     """Resolve the project directory the gate should audit.
 

--- a/hooks/ds-brainstorm-no-exploration-guard.py
+++ b/hooks/ds-brainstorm-no-exploration-guard.py
@@ -7,6 +7,16 @@ Block Bash commands that look like data analysis during brainstorm.
 import json
 import os
 import sys
+from pathlib import Path
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -14,8 +24,7 @@ def main():
     tool_params = tool_input.get("tool_input", {})
 
     if tool_name != "Bash":
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     command = tool_params.get("command", "")
 
@@ -34,17 +43,12 @@ def main():
         spec_path = os.path.join(os.getcwd(), ".planning", "SPEC.md")
         if os.path.exists(spec_path):
             # Brainstorm complete, allow exploration
-            print(json.dumps({"decision": "allow"}))
-            return
+            allow()
 
-        print(json.dumps({
-            "decision": "block",
-            "message": "\ud83d\uded1 Iron Law: No data exploration before asking questions. Complete the brainstorm interview and write SPEC.md first. Data exploration happens in ds-plan (Phase 2)."
-        }))
-        return
+        deny("\ud83d\uded1 Iron Law: No data exploration before asking questions. Complete the brainstorm interview and write SPEC.md first. Data exploration happens in ds-plan (Phase 2).")
 
     # Allow non-analysis bash commands
-    print(json.dumps({"decision": "allow"}))
+    allow()
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-no-main-chat-code-guard.py
+++ b/hooks/ds-no-main-chat-code-guard.py
@@ -7,6 +7,16 @@ Analysis code must be written by delegated subagents, not the orchestrator.
 import json
 import os
 import sys
+from pathlib import Path
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -15,8 +25,7 @@ def main():
 
     # Only check Write, Edit, and Bash
     if tool_name not in ("Write", "Edit", "Bash"):
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # For Bash, check if command contains analysis-related operations
     if tool_name == "Bash":
@@ -24,21 +33,14 @@ def main():
         # Allow git, ls, cat .planning/, check-all-ds.sh, and other orchestration commands
         safe_prefixes = ["git ", "ls ", "cat .planning/", "head ", "tail ", "wc ", "mkdir ", "chmod ", "bash scripts/"]
         if any(command.strip().startswith(p) for p in safe_prefixes):
-            print(json.dumps({"decision": "allow"}))
-            return
+            allow()
         # Allow pixi/python commands that are just running scripts
         if "check-all-ds" in command or "check-ds-" in command:
-            print(json.dumps({"decision": "allow"}))
-            return
+            allow()
         # Block python/pixi run commands that look like analysis
         if any(kw in command for kw in ["python3 -c", "pixi run python", "import pandas", "import numpy"]):
-            print(json.dumps({
-                "decision": "block",
-                "message": "🛑 Iron Law: No analysis code in main chat. Delegate to a subagent via ds-delegate."
-            }))
-            return
-        print(json.dumps({"decision": "allow"}))
-        return
+            deny("🛑 Iron Law: No analysis code in main chat. Delegate to a subagent via ds-delegate.")
+        allow()
 
     # For Write/Edit, check if target is an analysis file
     path = tool_params.get("file_path", "")
@@ -46,19 +48,14 @@ def main():
     # Allow writes to state files, planning, config
     allowed_patterns = [".planning/", ".claude/", "CLAUDE.md", "scripts/", "hooks/", "references/", "skills/"]
     if any(pattern in path for pattern in allowed_patterns):
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Block writes to analysis files (.py, .ipynb, .R, .sas, .sql in project dirs)
     analysis_extensions = [".py", ".ipynb", ".R", ".r", ".sas", ".sql", ".qmd"]
     if any(path.endswith(ext) for ext in analysis_extensions):
-        print(json.dumps({
-            "decision": "block",
-            "message": "🛑 Iron Law: No analysis code in main chat. This file should be written by a delegated subagent. Use ds-delegate to dispatch a Task agent."
-        }))
-        return
+        deny("🛑 Iron Law: No analysis code in main chat. This file should be written by a delegated subagent. Use ds-delegate to dispatch a Task agent.")
 
-    print(json.dumps({"decision": "allow"}))
+    allow()
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-post-subagent-guard.py
+++ b/hooks/ds-post-subagent-guard.py
@@ -27,8 +27,10 @@ def main():
     with open(flag_file, "w") as f:
         f.write("1")
 
-    # Allow the tool use to proceed
-    print(json.dumps({"decision": "allow"}))
+    # Nothing to say. PostToolUse accepts a top-level "decision", but ONLY the value
+    # "block" -- {"decision": "allow"} is rejected as invalid and the whole payload is
+    # dropped. Staying silent is how a PostToolUse hook says "carry on".
+    sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-pre-subagent-clear.py
+++ b/hooks/ds-pre-subagent-clear.py
@@ -7,7 +7,17 @@ reads needed to prepare the subagent prompt are not blocked.
 import json
 import os
 import sys
+from pathlib import Path
 import tempfile
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 
 def main():
@@ -19,7 +29,7 @@ def main():
     if os.path.exists(flag_file):
         os.remove(flag_file)
 
-    print(json.dumps({"decision": "allow"}))
+    allow()
 
 
 if __name__ == "__main__":

--- a/hooks/ds-read-after-subagent-guard.py
+++ b/hooks/ds-read-after-subagent-guard.py
@@ -7,7 +7,17 @@ Read/Grep on paths that are NOT under .planning/.
 import json
 import os
 import sys
+from pathlib import Path
 import tempfile
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -21,8 +31,7 @@ def main():
 
     if not os.path.exists(flag_file):
         # No subagent has returned yet — allow everything
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Subagent has returned — check if this is a read on non-state files
     path = ""
@@ -34,20 +43,15 @@ def main():
         path = tool_params.get("path", "")
 
     if not path:
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Allow reads of state files (.planning/), plugin files, and common config
     allowed_patterns = [".planning/", ".claude/", "CLAUDE.md", "plugins/cache/"]
     if any(pattern in path for pattern in allowed_patterns):
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Block reads of source/data files after subagent return
-    print(json.dumps({
-        "decision": "block",
-        "message": "\ud83d\uded1 Post-subagent boundary (C5): After a subagent returns, main chat must NOT read source/data files. Verify via .planning/ state files only. If you need to investigate further, dispatch a NEW subagent."
-    }))
+    deny("\ud83d\uded1 Post-subagent boundary (C5): After a subagent returns, main chat must NOT read source/data files. Verify via .planning/ state files only. If you need to investigate further, dispatch a NEW subagent.")
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-reviewer-readonly-guard.py
+++ b/hooks/ds-reviewer-readonly-guard.py
@@ -6,6 +6,16 @@ tool calls to prevent reviewers from "fixing" issues they find.
 """
 import json
 import sys
+from pathlib import Path
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -19,14 +29,10 @@ def main():
         path = tool_input.get("tool_input", {}).get("file_path", "")
         parts = [p for p in path.replace("\\", "/").split("/") if p and p != "."]
         if parts and parts[0] in (".planning", ".claude"):
-            print(json.dumps({"decision": "allow"}))
-            return
-        print(json.dumps({
-            "decision": "block",
-            "message": "\ud83d\uded1 Reviewer read-only enforcement: Review/verification agents must NOT modify files. Report findings back to the orchestrator for planned fixes. (Writes to .planning/ verdict sentinels are allowed.)"
-        }))
+            allow()
+        deny("\ud83d\uded1 Reviewer read-only enforcement: Review/verification agents must NOT modify files. Report findings back to the orchestrator for planned fixes. (Writes to .planning/ verdict sentinels are allowed.)")
     else:
-        print(json.dumps({"decision": "allow"}))
+        allow()
 
 if __name__ == "__main__":
     main()

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -106,6 +106,16 @@
           }
         ]
       }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/subagent-start.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/phase-gate-guard.py
+++ b/hooks/phase-gate-guard.py
@@ -84,14 +84,56 @@ verified in tests/phase_gate_guard_test.py:
     `APPROVED`. Same for quoted scalars with escapes or trailing junk.
   - STRICTER: duplicate keys now block instead of resolving to one of them.
     Ambiguous evidence is not evidence.
+  - STRICTER (bug fix): `status:APPROVED` no longer matches. A block mapping
+    needs whitespace after the colon, so YAML reads that line as the plain
+    scalar "status:APPROVED" — the document has no `status` key at all, and the
+    old reader handed back `APPROVED` from it.
   - LOOSER (YAML correctness): `status: APPROVED # signed off` now passes. YAML
     says that value is `APPROVED`; the old reader compared the whole string
     including the comment and blocked. A quoted `'APPROVED # invalid'` still
     blocks — inside quotes the '#' is literal text, not a comment.
+
+  - STRICTER: the frontmatter must be a FLAT mapping of scalars. If any
+    top-level line opens a flow collection or leaves a quote unterminated, the
+    whole block is refused — such a construct captures the lines beneath it, so
+    `broken: [` followed by `status: APPROVED` has no top-level `status` at all,
+    yet a line-wise reader would find one. Indented content (block scalars,
+    nested mappings) is fine: it cannot masquerade as a top-level key.
+
+Decorated YAML — anchors (`&a`), tags (`!!str`), aliases (`*a`), flow
+collections (`[x]`, `{k: v}`) — is not a plain scalar and fails closed. Gate
+artifacts never legitimately use them, and a resolver for them is surface to get
+subtly wrong. One accepted leniency: a stray trailing tab (`status: APPROVED\t`)
+is read as `APPROVED` where PyYAML rejects the document outright; it cannot
+smuggle a different value (`status: APPROVED\tx` still blocks).
+
+tests/phase_gate_guard_differential_test.py pins all of this against PyYAML over
+a generated corpus: the reader must never accept a value PyYAML disagrees with.
+
+KNOWN RESIDUAL — the reader can accept a gate value from a document that is
+malformed SOMEWHERE ELSE. Its checks cover every column-0 line, but indented
+lines are skipped by design (they belong to a parent key), so:
+
+    status: APPROVED
+    prior:
+      broken: 'x' junk        <- invalid YAML; PyYAML rejects the whole document
+
+still reads `status: APPROVED`. Closing this means validating the entire
+document — i.e. a real YAML parser, which is the dependency this hook avoids on
+purpose (it fires on every tool call; a gate that must resolve a package before
+answering can fail OPEN, which is strictly worse than this).
+
+The residual is bounded and does not fabricate verdicts. Everything that could
+make a line MEAN something other than what it says — capture by a multi-line
+construct, quoting, escapes, comments, duplicate keys — fails closed. What
+remains is only: a gate line that genuinely says `APPROVED`, in a file whose
+unrelated line is corrupt. It cannot smuggle a value the artifact does not
+contain, which is what the gate exists to prevent.
 """
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -175,9 +217,9 @@ def _yaml_scalar(raw: str) -> str:
                 return ''
             if ch == quote:
                 # Closing quote: only whitespace and an optional comment may
-                # follow. Anything else means this isn't the scalar we think.
-                rest = raw[i + 1:].strip()
-                if rest and not rest.startswith('#'):
+                # follow, and YAML needs whitespace before that comment.
+                # Anything else means this isn't the scalar we think.
+                if not _rest_is_clean(raw[i + 1:]):
                     return ''
                 return ''.join(chars)
             chars.append(ch)
@@ -192,12 +234,138 @@ def _yaml_scalar(raw: str) -> str:
     return raw
 
 
+def _quote_scan(value: str):
+    """(closed, raw_text_after_closing_quote) for a quoted scalar.
+
+    The remainder is returned UNSTRIPPED: whether whitespace separated the
+    closing quote from what follows is load-bearing (see _rest_is_clean).
+    """
+    quote = value[0]
+    i = 1
+    while i < len(value):
+        if quote == "'" and value[i] == "'" and value[i + 1:i + 2] == "'":
+            i += 2          # '' escape
+            continue
+        if quote == '"' and value[i] == '\\':
+            i += 2          # \x escape
+            continue
+        if value[i] == quote:
+            return True, value[i + 1:]
+        i += 1
+    return False, ''
+
+
+def _rest_is_clean(rest: str) -> bool:
+    """May this text follow a closing quote — i.e. nothing, or a real comment?
+
+    YAML requires whitespace before a trailing `#`, so `'APPROVED'#x` is not a
+    value plus a comment: it's a syntax error, and PyYAML rejects the document
+    rather than reading `APPROVED` out of it. Accepting the `#` as a comment
+    would open a gate on a file YAML refuses to parse.
+    """
+    if rest == '':
+        return True
+    if rest[:1] not in (' ', '\t'):
+        return False
+    tail = rest.strip()
+    return tail == '' or tail.startswith('#')
+
+
+# A gate artifact's top-level line is `key: scalar`. Anything outside that
+# subset is refused rather than interpreted — see supported_line().
+_KEY_RE = re.compile(r'^[A-Za-z0-9_.\-]+$')
+_BLOCK_HEADER_RE = re.compile(r'^[|>][+-]?\d*\s*(#.*)?$')
+# Indicators that start something other than a plain scalar: flow collections,
+# properties/aliases, complex keys, directives, and YAML's reserved characters.
+_NOT_PLAIN = set('!&*[]{}?%@`,>|')
+
+
+def supported_line(line: str) -> bool:
+    """Is this column-0 line inside the narrow `key: scalar` subset we support?
+
+    An ALLOWLIST, deliberately. Enumerating dangerous constructs is endless —
+    each new YAML feature is another hole. Enumerating the *supported* ones is
+    closed: anything unrecognized fails closed, including syntax that makes the
+    document invalid outright (`broken: 'x' junk`, `broken: foo: bar`), because
+    a gate must not read a value out of a file YAML itself rejects.
+    """
+    if ':' not in line:
+        return False                       # not a mapping entry at all
+    key, value = line.split(':', 1)
+    if not _KEY_RE.match(key):
+        return False                       # exotic key, or a `%TAG ...` directive
+    if value and value[:1] not in (' ', '\t'):
+        return False                       # `key:value` — YAML needs the space
+
+    v = value.strip()
+    if not v or v.startswith('#'):
+        return True                        # empty value, or value-less + comment
+    if _BLOCK_HEADER_RE.match(v):
+        return True                        # `|`, `>-`: content is indented, safe
+
+    if v[0] in ('"', "'"):
+        closed, rest = _quote_scan(v)
+        if not closed:
+            return False                   # captures the lines below
+        if v[0] == '"' and '\\' in v:
+            return False                   # escapes we deliberately don't decode
+        return _rest_is_clean(rest)        # no trailing tokens, no `'x'#unspaced`
+
+    if v[0] in _NOT_PLAIN:
+        return False
+    plain = v.split(' #', 1)[0].rstrip()   # drop a trailing comment
+    if ': ' in plain or plain.endswith(':'):
+        return False                       # `foo: bar` as a value — invalid here
+    return True
+
+
+def frontmatter_is_flat(frontmatter: str) -> bool:
+    """Is this frontmatter a flat mapping of scalars — i.e. safe to read line by line?
+
+    Reading a gate field line-by-line is only sound when no line can be captured
+    by a construct opened on an earlier one. An unterminated flow collection or
+    quote swallows the lines beneath it, so
+
+        broken: [
+        status: APPROVED
+
+    has NO top-level `status` — the line belongs to `broken` — yet a line-wise
+    reader sees `status: APPROVED` and opens the gate. Rather than re-implement
+    YAML to find out, refuse the whole block: a gate that cannot trust its own
+    evidence must not pass on it.
+
+    Enforced by supported_line(), which is an ALLOWLIST — that is what makes
+    this closed rather than whack-a-mole. Rejecting known-dangerous constructs
+    invites an endless series of "one more syntax": a flow collection captures
+    the lines below it, a tag hides the quote that captures them, and so on.
+    Accepting only `key: scalar` inverts the burden — unrecognized syntax fails
+    closed by default, including syntax that makes the document invalid outright,
+    which YAML would refuse to read at all.
+
+    Block scalars (`|`, `>`) are allowed and are not a hole: their content must
+    be INDENTED, so they can never capture a column-0 line (verified against
+    PyYAML). Plain scalars can continue, but only onto INDENTED lines, which
+    frontmatter_value() fails closed on.
+    """
+    for line in frontmatter.splitlines():
+        if not line.strip() or line.lstrip().startswith('#'):
+            continue
+        if line[:1] in (' ', '\t'):
+            continue            # indented: belongs to a parent key, not our level
+        if not supported_line(line):
+            return False
+    return True
+
+
 def frontmatter_value(frontmatter: str, key: str) -> str:
     """Return the top-level scalar for `key`, or '' when absent or ambiguous.
 
     Fails closed: an absent, nested, duplicated, or non-scalar key all yield ''
     so the caller blocks. A gate that cannot read its own evidence must not pass.
     """
+    if not frontmatter_is_flat(frontmatter):
+        return ''
+
     lines = frontmatter.splitlines()
     matches = []
     for i, line in enumerate(lines):
@@ -208,6 +376,15 @@ def frontmatter_value(frontmatter: str, key: str) -> str:
         if line.lstrip().startswith('#'):
             continue
         if not line.startswith(f'{key}:'):
+            continue
+
+        # A block mapping needs whitespace (or EOL) after the colon: `status:X`
+        # is NOT a key/value pair, it's the plain scalar "status:X", so the
+        # document has no `status` key at all. Matching it anyway would read
+        # `APPROVED` out of `status:APPROVED` and open a gate on a document
+        # that never recorded a status.
+        after = line[len(key) + 1:]
+        if after and after[:1] not in (' ', '\t'):
             continue
 
         # A YAML plain scalar continues onto indented following lines, so
@@ -328,6 +505,20 @@ def main():
             f"This phase cannot proceed without the gate artifact from the "
             f"previous phase. The artifact proves the gate actually ran — "
             f"instructional text alone is not enforcement.\n\n"
+            f"**Remedy:** {gate_remedy}"
+        )
+
+    if (required_status or required_fields) and not frontmatter_is_flat(read_frontmatter(artifact_path)):
+        deny(
+            tool_name, file_path,
+            f"GATE BLOCKED: {gate_description} — artifact is not readable.\n\n"
+            f"`{artifact_path}` does not parse as a flat YAML mapping of simple "
+            f"values: a line opens a flow collection (`[`, `{{`) or leaves a quote "
+            f"unterminated, which captures the lines beneath it. The gate cannot "
+            f"tell what this file actually records, and evidence it cannot read "
+            f"is not evidence.\n\n"
+            f"Fix the frontmatter so every top-level line is a plain `key: value` "
+            f"pair, then re-run the phase.\n\n"
             f"**Remedy:** {gate_remedy}"
         )
 

--- a/hooks/phase-gate-guard.py
+++ b/hooks/phase-gate-guard.py
@@ -7,9 +7,25 @@ artifact path and a human-readable gate description via environment variables:
 
   GATE_ARTIFACT=.planning/PLAN_REVIEWED.md
   GATE_STATUS=APPROVED           (optional: required frontmatter status value)
+  GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable
+                                 (optional: frontmatter keys that must be present,
+                                  optionally constrained to an allowed value set)
   GATE_DESCRIPTION=Plan review   (human-readable name for error messages)
   GATE_REMEDY=Return to dev-design and run dev-plan-reviewer
   GATE_BLOCKED_TOOLS=Write,Edit,Bash,Agent  (optional: default Write|Edit)
+
+GATE_REQUIRE_FIELDS syntax: comma-separated entries, each either `name` (key must
+be present and non-empty) or `name:v1|v2` (must also be one of the listed values).
+It answers a question GATE_STATUS cannot: "was this decision *recorded*, or
+silently skipped?" A phase can legitimately end in several dispositions, so
+pinning one `status:` value is wrong — but leaving the field absent entirely
+means the phase never ran and nobody noticed.
+
+Constraining the value set also catches the copy-paste failure: SKILL.md YAML
+templates are written as `field: a | b | c`, and an agent that pastes the
+template verbatim without substituting leaves a literal `a | b | c` that matches
+no single allowed value — so the gate blocks instead of accepting a placeholder
+as a real answer.
 
 Scoped to individual phase skills via frontmatter hooks. The skill sets env vars
 in the hook command, making this one script reusable across all workflow phases.
@@ -28,6 +44,17 @@ Usage in SKILL.md frontmatter:
               GATE_BLOCKED_TOOLS=Agent
               uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
 
+LANDMINE: GATE_REQUIRE_FIELDS values contain `|`, which bash reads as a PIPE. The
+assignment MUST be quoted in the hook command:
+
+    GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"   # correct
+    GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable     # BROKEN
+
+Unquoted, bash parses it as a pipeline, the env var is never set, this script sees
+no field requirement, and the gate silently allows everything — a phantom gate that
+looks wired but never blocks. `tests/phase_gate_guard_test.py` executes the real
+command strings out of the SKILL.md frontmatter to catch exactly this.
+
 LANDMINE: the `matcher` alone does NOT block a tool — it only decides which tool calls invoke this
 script. Blocking is decided here, by GATE_BLOCKED_TOOLS, which DEFAULTS to Write,Edit only (see
 DEFAULT_BLOCKED_TOOLS below). A matcher of "Write|Edit|Agent" with no GATE_BLOCKED_TOOLS=...,Agent
@@ -38,6 +65,29 @@ its matcher. Always list every tool named in `matcher` in GATE_BLOCKED_TOOLS too
 Grounded in: April 2026 meta-audit — workflow-creator found that advisory gates
 ("you must run X first") were systematically skipped under context pressure.
 Hooks are runtime-enforced by Claude Code; Claude cannot rationalize past them.
+
+FRONTMATTER READING — behavior notes for the skills already wiring this hook:
+
+The reader is hand-rolled and fails closed: absent, nested, duplicated, or
+non-scalar keys all read as '' and the gate blocks. Three consequences, all
+verified in tests/phase_gate_guard_test.py:
+
+  - STRICTER (bug fix): a nested `status: APPROVED` no longer satisfies the
+    status gate. The previous reader stripped every line before matching, so any
+    indented `status:` under any parent key passed the gate — a real bypass in
+    every skill that wires it.
+  - STRICTER (bug fix): `---` is a delimiter only as a standalone line. The
+    previous `text.split('---', 2)` cut on any occurrence, so the scalar
+    `status: APPROVED---nope` was truncated to a passing `APPROVED`.
+  - STRICTER: a plain scalar's indented continuation lines (`status: APPROVED`
+    / `  nope` — one value, `APPROVED nope`) now block instead of reading as
+    `APPROVED`. Same for quoted scalars with escapes or trailing junk.
+  - STRICTER: duplicate keys now block instead of resolving to one of them.
+    Ambiguous evidence is not evidence.
+  - LOOSER (YAML correctness): `status: APPROVED # signed off` now passes. YAML
+    says that value is `APPROVED`; the old reader compared the whole string
+    including the comment and blocked. A quoted `'APPROVED # invalid'` still
+    blocks — inside quotes the '#' is literal text, not a comment.
 """
 
 import json
@@ -58,29 +108,168 @@ def check_artifact_exists(artifact_path: str) -> bool:
     return Path(artifact_path).is_file()
 
 
-def check_artifact_status(artifact_path: str, required_status: str) -> bool:
-    """Check if the artifact's frontmatter contains the required status."""
+def read_frontmatter(artifact_path: str) -> str:
+    """Return the artifact's YAML frontmatter block, or '' if there isn't one.
+
+    A delimiter is a LINE that is exactly `---`, not any `---` substring: the
+    latter truncates scalars that merely contain the sequence, so
+    `status: APPROVED---nope` would be cut down to a passing `APPROVED` when
+    YAML says the value is `APPROVED---nope`.
+    """
     try:
         text = Path(artifact_path).read_text()
     except Exception:
-        return False
+        return ''
 
-    # Parse YAML frontmatter (between --- delimiters)
-    if not text.startswith('---'):
-        return False
-    parts = text.split('---', 2)
-    if len(parts) < 3:
-        return False
-    frontmatter = parts[1]
+    # rstrip, not strip: trailing whitespace after `---` is still a delimiter,
+    # but an INDENTED `  ---` is a plain-scalar continuation line — YAML reads
+    # `status: APPROVED` + `  ---` as the single value `APPROVED ---`, so
+    # treating it as the closing delimiter would pass a gate on a value the
+    # document doesn't contain.
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != '---':
+        return ''
+    for i in range(1, len(lines)):
+        if lines[i].rstrip() == '---':
+            return '\n'.join(lines[1:i])
+    return ''  # unterminated frontmatter — no readable evidence
 
-    # Simple status check — look for "status: VALUE" line
-    for line in frontmatter.strip().splitlines():
-        line = line.strip()
-        if line.startswith('status:'):
-            value = line.split(':', 1)[1].strip().strip('"').strip("'")
-            return value.upper() == required_status.upper()
 
-    return False
+def _yaml_scalar(raw: str) -> str:
+    """Extract the scalar from a YAML `key:` right-hand side.
+
+    Deliberately hand-rolled: every hook here is dependency-free, and this one
+    fires on every tool call — a hook that must resolve a package before it can
+    answer is a hook that can fail open. Handles exactly what gate fields are:
+    short quoted-or-bare scalars. Anything else returns '' and the gate blocks.
+    """
+    raw = raw.strip()
+    if not raw:
+        return ''
+
+    # Quoted scalar: the value is what's between the quotes. A '#' inside is
+    # literal text, NOT a comment — `'enabled # error'` is one value, not
+    # `enabled` with a note. Quotes are not merely delimiters to scan past:
+    # YAML escapes a quote by doubling it ('' inside '...') or with a backslash
+    # (\" inside "..."), so `'APPROVED'' # invalid'` is the single value
+    # `APPROVED' # invalid` — reading it as `APPROVED` would pass a gate the
+    # artifact does not actually satisfy.
+    if raw[0] in ('"', "'"):
+        quote = raw[0]
+        chars = []
+        i = 1
+        while i < len(raw):
+            ch = raw[i]
+            if quote == "'" and ch == "'" and raw[i + 1:i + 2] == "'":
+                chars.append("'")          # '' -> literal '
+                i += 2
+                continue
+            if quote == '"' and ch == '\\':
+                # A double-quoted YAML scalar can escape a newline (\n), a tab,
+                # a codepoint (✓)... Decoding that table by hand is a way to
+                # be subtly wrong: naively dropping the backslash turns
+                # "decli\ned" into `declined`, when YAML says it contains a
+                # newline and is NOT `declined`. Gate values are short enums —
+                # `APPROVED`, `enabled` — that never legitimately need an escape,
+                # so refuse the whole scalar instead of decoding it.
+                return ''
+            if ch == quote:
+                # Closing quote: only whitespace and an optional comment may
+                # follow. Anything else means this isn't the scalar we think.
+                rest = raw[i + 1:].strip()
+                if rest and not rest.startswith('#'):
+                    return ''
+                return ''.join(chars)
+            chars.append(ch)
+            i += 1
+        return ''                          # unterminated quote
+
+    # Bare scalar: YAML only starts a comment at a '#' preceded by whitespace,
+    # so `enabled#1` is a value while `enabled # note` is a value + comment.
+    for i, ch in enumerate(raw):
+        if ch == '#' and (i == 0 or raw[i - 1] in ' \t'):
+            return raw[:i].strip()
+    return raw
+
+
+def frontmatter_value(frontmatter: str, key: str) -> str:
+    """Return the top-level scalar for `key`, or '' when absent or ambiguous.
+
+    Fails closed: an absent, nested, duplicated, or non-scalar key all yield ''
+    so the caller blocks. A gate that cannot read its own evidence must not pass.
+    """
+    lines = frontmatter.splitlines()
+    matches = []
+    for i, line in enumerate(lines):
+        # Top-level keys only — an indented `codex_second_pass:` belongs to some
+        # nested mapping and must not satisfy a top-level requirement.
+        if not line[:1].strip():
+            continue
+        if line.lstrip().startswith('#'):
+            continue
+        if not line.startswith(f'{key}:'):
+            continue
+
+        # A YAML plain scalar continues onto indented following lines, so
+        #     status: APPROVED
+        #       nope
+        # is the single value `APPROVED nope` — reading only the first line
+        # would pass a gate on a value the document doesn't contain. Any
+        # indented continuation makes this unreadable here: fail closed.
+        nxt = lines[i + 1] if i + 1 < len(lines) else ''
+        if nxt.strip() and nxt[:1] in (' ', '\t'):
+            return ''
+
+        matches.append(_yaml_scalar(line.split(':', 1)[1]))
+
+    # Duplicate keys are ambiguous (real YAML rejects them) — block, don't guess.
+    if len(matches) != 1:
+        return ''
+    return matches[0]
+
+
+def check_artifact_status(artifact_path: str, required_status: str) -> bool:
+    """Check if the artifact's frontmatter contains the required status."""
+    frontmatter = read_frontmatter(artifact_path)
+    if not frontmatter:
+        return False
+    value = frontmatter_value(frontmatter, 'status')
+    return bool(value) and value.upper() == required_status.upper()
+
+
+def parse_required_fields(spec: str) -> list:
+    """Parse GATE_REQUIRE_FIELDS into [(key, allowed_values_or_None), ...].
+
+    `name` -> presence only; `name:v1|v2` -> presence + membership.
+    """
+    requirements = []
+    for entry in spec.split(','):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ':' in entry:
+            key, values = entry.split(':', 1)
+            allowed = {v.strip().lower() for v in values.split('|') if v.strip()}
+            requirements.append((key.strip(), allowed or None))
+        else:
+            requirements.append((entry, None))
+    return requirements
+
+
+def check_required_fields(artifact_path: str, spec: str) -> list:
+    """Return human-readable problems for each unmet field requirement."""
+    frontmatter = read_frontmatter(artifact_path)
+    problems = []
+    for key, allowed in parse_required_fields(spec):
+        value = frontmatter_value(frontmatter, key) if frontmatter else ''
+        if not value:
+            problems.append(f"`{key}` is missing or empty")
+        elif allowed and value.lower() not in allowed:
+            expected = ' | '.join(sorted(allowed))
+            problems.append(
+                f"`{key}: {value}` is not one of: {expected}"
+            )
+    return problems
 
 
 def is_allowed_path(file_path: str) -> bool:
@@ -93,6 +282,7 @@ def main():
     # Read hook configuration from environment
     artifact_path = os.environ.get('GATE_ARTIFACT', '')
     required_status = os.environ.get('GATE_STATUS', '')
+    required_fields = os.environ.get('GATE_REQUIRE_FIELDS', '')
     gate_description = os.environ.get('GATE_DESCRIPTION', 'Phase gate')
     gate_remedy = os.environ.get('GATE_REMEDY', 'Complete the previous phase first')
     blocked_tools_str = os.environ.get('GATE_BLOCKED_TOOLS', '')
@@ -149,6 +339,21 @@ def main():
             f"The file exists but does not have the required status.\n\n"
             f"**Remedy:** {gate_remedy}"
         )
+
+    if required_fields:
+        problems = check_required_fields(artifact_path, required_fields)
+        if problems:
+            detail = '\n'.join(f"- {p}" for p in problems)
+            deny(
+                tool_name, file_path,
+                f"GATE BLOCKED: {gate_description} — required decision not recorded.\n\n"
+                f"In `{artifact_path}`:\n{detail}\n\n"
+                f"The status says this phase passed, but a decision it was required "
+                f"to record is missing or unrecognized. A phase that reports success "
+                f"without recording what it decided cannot be audited afterwards — "
+                f"'it probably ran' is not evidence that it ran.\n\n"
+                f"**Remedy:** {gate_remedy}"
+            )
 
     # Gate passed — allow the tool call
     sys.exit(0)

--- a/hooks/pre-compact.py
+++ b/hooks/pre-compact.py
@@ -78,6 +78,64 @@ def append_compaction_marker(learnings_path: Path, workflow: str | None) -> bool
         return False
 
 
+def domain_skills_from_spec() -> list[str]:
+    """Skills listed under a 'Skills Touched'-style section of SPEC.md / PLAN.md.
+
+    ds-plan Step 5b globs these skills' references/ ONCE while drafting the plan. That is
+    plan-time only -- nothing re-reads them during implementation, which is how stale
+    domain knowledge slips through. Persisting them here lets SubagentStart re-assert it.
+    """
+    skills: list[str] = []
+    for name in ('SPEC.md', 'PLAN.md'):
+        p = Path.cwd() / '.planning' / name
+        if not p.exists():
+            continue
+        try:
+            text = p.read_text(encoding='utf-8')
+        except (IOError, OSError):
+            continue
+        # lines like:  - `wrds` -- TAQ millisecond data, SAS on the WRDS grid
+        for m in re.finditer(r'^\s*[-*]\s+`([a-z0-9][a-z0-9:_-]*)`\s*[-—]', text, re.M):
+            s = m.group(1)
+            if s not in skills:
+                skills.append(s)
+    return skills
+
+
+def write_state_file(workflow: str | None, instructions: list[str]) -> None:
+    """Persist workflow state so it survives compaction AND reaches spawned subagents."""
+    planning = Path.cwd() / '.planning'
+    if not planning.is_dir():
+        return
+    skills = domain_skills_from_spec()
+    ts = datetime.now().strftime('%Y-%m-%d %H:%M')
+    lines = [
+        "# STATE (auto-written by pre-compact.py -- safe to edit by hand)",
+        "",
+        f"_Last updated: {ts}_",
+        "",
+        f"## Active workflow: {'/' + workflow if workflow else 'UNKNOWN'}",
+        "",
+        *(f"- {i}" for i in instructions),
+        "",
+    ]
+    if skills:
+        lines += [
+            "## Domain knowledge — READ BEFORE WRITING CODE",
+            "",
+            "These skills' `references/` and `examples/` hold verified, project-specific",
+            "facts that supersede training data. Re-read them at implementation time, not",
+            "just at plan time:",
+            "",
+            *(f"- `{s}` — see `~/projects/workflows/skills/{s}/references/`" for s in skills),
+            "",
+        ]
+    try:
+        (planning / 'STATE.md').write_text("\n".join(lines), encoding='utf-8')
+    except (IOError, OSError) as e:
+        print(f"[PreCompact] Failed to write STATE.md: {e}", file=sys.stderr)
+
+
 def main():
     # Read hook input
     try:
@@ -122,15 +180,20 @@ def main():
             f"Read {learnings_loc} for session context and recent progress."
         )
 
-    # Output additionalContext to be included in compaction summary
+    # PreCompact does NOT support hookSpecificOutput.additionalContext -- the harness
+    # rejects the whole payload ("Hook JSON output validation failed"), silently dropping
+    # the reload instruction. Per https://code.claude.com/docs/en/hooks.md PreCompact only
+    # accepts top-level `decision`/`reason` plus universal fields (systemMessage, continue,
+    # suppressOutput, stopReason, terminalSequence).
+    #
+    # So PERSIST the state to .planning/STATE.md instead. SessionStart surfaces .planning/
+    # on the next session, and subagent-start.py reads STATE.md to brief spawned agents.
     if reload_instructions:
-        result = {
-            "hookSpecificOutput": {
-                "hookEventName": "PreCompact",
-                "additionalContext": "\n".join(reload_instructions)
-            }
-        }
-        print(json.dumps(result))
+        write_state_file(active_workflow, reload_instructions)
+        print(json.dumps({
+            "systemMessage": f"Workflow state saved to .planning/STATE.md"
+                             + (f" (/{active_workflow} active)" if active_workflow else "")
+        }))
 
     sys.exit(0)
 

--- a/hooks/subagent-start.py
+++ b/hooks/subagent-start.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env -S uv run python3
+"""
+SubagentStart hook: brief every spawned subagent with the project's domain knowledge.
+
+WHY THIS EXISTS
+    Domain references (e.g. wrds/references/taq.md) are globbed ONCE by ds-plan Step 5b
+    while drafting the plan. Nothing re-reads them during implementation, so a subagent
+    spawned to write code starts with no idea that verified, project-specific facts exist
+    -- and re-derives (or contradicts) them. Observed 2026-07-21: a TAQ pipeline was
+    rebuilt from scratch when taq.md already documented the correct pattern WITH
+    benchmarks, and a reference file's own validation numbers were treated as ground
+    truth when they were provisional.
+
+    SubagentStart is one of the events that DOES support
+    hookSpecificOutput.additionalContext (unlike PreCompact), so it is the right place
+    to re-assert this. See https://code.claude.com/docs/en/hooks.md
+
+WHAT IT INJECTS
+    - the active workflow + phase, from .planning/STATE.md
+    - the domain skills listed in SPEC.md/PLAN.md, with their references/ paths
+    - a hard instruction to READ them before writing code in that domain
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SKILLS_ROOT = Path.home() / 'projects' / 'workflows' / 'skills'
+
+
+def read(p: Path) -> str:
+    try:
+        return p.read_text(encoding='utf-8')
+    except (IOError, OSError):
+        return ''
+
+
+def domain_skills() -> list[str]:
+    """Skill names listed in .planning/SPEC.md or PLAN.md (the 'Skills Touched' section)."""
+    skills: list[str] = []
+    for name in ('STATE.md', 'SPEC.md', 'PLAN.md'):
+        text = read(Path.cwd() / '.planning' / name)
+        for m in re.finditer(r'^\s*[-*]\s+`([a-z0-9][a-z0-9:_-]*)`\s*[-—]', text, re.M):
+            s = m.group(1)
+            if s not in skills:
+                skills.append(s)
+    return skills
+
+
+def reference_files(skill: str) -> list[str]:
+    d = SKILLS_ROOT / skill / 'references'
+    if not d.is_dir():
+        return []
+    return sorted(p.name for p in d.glob('*.md'))
+
+
+def active_workflow() -> str | None:
+    m = re.search(r'^## Active workflow:\s*/?(\S+)', read(Path.cwd() / '.planning' / 'STATE.md'), re.M)
+    if m and m.group(1).upper() != 'UNKNOWN':
+        return m.group(1).lstrip('/')
+    return None
+
+
+def main():
+    try:
+        json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    if not (Path.cwd() / '.planning').is_dir():
+        sys.exit(0)
+
+    parts: list[str] = []
+
+    wf = active_workflow()
+    if wf:
+        parts.append(
+            f"ACTIVE WORKFLOW: /{wf}. This task is part of that workflow -- follow its "
+            f"conventions, and read .planning/STATE.md, SPEC.md and PLAN.md for the "
+            f"current phase, constraints and decisions already made."
+        )
+
+    skills = domain_skills()
+    if skills:
+        lines = [
+            "DOMAIN KNOWLEDGE -- READ BEFORE WRITING ANY CODE IN THESE AREAS.",
+            "",
+            "These reference files contain VERIFIED, project-specific facts (data-model",
+            "gotchas, validated patterns, measured benchmarks) that SUPERSEDE your training",
+            "data. They are frequently updated. Re-derived answers have repeatedly been wrong",
+            "or slower than the documented pattern. Read the relevant file FIRST, and treat",
+            "numbers in them as provisional if they are the project's own (not published)",
+            "results.",
+            "",
+        ]
+        for s in skills:
+            refs = reference_files(s)
+            base = SKILLS_ROOT / s / 'references'
+            if refs:
+                lines.append(f"- `{s}` -> {base}/")
+                lines.append(f"    {', '.join(refs)}")
+            else:
+                lines.append(f"- `{s}` (skill: {SKILLS_ROOT / s})")
+        parts.append("\n".join(lines))
+
+    if not parts:
+        sys.exit(0)
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SubagentStart",
+            "additionalContext": "\n\n".join(parts),
+        }
+    }))
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/hooks/suggest-compact.py
+++ b/hooks/suggest-compact.py
@@ -76,10 +76,15 @@ def main():
         message = f"[StrategicCompact] {count} edits - good checkpoint for /compact if context is stale"
 
     if message:
-        # Output as additionalContext to inform Claude
+        # hookEventName MUST match the event this hook was actually invoked on, or the
+        # harness rejects the payload and the suggestion is dropped. This hook is wired
+        # to PreToolUse (hooks/hooks.json) AND to PostToolUse (skills/workshop,
+        # skills/workshop-revise), so hardcoding "PreToolUse" silently broke it under
+        # the workshop wiring. Read the event from the payload instead.
+        event = hook_input.get('hook_event_name') or 'PreToolUse'
         result = {
             "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
+                "hookEventName": event,
                 "additionalContext": message
             }
         }

--- a/hooks/writing-claim-id-guard.py
+++ b/hooks/writing-claim-id-guard.py
@@ -15,10 +15,18 @@ risk flagged in DESIGN D-w-3):
 Only enforced inside a writing PROJECT (a .planning/ dir present).
 """
 import json
-import os
 import re
 import sys
 from pathlib import Path
+
+# Hooks read their payload from STDIN -- CLAUDE_TOOL_INPUT does not exist -- and there
+# is no {"result": ...} field in the hook contract. This hook used both, so it saw an
+# empty tool_input on every call and its output was rejected wholesale. Warnings go
+# through hookSpecificOutput.additionalContext; a hard stop on PostToolUse is
+# top-level decision:"block" + reason.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import context  # noqa: E402
 
 CLAIM_PATTERN = re.compile(r'CLAIM-\d+')
 
@@ -28,17 +36,18 @@ def _in_writing_project(p: Path) -> bool:
 
 
 def main():
-    tool_input_str = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
     try:
-        tool_input = json.loads(tool_input_str)
-    except json.JSONDecodeError:
-        print(json.dumps({"result": "continue"}))
-        return
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
 
+    if hook_input.get('tool_name', '') not in ('Write', 'Edit', 'MultiEdit'):
+        sys.exit(0)
+
+    tool_input = hook_input.get('tool_input', {}) or {}
     file_path = tool_input.get('file_path', '')
     if not file_path:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     p = Path(file_path)
     parts = p.parts
@@ -48,26 +57,22 @@ def main():
     is_draft = 'drafts' in parts
 
     if not (is_outline or is_draft):
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Check if the file exists and contains CLAIM-XX references
     if not p.exists():
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     try:
         content = p.read_text()
     except Exception:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     claims = CLAIM_PATTERN.findall(content)
     artifact_type = "outline" if is_outline else "draft"
 
     if claims:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     remedy = (
         f"No CLAIM-XX IDs found in {artifact_type} file: {file_path}\n"
@@ -89,7 +94,7 @@ def main():
         return
 
     # Outlines (or non-project files) → warn only; the outline-executable guard hard-gates at approval.
-    print(json.dumps({"result": "continue", "message": remedy}))
+    context('PostToolUse', remedy)
 
 
 if __name__ == '__main__':

--- a/hooks/writing-outline-guard.py
+++ b/hooks/writing-outline-guard.py
@@ -7,9 +7,12 @@ without a matching outline — the Iron Law in the prompt handles hard enforceme
 """
 
 import json
-import os
 import sys
 from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import deny  # noqa: E402
 
 
 def main():
@@ -63,16 +66,19 @@ def main():
     if outline_found:
         sys.exit(0)  # Outline exists, allow
 
-    # Hard block — NO PROSE WITHOUT OUTLINE (Iron Law enforcement)
-    error = (
+    # Hard block — NO PROSE WITHOUT OUTLINE (Iron Law enforcement).
+    #
+    # This used to be `print(..., file=sys.stderr); sys.exit(1)`, which does NOT block:
+    # on PreToolUse only exit code 2 blocks the tool call, and every other non-zero code
+    # is a "non-blocking error". The Write went through and the message never reached
+    # Claude. The contract-correct hard stop is permissionDecision "deny".
+    deny(
         f"BLOCKED: No outline found for this draft.\n\n"
         f"Writing to `{file_path}` but no matching outline in `{outlines_dir}/`.\n"
         f"Expected: `{outlines_dir}/{section_name}.md`\n\n"
         f"Create the outline first. Prose without structure produces wandering drafts "
         f"that require full rewrites — that's anti-helpful, not efficient."
     )
-    print(error, file=sys.stderr)
-    sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/hooks/writing-precis-guard.py
+++ b/hooks/writing-precis-guard.py
@@ -6,10 +6,18 @@ Fires after Write to .planning/PRECIS.md. Checks that all required sections
 (Thesis, Key Claims with CLAIM-XX IDs, Audience, Scope) are present.
 """
 import json
-import os
 import re
 import sys
 from pathlib import Path
+
+# Hooks receive their payload as JSON on STDIN -- there is no CLAUDE_TOOL_INPUT env
+# var, and there is no {"result": "continue"} in the hook contract. This hook used
+# both, so it read an empty input on every call and then emitted a payload the harness
+# rejected outright. Non-blocking feedback on PostToolUse goes through
+# hookSpecificOutput.additionalContext; saying nothing is how a hook says "carry on".
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import context  # noqa: E402
 
 REQUIRED_SECTIONS = {
     'thesis': re.compile(r'(?:^|\n)#+\s*thesis|(?:^|\n)\*\*thesis', re.IGNORECASE),
@@ -19,33 +27,31 @@ REQUIRED_SECTIONS = {
 
 
 def main():
-    tool_input_str = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
     try:
-        tool_input = json.loads(tool_input_str)
-    except json.JSONDecodeError:
-        print(json.dumps({"result": "continue"}))
-        return
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
 
+    if hook_input.get('tool_name', '') not in ('Write', 'Edit', 'MultiEdit'):
+        sys.exit(0)
+
+    tool_input = hook_input.get('tool_input', {}) or {}
     file_path = tool_input.get('file_path', '')
     if not file_path:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Only check PRECIS.md writes
     p = Path(file_path)
     if p.name != 'PRECIS.md' or '.planning' not in str(p):
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     if not p.exists():
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     try:
         content = p.read_text()
     except Exception:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     missing = []
     for section, pattern in REQUIRED_SECTIONS.items():
@@ -53,17 +59,13 @@ def main():
             missing.append(section)
 
     if missing:
-        print(json.dumps({
-            "result": "continue",
-            "message": (
-                f"PRECIS.md is missing required sections: {', '.join(missing)}\n"
-                f"A complete PRECIS needs: Thesis (main argument), "
-                f"Key Claims (with CLAIM-XX IDs), and Audience.\n"
-                f"Add the missing sections before proceeding to outline."
-            )
-        }))
-    else:
-        print(json.dumps({"result": "continue"}))
+        context('PostToolUse', (
+            f"PRECIS.md is missing required sections: {', '.join(missing)}\n"
+            f"A complete PRECIS needs: Thesis (main argument), "
+            f"Key Claims (with CLAIM-XX IDs), and Audience.\n"
+            f"Add the missing sections before proceeding to outline."
+        ))
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/hooks/writing-suggest-verify.py
+++ b/hooks/writing-suggest-verify.py
@@ -6,10 +6,20 @@ Only fires for Edit/Write on .md files when an active writing workflow exists.
 Tracks edit count in ACTIVE_WORKFLOW.md and suggests edit loop at threshold.
 """
 import json
-import os
 import re
 import sys
 from pathlib import Path
+
+# Hooks read their payload from STDIN -- CLAUDE_TOOL_INPUT does not exist -- and
+# {"result": "continue"} is not part of the hook contract. This hook used both, so it
+# saw an empty file_path on EVERY Edit/Write, took the early-return branch, and then
+# emitted a payload the harness rejected outright ("Hook JSON output validation
+# failed"). Net effect: the verify-nudge never fired and the edit counter never moved.
+# Non-blocking feedback on PostToolUse is hookSpecificOutput.additionalContext;
+# printing nothing is how a hook says "carry on".
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import context  # noqa: E402
 
 
 def parse_yaml_value(content: str, key: str, default=None):
@@ -40,37 +50,35 @@ def update_yaml_value(content: str, key: str, new_value) -> str:
 
 
 def main():
-    # Read tool input
-    tool_input_str = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
     try:
-        tool_input = json.loads(tool_input_str)
-    except json.JSONDecodeError:
-        tool_input = {}
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
 
+    if hook_input.get('tool_name', '') not in ('Write', 'Edit', 'MultiEdit'):
+        sys.exit(0)
+
+    tool_input = hook_input.get('tool_input', {}) or {}
     file_path = tool_input.get('file_path', '')
 
     # Only process markdown files
     if not file_path.endswith('.md'):
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Check for active writing workflow
     workflow_path = Path.cwd() / '.planning' / 'ACTIVE_WORKFLOW.md'
     if not workflow_path.exists():
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     try:
         content = workflow_path.read_text()
     except Exception:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Check if this is a writing workflow
     workflow_type = parse_yaml_value(content, 'workflow')
     if workflow_type != 'writing':
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Get current edit count and threshold
     edits = int(parse_yaml_value(content, 'edits_since_verify', '0'))
@@ -87,15 +95,16 @@ def main():
         style = parse_yaml_value(content, 'style', 'general')
         phase = parse_yaml_value(content, 'phase', 'edit')
 
-        print(json.dumps({
-            "result": "continue",
-            "message": f"📝 {edits} edits since last verify (style: {style}, phase: {phase}). Consider `/writing-revise` to apply fixes and polish."
-        }))
+        context(
+            'PostToolUse',
+            f"📝 {edits} edits since last verify (style: {style}, phase: {phase}). "
+            f"Consider `/writing-revise` to apply fixes and polish."
+        )
     else:
         # Just increment counter
         new_content = update_yaml_value(content, 'edits_since_verify', str(edits))
         workflow_path.write_text(new_content)
-        print(json.dumps({"result": "continue"}))
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/references/codex-availability.md
+++ b/references/codex-availability.md
@@ -75,13 +75,81 @@ Codex when present, not to onboard it.
 
 ## Invoke adversarial review
 
-```bash
-# Foreground (small diffs, < ~3 files)
-node "$CODEX_SCRIPT" adversarial-review --wait
+Always `--json`, always redirected to a file:
 
-# Background (anything bigger or unclear)
-node "$CODEX_SCRIPT" adversarial-review --background
+```bash
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
+
+The handle is **per-iteration** and is `rm -f`'d before the state records
+`requested`. A single reused path can be joined while it still holds the
+*previous* pass's verdict — the redirect only truncates it at launch, so a stop
+between the state write and the invocation leaves last iteration's `approve`
+sitting there to be parsed as this one's answer.
+
+**`--json` is not optional.** It is the only form carrying `confidence`; the
+rendered text prints `[high]` with no number, so the >= 0.8 iron law below has
+nothing to read without it.
+
+**The redirect is not optional either.** It is what makes a detached run
+joinable: the file is the handle, and it survives an interruption that a
+terminal buffer or transcript does not.
+
+**Background is the harness's job, not the companion's.** `--background` is a
+no-op for reviews — `adversarial-review` always runs in the foreground (only the
+`task` subcommand enqueues a tracked job), so nothing is holding a result for a
+later `/codex:status` fetch. To detach, run the SAME `--wait --json` command
+through `Bash(..., run_in_background: true)` and join via the file.
+
+### The join (this step is mandatory)
+
+A launch is not a verdict. Clear the per-iteration handle **and verify the clear
+worked**, record `codex_second_pass: requested` + `codex_output_file:` (the exact
+path), invoke, then join by resolving that recorded path — never a hardcoded one:
+
+```bash
+OUT=.planning/codex-second-pass-iter[N].json
+rm -f "$OUT"
+[ -e "$OUT" ] && { echo "BLOCKED: cannot clear $OUT"; exit 1; }
+```
+
+`rm -f` is quiet both when the file never existed and when it could not be
+removed, and nothing checks its exit status by default. A silently-failed clear
+means the launch redirect fails too and the previous envelope survives to be
+joined as this pass's answer — so successful invalidation is a *precondition* for
+recording `requested`, not a hope. If it fails, record `error` / `status:
+BLOCKED` instead.
+
+```bash
+uv run python3 - <<'PY'
+import json, pathlib
+import re
+state = pathlib.Path('.planning/REVIEW_STATE.md')
+m = re.search(r'^codex_output_file:\s*(\S+)\s*$', state.read_text(), re.M) if state.exists() else None
+if not m:
+    print('ERROR: no codex_output_file recorded'); raise SystemExit(0)
+p = pathlib.Path(m.group(1))          # the handle THIS pass owns
+if not p.exists() or not p.stat().st_size:
+    print('PENDING'); raise SystemExit(0)
+try:
+    envelope = json.loads(p.read_text())
+    if envelope.get('codex', {}).get('status') != 0:
+        print('ERROR: exit', envelope.get('codex', {}).get('status')); raise SystemExit(0)
+    v = json.loads(envelope['codex']['stdout'])
+except Exception as e:
+    print('ERROR:', e); raise SystemExit(0)
+print(v['verdict'], [(f['confidence'], f['title']) for f in v.get('findings', [])])
+PY
+```
+
+The payload is an envelope — `{review, target, threadId, codex: {status, stdout}}`
+— and `codex.stdout` is the schema-validated verdict **as a JSON string**, so it
+takes a second parse. Only after a verdict is parsed may the skill move
+`SECOND_PASS_PENDING` to a terminal state, in ONE write.
+
+`PENDING` on a resumed session means the run never finished: relaunch. The gate
+stays shut throughout, because `requested` does not admit verify.
 
 Scope flags mirror `/codex:adversarial-review`:
 
@@ -172,8 +240,11 @@ use Codex when present, not to onboard it.
 `phase-gate-guard.py` gate with:
 
 ```
-GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable
+GATE_REQUIRE_FIELDS="codex_second_pass:completed|declined|unavailable"
 ```
+
+(The quotes are load-bearing: unquoted, bash reads `|` as a pipe, the env var
+never reaches the hook, and the gate silently allows everything.)
 
 so Agent dispatch in the verify phase is blocked until `.planning/REVIEW_STATE.md`
 records one of those three values. This puts the second pass on the top tier of
@@ -197,14 +268,22 @@ template is not a recorded decision.
 
 The consuming skill records what happened in `.planning/REVIEW_STATE.md`:
 
-| `codex_second_pass:` | Meaning |
-|----------------------|---------|
-| `enabled` | Codex ran and returned a verdict |
-| `declined` | Offered; user chose to approve without it |
-| `unavailable` | No script, probe not ready, or no git repo |
-| `error` | Codex ran but failed (non-zero exit / unparseable output) |
+| `codex_second_pass:` | Meaning | Admits verify? |
+|----------------------|---------|----------------|
+| `requested` | Launched; no verdict parsed yet | **No** — a launch is not an answer |
+| `completed` | Codex ran and returned a verdict | Yes |
+| `declined` | Offered; user chose to approve without it | Yes |
+| `unavailable` | No script, probe not ready, or no git repo | Yes |
+| `error` | Codex ran but failed (non-zero exit / unparseable output) | **No** |
 
-Three rules keep this field honest:
+Four rules keep this field honest:
+
+- **A launch is not a verdict.** Record `requested` when you invoke Codex, and
+  only `completed` once you have parsed its output. Writing the terminal value
+  up front is the bug that makes the whole gate ornamental: combined with a
+  `status: APPROVED` left over from an earlier task, it opens verify while Codex
+  is still running — or after it crashed. Write a non-approved `status` BEFORE
+  invoking, so the window never exists.
 
 - **Never write `enabled` unless a Codex run actually returned a verdict.** The
   field's whole purpose is to distinguish "Codex approved this" from "Codex

--- a/references/codex-availability.md
+++ b/references/codex-availability.md
@@ -1,7 +1,40 @@
-# Codex Availability Probe & Adversarial Review Invocation
+# Codex Availability Probe & Second-Pass Review Invocation
 
-Shared reference for skills that delegate adversarial review to the Codex plugin
-when available, with graceful fallback to in-process Claude reviewers.
+Shared reference for review skills that run an optional **Codex second pass** —
+an independent adversarial review that runs *after* the primary Claude reviewer
+approves, and *before* the phase writes its APPROVED verdict.
+
+Consumed by `skills/dev-review/SKILL.md` and `skills/ds-review/SKILL.md`.
+
+## The second pass is additive, never a substitute
+
+Codex does not replace the Claude reviewer. A Codex-instead-of-Claude review
+leaves the diff reviewed exactly once, which is the single-reviewer blind spot
+the second pass exists to close. The order is fixed:
+
+```
+primary Claude review (single | parallel)
+        │
+        ├── CHANGES_REQUIRED / ESCALATE / BLOCKED → fix loop (no second pass)
+        │
+        └── APPROVED (candidate verdict)
+                 │
+                 └── Codex second pass  ← optional, opt-in, this reference
+                          │
+                          ├── approve → write status: APPROVED → verify phase
+                          └── needs-attention (≥0.8) → CHANGES_REQUIRED → fix loop
+```
+
+**Why a different model family:** this is `skills/audit-fix-loop/SKILL.md` Iron
+Law 1 — "the auditor must not be the fixer" — applied to the model itself. A
+Claude reviewer auditing Claude's code shares its training and therefore its
+blind spots. Codex runs out-of-process on a different model family, so its
+misses are uncorrelated. Two reviewers that fail the same way are one reviewer.
+
+**Where it sits relative to the gate:** `.planning/REVIEW_STATE.md`'s
+`status: APPROVED` is the structural gate that dev-verify / ds-verify hook on.
+The second pass therefore runs BEFORE that line is written. A second pass that
+ran after the gate was already open would be decorative.
 
 ## Locate the Codex companion script
 
@@ -89,16 +122,24 @@ The companion emits a structured payload validated against
 | `findings[]` | Each has `severity`, `title`, `body`, `file`, `line_start`, `line_end`, `confidence` (0-1), `recommendation` |
 | `next_steps[]` | Suggested follow-ups                               |
 
-### Mapping to dev-review verdicts
+### Mapping to review verdicts
+
+Identical in dev-review and ds-review; the implement/verify phase names differ.
 
 | Codex verdict     | Map to               | Notes                                                                          |
 |-------------------|----------------------|--------------------------------------------------------------------------------|
-| `approve`         | `APPROVED`           | Proceed to dev-verify                                                          |
-| `needs-attention` with any finding `confidence >= 0.8` | `CHANGES_REQUIRED` | Forward findings to dev-implement                       |
-| `needs-attention` with all findings `confidence < 0.8` | `APPROVED` (with note) | Below the dev-review iron-law threshold — log findings to LEARNINGS.md as advisory |
+| `approve`         | `APPROVED`           | Write `status: APPROVED`, proceed to the verify phase                          |
+| `needs-attention` with any finding `confidence >= 0.8` | `CHANGES_REQUIRED` | Forward findings to the implement phase             |
+| `needs-attention` with all findings `confidence < 0.8` | `APPROVED` (with note) | Below the iron-law threshold — log findings to LEARNINGS.md as advisory |
 
 This preserves the **iron law of review**: only issues with confidence ≥ 80
 block. Codex reports confidence as 0-1 floats; multiply by 100 when displaying.
+
+**A Codex `CHANGES_REQUIRED` overrides the primary reviewer's APPROVED.** The
+primary does not get a veto over the second pass — if it did, the second pass
+would be decorative. This is the one place a later reviewer outranks an earlier
+one, and it is deliberate: the second pass exists precisely to catch what the
+primary missed.
 
 ### Trace findings to requirements
 
@@ -109,20 +150,58 @@ receiving the JSON, the calling skill is responsible for:
 2. Tagging each finding with the most likely REQ-ID (or `OUT-OF-SPEC`)
 3. Treating `OUT-OF-SPEC` findings as advisory unless the user opts in
 
-## Fallback Decision Tree
+## Availability Decision Tree
+
+The primary Claude review has already run and approved at this point — so an
+unavailable Codex means "no second opinion," never "no review."
 
 ```
 Codex script located?
-├── No  → Fallback: Single or Parallel Claude reviewer (existing flow)
+├── No  → record codex_second_pass: unavailable → write status: APPROVED (silently)
 └── Yes → Probe `setup --json`
-          ├── ready: false → Fallback (silently)
-          └── ready: true  → Offer Codex adversarial as RECOMMENDED option
-                              (user can still pick Claude path if preferred)
+          ├── ready: false → same as above (silently)
+          └── ready: true  → ask the user once (opt-in), then run or record `declined`
 ```
+
+Never prompt the user to install or authenticate Codex. The skill's job is to
+use Codex when present, not to onboard it.
+
+## Recording the outcome
+
+The consuming skill records what happened in `.planning/REVIEW_STATE.md`:
+
+| `codex_second_pass:` | Meaning |
+|----------------------|---------|
+| `enabled` | Codex ran and returned a verdict |
+| `declined` | Offered; user chose to approve without it |
+| `unavailable` | No script, probe not ready, or no git repo |
+| `error` | Codex ran but failed (non-zero exit / unparseable output) |
+
+Three rules keep this field honest:
+
+- **Never write `enabled` unless a Codex run actually returned a verdict.** The
+  field's whole purpose is to distinguish "Codex approved this" from "Codex
+  never ran"; a fabricated `enabled` makes the record worse than absent.
+- **`error` is not an approval.** An unrun reviewer is not a passing reviewer.
+  `error` is an absence of evidence — neither approval nor rejection — so it is
+  **not a legal value under `status: APPROVED`**. Only `enabled`, `declined`,
+  and `unavailable` are. An `error` sets `status: BLOCKED` and asks the user to
+  retry or explicitly decline; only that decision reopens the path forward.
+- **`unavailable` and `error` are different facts.** `unavailable` means Codex
+  was never reachable (not installed, probe not ready, no git repo) and is
+  benign — the primary review stands. `error` means Codex was reached and
+  failed, which is a broken reviewer, not an absent one. Collapsing the two
+  hides failures behind a silent skip.
 
 ## Iteration tracking
 
-Codex adversarial review participates in the same `REVIEW_STATE.md` loop as
-Claude reviewers — increment iteration on `CHANGES_REQUIRED`, escalate at
-iteration 3. Re-runs go through Codex again (not a swap to Claude mid-loop)
-unless Codex becomes unavailable between runs.
+The second pass participates in the same `REVIEW_STATE.md` loop as Claude
+reviewers — increment iteration on `CHANGES_REQUIRED`, escalate at iteration 3.
+
+**Decide once per loop, not once per iteration.** The opt-in answer is stored in
+`codex_second_pass:` and honored on subsequent iterations without re-asking;
+only `unavailable` is re-probed (Codex may have been installed since). Asking on
+every fix iteration turns an opt-in into nagging.
+
+On each iteration the full order repeats: primary review first, second pass only
+if the primary approves.

--- a/references/codex-availability.md
+++ b/references/codex-availability.md
@@ -168,6 +168,33 @@ use Codex when present, not to onboard it.
 
 ## Recording the outcome
 
+**This field is hook-enforced.** `dev-verify` / `ds-verify` declare a PreToolUse
+`phase-gate-guard.py` gate with:
+
+```
+GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable
+```
+
+so Agent dispatch in the verify phase is blocked until `.planning/REVIEW_STATE.md`
+records one of those three values. This puts the second pass on the top tier of
+PHILOSOPHY's enforcement gradient (`hook-enforced > artifact check > advisory
+text`) — the review skill's prose can be compacted away or rationalized past, but
+the hook fires on every tool call.
+
+What the hook can and cannot prove:
+
+- **It can prove a disposition was recorded** rather than silently skipped.
+- **It cannot prove Codex ran** — `declined` and `unavailable` are legal, because
+  the second pass is opt-in and Codex is optional. That is the intended ceiling:
+  the gate enforces *honesty about what happened*, not *that Codex was used*.
+- **`error` is excluded from the allowed set**, so an errored second pass
+  structurally cannot reach verify. That is the "error is not an approval" rule,
+  enforced rather than narrated.
+
+Write **one** value, never the `a | b | c` template line — a literal placeholder
+matches no allowed value and the gate blocks it, which is the point: a pasted
+template is not a recorded decision.
+
 The consuming skill records what happened in `.planning/REVIEW_STATE.md`:
 
 | `codex_second_pass:` | Meaning |

--- a/references/enforcement-checklist.md
+++ b/references/enforcement-checklist.md
@@ -110,6 +110,23 @@ Before proceeding to [next phase]:
 
 **Key insight:** Gates must be *programmatically verifiable*. "Quality is sufficient" is not a gate. "File X contains string Y" is a gate.
 
+**If the gate is a HOOK, its OUTPUT must be valid for its event — or it is not a gate at all.**
+A hook that emits a field its event does not accept has its **entire** payload rejected by the
+harness (`Hook JSON output validation failed — (root): Invalid input`). It still runs, still
+exits 0, prints nothing anyone sees, and its `deny` silently becomes an allow. Checking that the
+hook exists, that its `command:` resolves, and that its `matcher` covers the step does **not**
+catch this — all three pass on a hook that enforces nothing.
+
+The three that keep recurring:
+- top-level `decision` on `PreToolUse` (gates use `hookSpecificOutput.permissionDecision`)
+- `hookSpecificOutput` on `PreCompact` / `SessionEnd` / `Notification`, which accept none
+- `decision: "allow"` or an invented `{"result": "continue"}` / `"message"` — no event has these
+
+Validate by EXECUTION, never by reading: `./scripts/check-hooks.sh` runs every wiring (from
+`hooks/hooks.json` **and** every skill's `hooks:` frontmatter) against the per-event schema. See
+workflow-creator Mode 2 **Step 3c**. Reading the hook is not enough — the invalid branch is
+usually the *block* branch, which only a real payload reaches.
+
 ---
 
 ### 5. Flowcharts as Spec

--- a/scripts/check-hooks.sh
+++ b/scripts/check-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Validate every wired hook's output against the per-event schema from
+# https://code.claude.com/docs/en/hooks.md
+#
+#   ./scripts/check-hooks.sh            # pytest: one case per wiring, fails loudly
+#   ./scripts/check-hooks.sh --report   # human table: script | event | matcher | verdict
+#
+# An invalid hook payload is rejected wholesale by the harness ("Hook JSON output
+# validation failed — (root): Invalid input") without raising, warning, or exiting
+# non-zero. Nothing else in this repo notices. This does.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ "${1:-}" = "--report" ]; then
+    exec uv run --with pyyaml python3 tests/hook_output_schema_test.py
+fi
+
+exec uv run --with pytest --with pyyaml python3 -m pytest \
+    tests/hook_output_schema_test.py "${@}"

--- a/scripts/checks/hook_output_schema.py
+++ b/scripts/checks/hook_output_schema.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Per-event output schema for Claude Code hooks, plus a validator.
+
+WHY THIS EXISTS
+    A hook that emits a field the harness does not recognise for its event gets its
+    ENTIRE payload rejected -- "Hook JSON output validation failed -- (root): Invalid
+    input" -- and whatever it was trying to say is silently dropped. Nothing fails
+    loudly, so a broken hook can sit in production indefinitely. That is exactly what
+    happened to hooks/pre-compact.py, which emitted
+    hookSpecificOutput.additionalContext on PreCompact (an event that does not accept
+    it), so the "reload the active workflow after compaction" instruction never
+    reached Claude and the workflow Iron Laws stopped being enforced after every
+    compaction.
+
+SOURCE OF TRUTH
+    https://code.claude.com/docs/en/hooks.md -- transcribed 2026-07-21. When the docs
+    change, update EVENTS here and the harness (tests/hook_output_schema_test.py)
+    picks it up.
+"""
+
+from __future__ import annotations
+
+# Fields accepted on EVERY event.
+UNIVERSAL_FIELDS = {
+    'continue',
+    'stopReason',
+    'suppressOutput',
+    'systemMessage',
+    'terminalSequence',
+}
+
+
+class Event:
+    __slots__ = ('top', 'hso', 'decision', 'stdout_is_context')
+
+    def __init__(self, top=(), hso=None, decision=(), stdout_is_context=False):
+        # Extra top-level fields beyond UNIVERSAL_FIELDS.
+        self.top = frozenset(top)
+        # None => hookSpecificOutput is NOT supported for this event.
+        self.hso = None if hso is None else frozenset(hso)
+        # Allowed values for a top-level "decision". Empty => decision unsupported.
+        self.decision = frozenset(decision)
+        self.stdout_is_context = stdout_is_context
+
+
+EVENTS: dict[str, Event] = {
+    'SessionStart': Event(
+        top={'additionalContext', 'initialUserMessage', 'sessionTitle', 'watchPaths', 'reloadSkills'},
+        hso={'additionalContext', 'watchPaths', 'reloadSkills'},
+        stdout_is_context=True,
+    ),
+    'Setup': Event(
+        top={'additionalContext'},
+        hso={'additionalContext'},
+        stdout_is_context=True,
+    ),
+    'UserPromptSubmit': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'UserPromptExpansion': Event(
+        top={'decision', 'reason'},
+        hso=None,
+        decision={'block'},
+    ),
+    'PreToolUse': Event(
+        top=set(),
+        hso={'permissionDecision', 'permissionDecisionReason', 'updatedInput', 'additionalContext'},
+        decision=set(),  # PreToolUse uses hookSpecificOutput.permissionDecision, NOT decision
+    ),
+    'PostToolUse': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'updatedToolOutput', 'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'PostToolUseFailure': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'PostToolBatch': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'Stop': Event(
+        top={'decision', 'reason'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'SubagentStop': Event(
+        top={'decision', 'reason'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'SubagentStart': Event(
+        top={'additionalContext'},
+        hso={'additionalContext'},
+        stdout_is_context=True,
+    ),
+    'PreCompact': Event(
+        top={'decision', 'reason'},
+        hso=None,  # <- the pre-compact.py bug: hookSpecificOutput is NOT accepted here
+        decision={'block'},
+    ),
+    'PostCompact': Event(hso=None),
+    'SessionEnd': Event(hso=None),
+    'Notification': Event(hso=None),
+    'PermissionRequest': Event(hso={'decision'}),
+    'PermissionDenied': Event(hso={'retry'}),
+}
+
+# permissionDecision values, PreToolUse only.
+PERMISSION_DECISIONS = frozenset({'allow', 'deny', 'ask', 'defer'})
+
+
+def validate_payload(event: str, payload: dict) -> list[str]:
+    """Return a list of schema violations for `payload` emitted on `event`.
+
+    Empty list == valid. Mirrors the harness-side check whose failure produces
+    "Hook JSON output validation failed -- (root): Invalid input".
+    """
+    if event not in EVENTS:
+        return [f'unknown hook event {event!r}']
+    spec = EVENTS[event]
+    errors: list[str] = []
+
+    if not isinstance(payload, dict):
+        return [f'top-level output must be a JSON object, got {type(payload).__name__}']
+
+    allowed_top = UNIVERSAL_FIELDS | spec.top | {'hookSpecificOutput'}
+    for key in payload:
+        if key == 'hookSpecificOutput':
+            continue
+        if key not in allowed_top:
+            errors.append(
+                f'unsupported top-level field {key!r} on {event} '
+                f'(allowed: {", ".join(sorted(allowed_top))})'
+            )
+
+    if 'decision' in payload:
+        if not spec.decision:
+            hint = (
+                ' — PreToolUse uses hookSpecificOutput.permissionDecision'
+                if event == 'PreToolUse' else ''
+            )
+            errors.append(f'{event} does not support a top-level "decision" field{hint}')
+        elif payload['decision'] not in spec.decision:
+            errors.append(
+                f'decision={payload["decision"]!r} not allowed on {event} '
+                f'(allowed: {", ".join(sorted(spec.decision))})'
+            )
+
+    if 'hookSpecificOutput' in payload:
+        hso = payload['hookSpecificOutput']
+        if spec.hso is None:
+            errors.append(
+                f'{event} does not support hookSpecificOutput at all '
+                f'(this rejects the WHOLE payload — the pre-compact.py bug)'
+            )
+        elif not isinstance(hso, dict):
+            errors.append('hookSpecificOutput must be a JSON object')
+        else:
+            name = hso.get('hookEventName')
+            if name is None:
+                errors.append('hookSpecificOutput is missing hookEventName')
+            elif name != event:
+                errors.append(
+                    f'hookSpecificOutput.hookEventName={name!r} but the hook is wired to {event}'
+                )
+            for key in hso:
+                if key == 'hookEventName':
+                    continue
+                if key not in spec.hso:
+                    errors.append(
+                        f'unsupported hookSpecificOutput field {key!r} on {event} '
+                        f'(allowed: {", ".join(sorted(spec.hso))})'
+                    )
+            pd = hso.get('permissionDecision')
+            if pd is not None and pd not in PERMISSION_DECISIONS:
+                errors.append(
+                    f'permissionDecision={pd!r} invalid '
+                    f'(allowed: {", ".join(sorted(PERMISSION_DECISIONS))})'
+                )
+
+    return errors

--- a/skills/dev-review/SKILL.md
+++ b/skills/dev-review/SKILL.md
@@ -50,9 +50,9 @@ If the message could be EITHER a new topic OR part of the review, ask before ass
 ## Contents
 
 - [Prerequisites - Test Output Gate](#prerequisites---test-output-gate)
-- [Review Strategy Choice](#review-strategy-choice)
-- [Codex Adversarial Review](#codex-adversarial-review) (default when Codex is installed)
-- [Parallel Review (Thorough)](#parallel-review-thorough) (Claude-only fallback)
+- [Review Strategy Choice](#review-strategy-choice) (picks the primary reviewer)
+- [Codex Second Pass](#codex-second-pass) (optional second opinion before any APPROVED verdict)
+- [Parallel Review (Thorough)](#parallel-review-thorough)
 - [The Iron Law of Review](#the-iron-law-of-review) (single Claude reviewer path)
 - [Review Focus Areas](#review-focus-areas)
 - [Confidence Scoring](#confidence-scoring)
@@ -132,7 +132,14 @@ If no test output is found, STOP and return to /dev-implement.
 
 ## Review Strategy Choice
 
-After verifying test output in LEARNINGS.md, choose review strategy.
+After verifying test output in LEARNINGS.md, choose the **primary reviewer**.
+
+This choice picks who reviews FIRST. It is not a choice about whether Codex
+runs — Codex is a *second pass* over whatever the primary reviewer approves
+(see [Codex Second Pass](#codex-second-pass)). The two are additive, never
+alternatives: a Codex pass that replaced Claude would leave the diff reviewed
+exactly once, which is the single-reviewer blind spot the second pass exists
+to close.
 
 **Skip this choice when:**
 - Trivial changes (< 50 LOC, single file)
@@ -140,47 +147,7 @@ After verifying test output in LEARNINGS.md, choose review strategy.
 - Automated refactoring (rename, extract)
 - Internal utility functions (not user-facing or security-sensitive)
 
-### Step 1: Probe Codex availability (silent)
-
-Codex provides an out-of-process adversarial reviewer that uses a different
-model family than Claude — the diversity catches issues a Claude-reviewing-Claude
-loop would miss. When installed and authenticated, it is the **default**
-adversarial path. When unavailable, fall back to the existing Claude-based
-flow without prompting the user about installation.
-
-Read `${CLAUDE_SKILL_DIR}/../../references/codex-availability.md` for the full
-probe and invocation contract. Execute the probe before asking the user:
-
-```bash
-CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-if [ -n "$CODEX_SCRIPT" ]; then
-  node "$CODEX_SCRIPT" setup --json 2>/dev/null | jq -r '.ready // false'
-else
-  echo "false"
-fi
-```
-
-Set `CODEX_READY=true` only when the probe prints `true`. Otherwise
-`CODEX_READY=false` and skip Codex entirely — do not announce its absence.
-
-### Step 2: Ask the user
-
-**If `CODEX_READY=true`:**
-
-```python
-AskUserQuestion(questions=[{
-  "question": "How should we review this implementation?",
-  "header": "Review Strategy",
-  "options": [
-    {"label": "Codex adversarial review (Recommended)", "description": "Out-of-process adversarial review via Codex. Different model family from Claude — catches issues a Claude-on-Claude loop misses. Default for adversarial review."},
-    {"label": "Single Claude reviewer", "description": "Combined Claude review covering spec compliance and code quality. Faster, lower overhead. Use when Codex is overkill."},
-    {"label": "Parallel Claude review (Thorough)", "description": "Spawn 3 specialized Claude reviewers (Security, Performance, Tests). Use when Codex is unavailable or you want multi-perspective Claude review."}
-  ],
-  "multiSelect": false
-}])
-```
-
-**If `CODEX_READY=false`:**
+**Ask the user:**
 
 ```python
 AskUserQuestion(questions=[{
@@ -198,34 +165,89 @@ AskUserQuestion(questions=[{
 
 | Choice | Go to |
 |--------|-------|
-| Codex adversarial review | [Codex Adversarial Review](#codex-adversarial-review) |
 | Single (Claude) reviewer | [The Iron Law of Review](#the-iron-law-of-review) |
 | Parallel (Claude) review | [Parallel Review (Thorough)](#parallel-review-thorough) |
 
+Both paths converge on [Phase Complete](#phase-complete), which runs the Codex
+second pass before any APPROVED verdict is written.
+
 ---
 
-## Codex Adversarial Review
+## Codex Second Pass
 
-Use this section when the user chose **Codex adversarial review**.
+**When this runs:** after the primary reviewer (single or parallel) returns
+APPROVED, and BEFORE `status: APPROVED` is written to `.planning/REVIEW_STATE.md`.
+It never runs on CHANGES_REQUIRED, ESCALATE, or BLOCKED — there is nothing to
+second-guess when the primary reviewer already found blocking issues; fix those
+first and the second pass runs on the next iteration.
+
+**Why it exists:** the primary reviewer is Claude reviewing Claude's code. Codex
+is a different model family in a different process, so its blind spots are not
+correlated with the implementer's. This is the audit-fix-loop Iron Law ("the
+auditor must not be the fixer") applied to the model itself.
 
 > **Reference:** See `references/codex-availability.md` for the full invocation
 > contract, JSON schema, and verdict mapping table.
 
-### 1. Prerequisites Check
+### 1. Decide once per review loop, not once per iteration
 
-Before invoking Codex, verify (same as the other review paths):
+Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
+value, honor it and do NOT re-ask:
 
-1. **Test evidence exists** — LEARNINGS.md contains actual test output
-2. **E2E evidence for UI changes** — user-facing changes have E2E test output
-3. **SPEC.md exists** — for REQ-ID tagging of findings post-hoc
-4. **Git repo present** — Codex adversarial review is git-diff scoped
+| Stored value | Action |
+|--------------|--------|
+| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
+| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | Probe, then ask (steps 2-3) |
 
-If any prerequisite fails, STOP and return BLOCKED to /dev-implement.
+Asking on every fix iteration turns an opt-in into nagging, and a user who
+answers "no" three times has been asked three times too many.
 
-### 2. Estimate Scope and Choose Wait vs Background
+Probe on every iteration even when the answer is stored — `enabled` records a
+user's consent, not Codex's continued availability.
+
+### 2. Probe Codex availability (silent)
 
 ```bash
-# Working-tree review
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
+if [ -n "$CODEX_SCRIPT" ]; then
+  node "$CODEX_SCRIPT" setup --json 2>/dev/null | jq -r '.ready // false'
+else
+  echo "false"
+fi
+```
+
+If the probe does not print `true`: record `codex_second_pass: unavailable` and
+proceed to Phase Complete's APPROVED write. Do **not** announce Codex's absence
+and do **not** prompt the user to install it — this skill's job is to use Codex
+when present, not to onboard it.
+
+### 3. Ask the user (only when the probe printed `true`)
+
+```python
+AskUserQuestion(questions=[{
+  "question": "Primary review passed. Run a Codex second pass before verify?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Run Codex second pass (Recommended)", "description": "Independent adversarial review via Codex — a different model family in a separate process, so its blind spots don't overlap with Claude's. Findings at >=80 confidence re-enter the fix loop."},
+    {"label": "Skip — approve now", "description": "Accept the primary review's APPROVED verdict and proceed to dev-verify. Faster; the diff is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
+or `codex_second_pass: declined` before acting on it.
+
+### 4. Prerequisites
+
+Codex adversarial review is **git-diff scoped**. If there is no git repo, record
+`codex_second_pass: unavailable` and proceed — do not fabricate a scope.
+
+### 5. Estimate scope and choose wait vs background
+
+```bash
 git status --short --untracked-files=all
 git diff --shortstat --cached
 git diff --shortstat
@@ -234,7 +256,10 @@ git diff --shortstat
 Wait when the diff is clearly tiny (1-2 files, no untracked dir-sized changes).
 Otherwise launch in background.
 
-### 3. Invoke Codex
+### 6. Invoke Codex
+
+Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
+survive — re-resolve it in the same command that uses it.
 
 **Foreground (small diff):**
 
@@ -245,18 +270,19 @@ node "$CODEX_SCRIPT" adversarial-review --wait
 
 **Background (anything bigger):**
 
-Launch with `Bash(..., run_in_background: true)` and tell the user:
-"Codex adversarial review started in the background. Check `/codex:status` for progress."
+Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
+"Codex second pass started in the background. Check `/codex:status` for progress."
 
-Then await completion notification before proceeding to step 4.
+Then await completion before proceeding to step 7.
 
 **Optional focus text** — append SPEC.md context to weight the review:
 
 ```bash
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
 node "$CODEX_SCRIPT" adversarial-review --wait "focus: REQ-AUTH-01 token rotation under retry"
 ```
 
-### 4. Parse Verdict
+### 7. Parse verdict
 
 Codex returns JSON validated against its review-output schema. Top-level fields:
 `verdict` (`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`.
@@ -266,47 +292,45 @@ Each finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
 **Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
 when displaying alongside Claude-style scores.
 
-| Codex result | dev-review verdict |
-|--------------|--------------------|
-| `verdict: approve` | APPROVED |
-| `needs-attention` + any finding ≥ 0.8 confidence | CHANGES_REQUIRED |
-| `needs-attention` + all findings < 0.8 confidence | APPROVED (log advisory findings to LEARNINGS.md) |
+| Codex result | Second-pass outcome |
+|--------------|---------------------|
+| `verdict: approve` | APPROVED — proceed to Phase Complete's APPROVED write |
+| `needs-attention` + any finding ≥ 0.8 confidence | CHANGES_REQUIRED — overrides the primary reviewer's APPROVED |
+| `needs-attention` + all findings < 0.8 | APPROVED (log advisory findings to LEARNINGS.md) |
 
-### 5. Tag Findings to Requirements
+**A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
+reviewer does not get a veto over the second pass — if it did, the second pass
+would be decorative.
+
+If Codex fails to run (non-zero exit, unparseable output): record
+`codex_second_pass: error` and report the failure to the user. Do **not**
+silently treat a broken second pass as an approval — an unrun reviewer is not a
+passing reviewer.
+
+### 8. Tag findings to requirements
 
 Codex doesn't know SPEC.md REQ-IDs. For each blocking finding:
 
 1. Read `.planning/SPEC.md`
 2. Tag the finding with the most likely REQ-ID (or `OUT-OF-SPEC`)
-3. `OUT-OF-SPEC` findings are advisory unless user opts in
+3. `OUT-OF-SPEC` findings are advisory unless the user opts in
 
-### 6. Report
+### 9. Report
 
 Use the same output structure as `## Required Output Structure` below, with
-**Reviewer: Codex (adversarial)** in the header. Each issue includes the
-Codex confidence (×100) and the REQ-ID you tagged in step 5.
+**Reviewer: Codex (second pass)** in the header. Each issue includes the Codex
+confidence (×100) and the REQ-ID you tagged in step 8.
 
-### 7. Iteration & Re-Review
+### 10. Iteration & re-review
 
-Codex adversarial review participates in the same `REVIEW_STATE.md` loop as
-Claude reviewers — increment iteration on CHANGES_REQUIRED, escalate at
-iteration 3. **Re-runs stay on Codex** unless it becomes unavailable between
-runs (re-probe each iteration).
+The second pass participates in the same `REVIEW_STATE.md` loop as Claude
+reviewers — a blocking second pass increments iteration and returns
+CHANGES_REQUIRED, escalating at iteration 3 like any other verdict.
 
-The "Iron Law of Re-Review" still applies: implementer claims "fixed" → main
-chat re-invokes Codex via the same command — no spot-checks.
-
-### Phase Complete (Codex Adversarial)
-
-After Codex review completes:
-
-**If APPROVED:** Immediately invoke the dev-verify skill:
-
-Read `${CLAUDE_SKILL_DIR}/../../skills/dev-verify/SKILL.md` and follow its instructions.
-
-**If CHANGES_REQUIRED:** Return to `/dev-implement` with the parsed findings.
-
-**If BLOCKED (test evidence missing):** Return to `/dev-implement` to collect test evidence.
+On the next iteration the order repeats in full: primary review runs first, and
+the second pass runs again only if the primary approves. The "Iron Law of
+Re-Review" applies to Codex too — the implementer claims "fixed", main chat
+re-invokes the full review, no spot-checks.
 
 ---
 
@@ -513,17 +537,18 @@ All 3 reviewers approved with no issues >= 80 confidence.
 X critical and Y important issues must be addressed. Return to /dev-implement.
 ```
 
-## Phase Complete (Parallel Review)
+## After Parallel Review
 
-After parallel review completes:
+Parallel review produces a *primary* verdict — it is not a terminal state. Do
+NOT invoke dev-verify or write `status: APPROVED` from here.
 
-**If APPROVED:** Immediately invoke the dev-verify skill:
+Go to [Phase Complete](#phase-complete) and follow it for every verdict.
+Phase Complete is the single authority that runs the Codex second pass, writes
+`.planning/REVIEW_STATE.md`, and invokes dev-verify.
 
-Read `${CLAUDE_SKILL_DIR}/../../skills/dev-verify/SKILL.md` and follow its instructions.
-
-**If CHANGES REQUIRED:** Return to `/dev-implement` to fix reported issues.
-
-**If BLOCKED (test evidence missing):** Return to `/dev-implement` to collect test evidence.
+A branch-local "APPROVED → dev-verify" shortcut would let the parallel path
+reach verification without the second pass ever running, being declined, or
+being recorded — which is exactly the bypass the second pass exists to prevent.
 
 ---
 
@@ -789,12 +814,25 @@ affects: []             # read-only review; fixes happen in dev-implement
 verdict: APPROVED | CHANGES_REQUIRED | ESCALATE | BLOCKED
 iterations: N
 issues-found: X (Y critical, Z important)
+codex-second-pass: enabled | declined | unavailable | error
 ---
 ```
 
 After review completes, handle verdict-specific transitions:
 
 ### If APPROVED (no issues >= 80 confidence)
+
+**STOP — run the [Codex Second Pass](#codex-second-pass) first.** A primary
+APPROVED is a candidate verdict, not a final one. Writing `status: APPROVED`
+before the second pass runs would hand dev-verify a gate that no second reviewer
+ever saw — the second pass would be decorative, and the diff would ship reviewed
+once by the same model family that wrote it.
+
+Order of operations:
+
+1. Run the Codex second pass (it self-skips when Codex is unavailable or declined).
+2. If it returns **CHANGES_REQUIRED**, follow [If CHANGES REQUIRED](#if-changes-required-issues--80-confidence-found-iteration--3) instead of this section.
+3. Only if it returns **APPROVED** (or self-skipped), write the state below.
 
 Mark review complete in `.planning/REVIEW_STATE.md`:
 
@@ -805,15 +843,66 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
+codex_second_pass: enabled | declined | unavailable
 verdict: APPROVED
 ---
 ```
+
+`codex_second_pass` records what actually happened, so a later reader can tell
+"Codex approved this" from "Codex never ran." Never write `enabled` unless a
+Codex run actually returned a verdict.
+
+**`error` is not a valid value under `status: APPROVED`** — those three are the
+only ones. A failed second pass has no verdict, so it cannot support an
+approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 The `status: APPROVED` line is the structural gate dev-verify checks — only an APPROVED review admits verification. On non-approved paths (CHANGES_REQUIRED / ESCALATE / BLOCKED) set `status:` to that verdict so the gate correctly blocks.
 
 Immediately invoke dev-verify:
 
 Read `${CLAUDE_SKILL_DIR}/../../skills/dev-verify/SKILL.md` and follow its instructions.
+
+### If the Codex second pass errored
+
+Codex ran but produced no verdict (non-zero exit, unparseable output). **This is
+not an approval and not a rejection — it is an absence of evidence.** Do NOT
+write `status: APPROVED` and do NOT invoke dev-verify.
+
+Record the attempt and leave the gate closed:
+
+```yaml
+---
+status: BLOCKED
+iteration: [N]          # unchanged — no review verdict was produced
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: error
+verdict: BLOCKED
+---
+```
+
+Report the failure to the user and ask how to proceed:
+
+```python
+AskUserQuestion(questions=[{
+  "question": "The Codex second pass failed to produce a verdict. How should we proceed?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Retry the second pass", "description": "Re-run Codex. Transient failures (auth expiry, a dropped thread) usually clear on a retry."},
+    {"label": "Approve without it", "description": "Record codex_second_pass: declined and proceed to dev-verify on the primary review alone. The diff is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+- **Retry** → return to [Codex Second Pass](#codex-second-pass) step 2.
+- **Approve without it** → rewrite `codex_second_pass: declined` and follow
+  [If APPROVED](#if-approved-no-issues--80-confidence) from the top.
+
+Only an explicit user decision converts an `error` into a path forward. Silently
+downgrading it to an approval is the fabricated-verdict failure this skill exists
+to prevent.
 
 ### If CHANGES REQUIRED (issues >= 80 confidence found, iteration < 3)
 
@@ -826,11 +915,19 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
+codex_second_pass: enabled | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```
 
+Carry `codex_second_pass` forward unchanged — the decision is made once per
+review loop, not re-asked on each iteration.
+
 Return to `/dev-implement` with specific issues. **Implementer MUST re-invoke /dev-review after fixes.**
+
+When the blocking findings came from the second pass, say so in the handoff
+("Codex second pass, REQ-AUTH-01, confidence 92") — the implementer needs to
+know which reviewer to satisfy.
 
 **Critical:** When implementer returns claiming "fixed", you MUST re-run the FULL review. No shortcuts.
 
@@ -874,7 +971,8 @@ Return immediately to `/dev-implement` to collect test evidence. Do NOT incremen
 
 | Verdict | Next Action | Iteration Counter |
 |---------|-------------|-------------------|
-| APPROVED | Invoke /dev-verify immediately, mark task `[x]` in PLAN.md | Reset to 1 for next task |
+| APPROVED (primary) | Run the [Codex Second Pass](#codex-second-pass) before writing `status: APPROVED` | No change (not a terminal verdict) |
+| APPROVED (second pass done/skipped) | Invoke /dev-verify immediately, mark task `[x]` in PLAN.md | Reset to 1 for next task |
 | CHANGES REQUIRED | Return to /dev-implement, implementer fixes then re-invokes /dev-review | Increment |
 | ESCALATE | Ask user for direction | Keep at max |
 | BLOCKED | Return to /dev-implement for test evidence | No change (no review ran) |

--- a/skills/dev-review/SKILL.md
+++ b/skills/dev-review/SKILL.md
@@ -50,6 +50,7 @@ If the message could be EITHER a new topic OR part of the review, ask before ass
 ## Contents
 
 - [Prerequisites - Test Output Gate](#prerequisites---test-output-gate)
+- [Invalidate the previous verdict FIRST](#invalidate-the-previous-verdict-first) (first write of the phase)
 - [Review Strategy Choice](#review-strategy-choice) (picks the primary reviewer)
 - [Codex Second Pass](#codex-second-pass) (optional second opinion before any APPROVED verdict)
 - [Parallel Review (Thorough)](#parallel-review-thorough)
@@ -130,6 +131,34 @@ If no test output is found, STOP and return to /dev-implement.
 "It should work" is NOT evidence. Test output IS evidence.
 </EXTREMELY-IMPORTANT>
 
+## Invalidate the previous verdict FIRST
+
+**Before any reviewing starts — the first write of this phase:** if
+`.planning/REVIEW_STATE.md` exists and carries `status: APPROVED`, that approval
+belongs to the *previous* task or iteration. Overwrite it now:
+
+```yaml
+---
+status: IN_REVIEW
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+verdict: IN_REVIEW
+---
+```
+
+Drop any `codex_second_pass:` and `codex_output_file:` from the prior task at the
+same time — a second pass over last task's diff says nothing about this one.
+
+The loop resets `iteration` for a new task but not `status`, so a stale APPROVED
+otherwise sits on disk for the whole review — and `status: APPROVED` is exactly
+what dev-verify's gate hooks on. Every intermediate state after this point
+(`IN_REVIEW`, `SECOND_PASS_PENDING`) keeps that gate shut until this phase
+genuinely re-approves. A gate that was already open before the reviewer started
+is not a gate.
+
+---
+
 ## Review Strategy Choice
 
 After verifying test output in LEARNINGS.md, choose the **primary reviewer**.
@@ -194,18 +223,24 @@ auditor must not be the fixer") applied to the model itself.
 Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
 value, honor it and do NOT re-ask:
 
-| Stored value | Action |
-|--------------|--------|
-| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
-| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
-| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
-| absent | Probe, then ask (steps 2-3) |
+| Stored value | Meaning | Action |
+|--------------|---------|--------|
+| `requested` | consented and launched; no verdict yet | **Rejoin it** — go to step 7 and read `codex_output_file`. Relaunch (step 6) only if that file is missing or unparseable. Do NOT re-ask. |
+| `completed` | Codex returned a verdict this iteration | Probe (step 2), then run again for the new fixes — skip step 3 |
+| `declined` | user opted out of the loop | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | never reachable / ran and failed | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | not yet decided | Probe, then ask (steps 2-3) |
 
 Asking on every fix iteration turns an opt-in into nagging, and a user who
 answers "no" three times has been asked three times too many.
 
-Probe on every iteration even when the answer is stored — `enabled` records a
-user's consent, not Codex's continued availability.
+Probe on every iteration even when consent is stored — it records the user's
+answer, not Codex's continued availability.
+
+**`requested` and `completed` are different facts, and conflating them is a
+bypass.** `requested` means "we asked Codex"; only `completed` means "Codex
+answered". A launched-but-unjoined pass has produced no evidence, so the verify
+gate accepts `completed`, `declined`, and `unavailable` — never `requested`.
 
 ### 2. Probe Codex availability (silent)
 
@@ -237,15 +272,80 @@ AskUserQuestion(questions=[{
 }])
 ```
 
-Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
-or `codex_second_pass: declined` before acting on it.
+If the user declines, record `codex_second_pass: declined` and continue to Phase
+Complete. If the user opts in, do NOT record `enabled`/`completed` here — nothing
+has run yet. Go to step 4; step 5 writes the pending state.
 
 ### 4. Prerequisites
 
 Codex adversarial review is **git-diff scoped**. If there is no git repo, record
 `codex_second_pass: unavailable` and proceed — do not fabricate a scope.
 
-### 5. Estimate scope and choose wait vs background
+### 5. Close the gate BEFORE launching
+
+First clear the handle, and **verify the clear worked**. It is
+**per-iteration**, and it is emptied *before* the state says `requested`:
+
+```bash
+# substitute this iteration's N
+OUT=.planning/codex-second-pass-iter[N].json
+rm -f "$OUT"
+if [ -e "$OUT" ]; then
+  echo "BLOCKED: cannot clear $OUT — refusing to request a pass that could join a stale verdict"
+  exit 1
+fi
+```
+
+**A clear that silently failed is worse than no clear.** `rm -f` reports success
+for a file that never existed and stays quiet about one it could not remove (a
+read-only `.planning/`, wrong ownership, an immutable bit). The launch redirect
+would then fail for the same reason, leaving the *old* envelope in place for the
+join to read as this pass's answer. Checking that the path is actually gone turns
+that assumption into a precondition.
+
+If the clear fails: do NOT record `requested`. Record `codex_second_pass: error`
+with `status: BLOCKED` and report it — see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored). An
+environment that cannot give the pass a clean handle cannot give it an honest
+verdict either.
+
+Then write this to `.planning/REVIEW_STATE.md` **before** invoking Codex:
+
+```yaml
+---
+status: SECOND_PASS_PENDING
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: requested
+codex_output_file: .planning/codex-second-pass-iter[N].json
+verdict: SECOND_PASS_PENDING
+---
+```
+
+**A previous pass's verdict is not this pass's answer.** The shell redirect only
+truncates the file when Codex is actually invoked, so a single reused path leaves
+a window: stop between this state write and the launch — or resume into the join —
+and step 7 would read the *last* iteration's envelope, parse its `approve`, and
+write `completed`. The requested pass never ran. Both halves close that: a fresh
+name per iteration means last iteration's answer is never at this iteration's
+path, and the `rm -f` means a re-launch within an iteration cannot join its own
+stale output either. Absent file → `PENDING` → relaunch, which is correct.
+
+**Why before, not after.** `status: APPROVED` may still be sitting in this file
+from an earlier task or iteration — the loop resets `iteration`, not `status`.
+If you launch Codex while a stale APPROVED is on disk, the verify gate is open
+for the entire time Codex is running: a crash, an interruption, or a resumed
+session walks straight into dev-verify on a second pass that never returned.
+Writing a non-approved status first means the window never exists — the gate is
+shut before the reviewer is even asked, and only its verdict reopens it.
+
+`codex_output_file` is the join handle (step 7). It is a path, not a promise:
+if the session dies here, the state on disk still says PENDING and the gate
+stays shut.
+
+### 6. Estimate scope and choose wait vs background
 
 ```bash
 git status --short --untracked-files=all
@@ -256,38 +356,106 @@ git diff --shortstat
 Wait when the diff is clearly tiny (1-2 files, no untracked dir-sized changes).
 Otherwise launch in background.
 
-### 6. Invoke Codex
+### 6b. Invoke Codex
 
 Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
 survive — re-resolve it in the same command that uses it.
 
-**Foreground (small diff):**
+**Always pass `--json`, and always redirect to `codex_output_file`.** Both are
+load-bearing:
+
+- `--json` is the ONLY form that carries `confidence`. The default rendered text
+  prints `[high]` but no number, and the iron law below thresholds on
+  confidence ≥ 0.8 — applied to rendered output it would be a rule with nothing
+  to read.
+- The redirect turns the verdict into a **file on disk**, which is what makes
+  the background path joinable (step 7). Output that exists only in a terminal
+  or a transcript is lost to any interruption.
+
+Redirect to the **exact path recorded in `codex_output_file`** — the state file
+is the authority on which handle this pass owns:
 
 ```bash
 CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-node "$CODEX_SCRIPT" adversarial-review --wait
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
 
-**Background (anything bigger):**
+**Foreground (small diff):** run the command above and go to step 7.
 
-Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
-"Codex second pass started in the background. Check `/codex:status` for progress."
+**Background (anything bigger):** run the **same** command via
+`Bash(..., run_in_background: true)`, then tell the user: "Codex second pass
+started in the background." Do not advance past step 7's join check until the
+background task reports completion — an unjoined launch is not a verdict.
 
-Then await completion before proceeding to step 7.
+`--background` on the companion is a no-op for reviews: `adversarial-review`
+always runs in the foreground (only `task` enqueues a job), so the harness's
+`run_in_background` is what actually detaches it. That is exactly why the
+redirect matters — the companion is not holding a result for you to fetch later.
 
 **Optional focus text** — append SPEC.md context to weight the review:
 
 ```bash
-CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-node "$CODEX_SCRIPT" adversarial-review --wait "focus: REQ-AUTH-01 token rotation under retry"
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  "focus: REQ-AUTH-01 token rotation under retry" \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
 
-### 7. Parse verdict
+### 7. Join the run, then parse the verdict
 
-Codex returns JSON validated against its review-output schema. Top-level fields:
-`verdict` (`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`.
-Each finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
-`confidence` (0-1 float), `recommendation`.
+**The join is a real step, not a hope.** The state on disk says
+`codex_second_pass: requested`; nothing may advance until this step turns it
+into `completed` or `error`. This is also the resume path: a fresh session that
+finds `requested` starts here.
+
+Extract the verdict mechanically — do not read it off the screen:
+
+```bash
+uv run python3 - <<'PY'
+import json, pathlib, re
+state = pathlib.Path('.planning/REVIEW_STATE.md')
+m = re.search(r'^codex_output_file:\s*(\S+)\s*$', state.read_text(), re.M) if state.exists() else None
+if not m:
+    print('ERROR: no codex_output_file recorded — relaunch (step 6b)')
+    raise SystemExit(0)
+p = pathlib.Path(m.group(1))          # the handle THIS pass owns
+if not p.exists() or not p.stat().st_size:
+    print('PENDING: no output yet — the run is unfinished, failed, or was lost')
+    raise SystemExit(0)
+try:
+    envelope = json.loads(p.read_text())
+    if envelope.get('codex', {}).get('status') != 0:
+        print('ERROR: codex exited', envelope.get('codex', {}).get('status'))
+        raise SystemExit(0)
+    v = json.loads(envelope['codex']['stdout'])   # the schema-validated verdict
+except Exception as e:
+    print('ERROR: unparseable output —', e)
+    raise SystemExit(0)
+print('verdict:', v['verdict'])
+for f in v.get('findings', []):
+    print(f"  {f['confidence']:.2f}  [{f['severity']}]  {f['file']}:{f['line_start']}  {f['title']}")
+PY
+```
+
+It resolves the path from `codex_output_file` rather than hardcoding one — the
+state file names the handle this pass owns, so a verdict left at some other
+path by an earlier iteration can never be read as this one's answer.
+
+The payload is an envelope: `{review, target, threadId, codex: {status, stdout}}`,
+and `codex.stdout` is the schema-validated verdict **as a JSON string** — it
+needs a second parse, which is why this runs as a script and not as an eyeball.
+
+Route on what it printed:
+
+| Printed | Meaning | Do |
+|---------|---------|----|
+| `verdict: ...` | Codex answered | continue below; the pass is `completed` |
+| `PENDING: ...` | still running, or the output was lost | do NOT proceed. If the background task is still going, wait. If it is gone, relaunch (step 6b). The gate stays shut meanwhile. |
+| `ERROR: ...` | ran and failed | go to [If the Codex second pass errored](#if-the-codex-second-pass-errored) |
+
+The verdict object: `verdict` (`approve` | `needs-attention`), `summary`,
+`findings[]`, `next_steps[]`. Each finding has `severity`, `title`, `body`,
+`file`, `line_start`, `line_end`, `confidence` (0-1 float), `recommendation`.
 
 **Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
 when displaying alongside Claude-style scores.
@@ -301,6 +469,11 @@ when displaying alongside Claude-style scores.
 **A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
 reviewer does not get a veto over the second pass — if it did, the second pass
 would be decorative.
+
+**Move `SECOND_PASS_PENDING` to its terminal state in ONE write** — the same
+edit sets `status:` and flips `codex_second_pass: requested` → `completed`. Two
+writes means a window where the file claims a verdict it hasn't recorded, or
+records a disposition with a status that no longer matches it.
 
 If Codex fails to run (non-zero exit, unparseable output): record
 `codex_second_pass: error` and report the failure to the user. Do **not**
@@ -814,7 +987,7 @@ affects: []             # read-only review; fixes happen in dev-implement
 verdict: APPROVED | CHANGES_REQUIRED | ESCALATE | BLOCKED
 iterations: N
 issues-found: X (Y critical, Z important)
-codex-second-pass: enabled | declined | unavailable | error
+codex-second-pass: completed | declined | unavailable | error | error
 ---
 ```
 
@@ -843,23 +1016,24 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: APPROVED
 ---
 ```
 
 `codex_second_pass` records what actually happened, so a later reader can tell
-"Codex approved this" from "Codex never ran." Never write `enabled` unless a
-Codex run actually returned a verdict.
+"Codex approved this" from "Codex never ran." Never write `completed` unless a
+Codex run actually returned a verdict you parsed in step 7.
 
-**`error` is not a valid value under `status: APPROVED`** — those three are the
-only ones. A failed second pass has no verdict, so it cannot support an
-approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
+**`requested` and `error` are not valid under `status: APPROVED`** — those three
+are the only ones. `requested` is a launch, not an answer; `error` is a failure,
+not an answer. Neither supports an approval; see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 **This is hook-enforced, not advisory.** dev-verify gates Agent dispatch on
-`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+`GATE_REQUIRE_FIELDS=codex_second_pass:completed|declined|unavailable`, so verify
 cannot start until this field records one of those three. Substitute a single
-value — pasting the `enabled | declined | unavailable` line verbatim matches
+value — pasting the `completed | declined | unavailable` line verbatim matches
 nothing and the gate blocks it.
 
 The `status: APPROVED` line is the structural gate dev-verify checks — only an APPROVED review admits verification. On non-approved paths (CHANGES_REQUIRED / ESCALATE / BLOCKED) set `status:` to that verdict so the gate correctly blocks.
@@ -921,7 +1095,7 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```

--- a/skills/dev-review/SKILL.md
+++ b/skills/dev-review/SKILL.md
@@ -856,6 +856,12 @@ Codex run actually returned a verdict.
 only ones. A failed second pass has no verdict, so it cannot support an
 approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
+**This is hook-enforced, not advisory.** dev-verify gates Agent dispatch on
+`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+cannot start until this field records one of those three. Substitute a single
+value — pasting the `enabled | declined | unavailable` line verbatim matches
+nothing and the gate blocks it.
+
 The `status: APPROVED` line is the structural gate dev-verify checks — only an APPROVED review admits verification. On non-approved paths (CHANGES_REQUIRED / ESCALATE / BLOCKED) set `status:` to that verdict so the gate correctly blocks.
 
 Immediately invoke dev-verify:

--- a/skills/dev-verify/SKILL.md
+++ b/skills/dev-verify/SKILL.md
@@ -15,10 +15,10 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
-            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
+            GATE_REQUIRE_FIELDS="codex_second_pass:completed|declined|unavailable"
             GATE_BLOCKED_TOOLS=Agent
             GATE_DESCRIPTION="Code review approved"
-            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
+            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify. REVIEW_STATE.md must also record codex_second_pass: completed (Codex returned a verdict) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). codex_second_pass: requested means the second pass was launched but has not returned — join it (read the file named by codex_output_file) before verifying; a launched-but-unjoined pass is not a completed one. codex_second_pass: error is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
         - type: command
           command: "FLOOR=dev uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/mechanical-floor-gate.py"

--- a/skills/dev-verify/SKILL.md
+++ b/skills/dev-verify/SKILL.md
@@ -15,9 +15,10 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
+            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
             GATE_BLOCKED_TOOLS=Agent
             GATE_DESCRIPTION="Code review approved"
-            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify."
+            GATE_REMEDY="Return to dev-review (Phase 6). Review must complete with verdict APPROVED (REVIEW_STATE.md status: APPROVED) before verification. A CHANGES_REQUIRED/ESCALATE/BLOCKED review does not admit verify. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
         - type: command
           command: "FLOOR=dev uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/mechanical-floor-gate.py"

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -984,6 +984,12 @@ Codex run actually returned a verdict.
 only ones. A failed second pass has no verdict, so it cannot support an
 approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
+**This is hook-enforced, not advisory.** ds-verify gates Agent dispatch on
+`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+cannot start until this field records one of those three. Substitute a single
+value — pasting the `enabled | declined | unavailable` line verbatim matches
+nothing and the gate blocks it.
+
 **`status: APPROVED` is the structural gate field** — ds-verify declares a PreToolUse `phase-gate-guard.py` hook that blocks Agent dispatch until `.planning/REVIEW_STATE.md` shows `status: APPROVED`. While the review loop is unresolved (CHANGES_REQUIRED / ESCALATE), `status` is NOT `APPROVED`, so verification is structurally blocked.
 
 Immediately discover and load ds-verify:

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -60,6 +60,35 @@ Announce: "Using ds-review (Phase 4) to check methodology and quality."
 | Warning | 25-35% | Complete current review cycle, then trigger ds-handoff |
 | Critical | ≤25% | Immediately trigger ds-handoff — do not start new review cycles |
 
+## Invalidate the previous verdict FIRST
+
+**Before any reviewing starts — the first write of this phase:** if
+`.planning/REVIEW_STATE.md` exists and carries `status: APPROVED`, that approval
+belongs to the *previous* analysis or iteration. Overwrite it now:
+
+```yaml
+---
+status: IN_REVIEW
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+verdict: IN_REVIEW
+---
+```
+
+Drop any `codex_second_pass:` and `codex_output_file:` from the prior analysis at
+the same time — a second pass over last analysis's diff says nothing about this
+one.
+
+The loop resets `iteration` for a new analysis but not `status`, so a stale
+APPROVED otherwise sits on disk for the whole review — and `status: APPROVED` is
+exactly what ds-verify's gate hooks on. Every intermediate state after this point
+(`IN_REVIEW`, `SECOND_PASS_PENDING`) keeps that gate shut until this phase
+genuinely re-approves. A gate that was already open before the reviewer started
+is not a gate.
+
+---
+
 ## Review Strategy Choice
 
 After announcing phase, choose the **primary reviewer**.
@@ -125,16 +154,22 @@ A Codex approval is not evidence the methodology is sound.
 Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
 value, honor it and do NOT re-ask:
 
-| Stored value | Action |
-|--------------|--------|
-| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
-| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
-| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
-| absent | Probe, then ask (steps 2-3) |
+| Stored value | Meaning | Action |
+|--------------|---------|--------|
+| `requested` | consented and launched; no verdict yet | **Rejoin it** — go to step 7 and read `codex_output_file`. Relaunch (step 6b) only if that file is missing or unparseable. Do NOT re-ask. |
+| `completed` | Codex returned a verdict this iteration | Probe (step 2), then run again for the new fixes — skip step 3 |
+| `declined` | user opted out of the loop | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | never reachable / ran and failed | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | not yet decided | Probe, then ask (steps 2-3) |
 
 Asking on every fix iteration turns an opt-in into nagging. Probe on every
-iteration even when the answer is stored — `enabled` records a user's consent,
-not Codex's continued availability.
+iteration even when consent is stored — it records the user's answer, not
+Codex's continued availability.
+
+**`requested` and `completed` are different facts, and conflating them is a
+bypass.** `requested` means "we asked Codex"; only `completed` means "Codex
+answered". A launched-but-unjoined pass has produced no evidence, so the verify
+gate accepts `completed`, `declined`, and `unavailable` — never `requested`.
 
 ### 2. Probe Codex availability (silent)
 
@@ -165,8 +200,9 @@ AskUserQuestion(questions=[{
 }])
 ```
 
-Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
-or `codex_second_pass: declined` before acting on it.
+If the user declines, record `codex_second_pass: declined` and continue to Phase
+Complete. If the user opts in, do NOT record `enabled`/`completed` here — nothing
+has run yet. Go to step 4; step 5 writes the pending state.
 
 ### 4. Prerequisites
 
@@ -177,7 +213,67 @@ Notebooks: review the paired text representation (`.py` via jupytext) when one
 exists. A diff of `.ipynb` JSON is mostly execution-count and output noise, and
 a reviewer reading noise finds nothing.
 
-### 5. Estimate scope and choose wait vs background
+### 5. Close the gate BEFORE launching
+
+First clear the handle, and **verify the clear worked**. It is
+**per-iteration**, and it is emptied *before* the state says `requested`:
+
+```bash
+# substitute this iteration's N
+OUT=.planning/codex-second-pass-iter[N].json
+rm -f "$OUT"
+if [ -e "$OUT" ]; then
+  echo "BLOCKED: cannot clear $OUT — refusing to request a pass that could join a stale verdict"
+  exit 1
+fi
+```
+
+**A clear that silently failed is worse than no clear.** `rm -f` reports success
+for a file that never existed and stays quiet about one it could not remove (a
+read-only `.planning/`, wrong ownership, an immutable bit). The launch redirect
+would then fail for the same reason, leaving the *old* envelope in place for the
+join to read as this pass's answer. Checking that the path is actually gone turns
+that assumption into a precondition.
+
+If the clear fails: do NOT record `requested`. Record `codex_second_pass: error`
+with `status: BLOCKED` and report it — see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored). An
+environment that cannot give the pass a clean handle cannot give it an honest
+verdict either.
+
+Then write this to `.planning/REVIEW_STATE.md` **before** invoking Codex:
+
+```yaml
+---
+status: SECOND_PASS_PENDING
+iteration: [N]
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: requested
+codex_output_file: .planning/codex-second-pass-iter[N].json
+verdict: SECOND_PASS_PENDING
+---
+```
+
+**A previous pass's verdict is not this pass's answer.** The shell redirect only
+truncates the file when Codex is actually invoked, so a single reused path leaves
+a window: stop between this state write and the launch — or resume into the join —
+and step 7 would read the *last* iteration's envelope, parse its `approve`, and
+write `completed`. The requested pass never ran. A fresh name per iteration plus
+the `rm -f` closes both halves; an absent file gives `PENDING` → relaunch.
+
+**Why before, not after.** `status: APPROVED` may still be sitting in this file
+from an earlier analysis or iteration — the loop resets `iteration`, not
+`status`. If you launch Codex while a stale APPROVED is on disk, the verify gate
+is open for the entire time Codex is running: a crash, an interruption, or a
+resumed session walks straight into ds-verify on a second pass that never
+returned. Writing a non-approved status first means the window never exists.
+
+`codex_output_file` is the join handle (step 7). If the session dies here, the
+state on disk still says PENDING and the gate stays shut.
+
+### 6. Estimate scope and choose wait vs background
 
 ```bash
 git status --short --untracked-files=all
@@ -187,35 +283,99 @@ git diff --shortstat
 
 Wait when the diff is clearly tiny (1-2 files). Otherwise launch in background.
 
-### 6. Invoke Codex
+### 6b. Invoke Codex
 
 Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
 survive — re-resolve it in the same command that uses it.
 
-**Foreground (small diff):**
+**Always pass `--json`, and always redirect to `codex_output_file`.** Both are
+load-bearing:
+
+- `--json` is the ONLY form that carries `confidence`. The default rendered text
+  prints `[high]` but no number, and the iron law below thresholds on
+  confidence >= 0.8 — applied to rendered output it would be a rule with nothing
+  to read.
+- The redirect turns the verdict into a **file on disk**, which is what makes
+  the background path joinable (step 7). Output that exists only in a terminal
+  or a transcript is lost to any interruption.
+
+Redirect to the **exact path recorded in `codex_output_file`** — the state file
+is the authority on which handle this pass owns:
 
 ```bash
 CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
-node "$CODEX_SCRIPT" adversarial-review --wait
+node "$CODEX_SCRIPT" adversarial-review --wait --json \
+  "focus: data leakage between train/test, join row-count fan-out, filters applied after the split, parameters that contradict .planning/SPEC.md" \
+  > .planning/codex-second-pass-iter[N].json 2> .planning/codex-second-pass-iter[N].err
 ```
 
-**Background (anything bigger):**
+**Foreground (small diff):** run the command above and go to step 7.
 
-Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
-"Codex second pass started in the background. Check `/codex:status` for progress."
+**Background (anything bigger):** run the **same** command via
+`Bash(..., run_in_background: true)`, then tell the user: "Codex second pass
+started in the background." Do not advance past step 7's join check until the
+background task reports completion — an unjoined launch is not a verdict.
 
-**Focus text** — carry the analysis question and the DS failure modes:
+`--background` on the companion is a no-op for reviews: `adversarial-review`
+always runs in the foreground (only `task` enqueues a job), so the harness's
+`run_in_background` is what actually detaches it. That is exactly why the
+redirect matters — the companion is not holding a result for you to fetch later.
+
+### 7. Join the run, then parse the verdict
+
+**The join is a real step, not a hope.** The state on disk says
+`codex_second_pass: requested`; nothing may advance until this step turns it
+into `completed` or `error`. This is also the resume path: a fresh session that
+finds `requested` starts here.
+
+Extract the verdict mechanically — do not read it off the screen:
 
 ```bash
-node "$CODEX_SCRIPT" adversarial-review --wait "focus: data leakage between train/test, join row-count fan-out, filters applied after the split, parameters that contradict .planning/SPEC.md"
+uv run python3 - <<'PY'
+import json, pathlib, re
+state = pathlib.Path('.planning/REVIEW_STATE.md')
+m = re.search(r'^codex_output_file:\s*(\S+)\s*$', state.read_text(), re.M) if state.exists() else None
+if not m:
+    print('ERROR: no codex_output_file recorded — relaunch (step 6b)')
+    raise SystemExit(0)
+p = pathlib.Path(m.group(1))          # the handle THIS pass owns
+if not p.exists() or not p.stat().st_size:
+    print('PENDING: no output yet — the run is unfinished, failed, or was lost')
+    raise SystemExit(0)
+try:
+    envelope = json.loads(p.read_text())
+    if envelope.get('codex', {}).get('status') != 0:
+        print('ERROR: codex exited', envelope.get('codex', {}).get('status'))
+        raise SystemExit(0)
+    v = json.loads(envelope['codex']['stdout'])   # the schema-validated verdict
+except Exception as e:
+    print('ERROR: unparseable output —', e)
+    raise SystemExit(0)
+print('verdict:', v['verdict'])
+for f in v.get('findings', []):
+    print(f"  {f['confidence']:.2f}  [{f['severity']}]  {f['file']}:{f['line_start']}  {f['title']}")
+PY
 ```
 
-### 7. Parse verdict
+It resolves the path from `codex_output_file` rather than hardcoding one — the
+state file names the handle this pass owns, so a verdict left at some other
+path by an earlier iteration can never be read as this one's answer.
 
-Codex returns JSON validated against its review-output schema: `verdict`
-(`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`. Each
-finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
-`confidence` (0-1 float), `recommendation`.
+The payload is an envelope: `{review, target, threadId, codex: {status, stdout}}`,
+and `codex.stdout` is the schema-validated verdict **as a JSON string** — it
+needs a second parse, which is why this runs as a script and not as an eyeball.
+
+Route on what it printed:
+
+| Printed | Meaning | Do |
+|---------|---------|----|
+| `verdict: ...` | Codex answered | continue below; the pass is `completed` |
+| `PENDING: ...` | still running, or the output was lost | do NOT proceed. If the background task is still going, wait. If it is gone, relaunch (step 6b). The gate stays shut meanwhile. |
+| `ERROR: ...` | ran and failed | go to [If the Codex second pass errored](#if-the-codex-second-pass-errored) |
+
+The verdict object: `verdict` (`approve` | `needs-attention`), `summary`,
+`findings[]`, `next_steps[]`. Each finding has `severity`, `title`, `body`,
+`file`, `line_start`, `line_end`, `confidence` (0-1 float), `recommendation`.
 
 **Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
 when displaying alongside Claude-style scores.
@@ -229,6 +389,10 @@ when displaying alongside Claude-style scores.
 **A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
 reviewer does not get a veto over the second pass — if it did, the second pass
 would be decorative.
+
+**Move `SECOND_PASS_PENDING` to its terminal state in ONE write** — the same
+edit sets `status:` and flips `codex_second_pass: requested` -> `completed`. Two
+writes means a window where the file claims a verdict it hasn't recorded.
 
 If Codex fails to run (non-zero exit, unparseable output): record
 `codex_second_pass: error` and report the failure to the user. Do **not**
@@ -971,23 +1135,24 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: APPROVED
 ---
 ```
 
 `codex_second_pass` records what actually happened, so a later reader can tell
-"Codex approved this" from "Codex never ran." Never write `enabled` unless a
-Codex run actually returned a verdict.
+"Codex approved this" from "Codex never ran." Never write `completed` unless a
+Codex run actually returned a verdict you parsed in step 7.
 
-**`error` is not a valid value under `status: APPROVED`** — those three are the
-only ones. A failed second pass has no verdict, so it cannot support an
-approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
+**`requested` and `error` are not valid under `status: APPROVED`** — those three
+are the only ones. `requested` is a launch, not an answer; `error` is a failure,
+not an answer. Neither supports an approval; see
+[If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 **This is hook-enforced, not advisory.** ds-verify gates Agent dispatch on
-`GATE_REQUIRE_FIELDS=codex_second_pass:enabled|declined|unavailable`, so verify
+`GATE_REQUIRE_FIELDS=codex_second_pass:completed|declined|unavailable`, so verify
 cannot start until this field records one of those three. Substitute a single
-value — pasting the `enabled | declined | unavailable` line verbatim matches
+value — pasting the `completed | declined | unavailable` line verbatim matches
 nothing and the gate blocks it.
 
 **`status: APPROVED` is the structural gate field** — ds-verify declares a PreToolUse `phase-gate-guard.py` hook that blocks Agent dispatch until `.planning/REVIEW_STATE.md` shows `status: APPROVED`. While the review loop is unresolved (CHANGES_REQUIRED / ESCALATE), `status` is NOT `APPROVED`, so verification is structurally blocked.
@@ -1048,7 +1213,7 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
-codex_second_pass: enabled | declined | unavailable
+codex_second_pass: completed | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -62,7 +62,12 @@ Announce: "Using ds-review (Phase 4) to check methodology and quality."
 
 ## Review Strategy Choice
 
-After announcing phase, choose review strategy.
+After announcing phase, choose the **primary reviewer**.
+
+This choice picks who reviews FIRST. It is not a choice about whether Codex
+runs — Codex is a *second pass* over whatever the primary reviewer approves
+(see [Codex Second Pass](#codex-second-pass)). The two are additive, never
+alternatives.
 
 **Skip this choice when:**
 - Exploratory analysis (one-off, not for publication)
@@ -87,6 +92,167 @@ AskUserQuestion(questions=[{
 **If Single reviewer:** Proceed to [The Iron Law of DS Review](#the-iron-law-of-ds-review) below (current behavior).
 
 **If Parallel review:** Skip to [Parallel Review (Research-Grade)](#parallel-review-research-grade).
+
+Both paths converge on [Phase Complete](#phase-complete), which runs the Codex
+second pass before any APPROVED verdict is written.
+
+---
+
+## Codex Second Pass
+
+**When this runs:** after the primary reviewer (single or parallel) returns
+APPROVED, and BEFORE `status: APPROVED` is written to `.planning/REVIEW_STATE.md`.
+It never runs on CHANGES_REQUIRED, ESCALATE, or BLOCKED — fix those findings
+first, and the second pass runs on the next iteration.
+
+**Why it exists:** the primary reviewer is Claude reviewing Claude's analysis.
+Codex is a different model family in a different process, so its blind spots are
+not correlated with the analyst's. This is the audit-fix-loop Iron Law ("the
+auditor must not be the fixer") applied to the model itself.
+
+**What it is good at, and what it is not:** Codex reviews the *code* — leakage
+between fit and evaluation, a join that silently fans out rows, a filter applied
+after the split, a hardcoded parameter contradicting SPEC.md. It cannot judge
+whether the research question is worth asking or whether a result is
+substantively interesting. Those stay with the Claude reviewers and the user.
+A Codex approval is not evidence the methodology is sound.
+
+> **Reference:** See `references/codex-availability.md` for the full invocation
+> contract, JSON schema, and verdict mapping table.
+
+### 1. Decide once per review loop, not once per iteration
+
+Read `.planning/REVIEW_STATE.md`. If it already carries a `codex_second_pass:`
+value, honor it and do NOT re-ask:
+
+| Stored value | Action |
+|--------------|--------|
+| `enabled` | Probe (step 2), then run without re-asking — skip step 3 |
+| `declined` | Skip the second pass entirely → Phase Complete's APPROVED write |
+| `unavailable` / `error` | Re-probe (step 2) — Codex may have been installed or fixed since |
+| absent | Probe, then ask (steps 2-3) |
+
+Asking on every fix iteration turns an opt-in into nagging. Probe on every
+iteration even when the answer is stored — `enabled` records a user's consent,
+not Codex's continued availability.
+
+### 2. Probe Codex availability (silent)
+
+```bash
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
+if [ -n "$CODEX_SCRIPT" ]; then
+  node "$CODEX_SCRIPT" setup --json 2>/dev/null | jq -r '.ready // false'
+else
+  echo "false"
+fi
+```
+
+If the probe does not print `true`: record `codex_second_pass: unavailable` and
+proceed to Phase Complete's APPROVED write. Do **not** announce Codex's absence
+and do **not** prompt the user to install it.
+
+### 3. Ask the user (only when the probe printed `true`)
+
+```python
+AskUserQuestion(questions=[{
+  "question": "Primary review passed. Run a Codex second pass before verify?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Run Codex second pass (Recommended)", "description": "Independent adversarial review of the analysis code via Codex — a different model family, so its blind spots don't overlap with Claude's. Catches leakage, join fan-out, and spec drift. Findings at >=80 confidence re-enter the fix loop."},
+    {"label": "Skip — approve now", "description": "Accept the primary review's APPROVED verdict and proceed to ds-verify. Faster; the analysis is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+Record the answer in `.planning/REVIEW_STATE.md` as `codex_second_pass: enabled`
+or `codex_second_pass: declined` before acting on it.
+
+### 4. Prerequisites
+
+Codex adversarial review is **git-diff scoped**. If there is no git repo, record
+`codex_second_pass: unavailable` and proceed — do not fabricate a scope.
+
+Notebooks: review the paired text representation (`.py` via jupytext) when one
+exists. A diff of `.ipynb` JSON is mostly execution-count and output noise, and
+a reviewer reading noise finds nothing.
+
+### 5. Estimate scope and choose wait vs background
+
+```bash
+git status --short --untracked-files=all
+git diff --shortstat --cached
+git diff --shortstat
+```
+
+Wait when the diff is clearly tiny (1-2 files). Otherwise launch in background.
+
+### 6. Invoke Codex
+
+Each Bash call runs in a fresh shell, so `$CODEX_SCRIPT` from the probe does not
+survive — re-resolve it in the same command that uses it.
+
+**Foreground (small diff):**
+
+```bash
+CODEX_SCRIPT=$(find "$HOME/.claude/plugins/cache/openai-codex/codex" -maxdepth 3 -name codex-companion.mjs -type f 2>/dev/null | sort -rV | head -1)
+node "$CODEX_SCRIPT" adversarial-review --wait
+```
+
+**Background (anything bigger):**
+
+Launch the same command with `Bash(..., run_in_background: true)` and tell the user:
+"Codex second pass started in the background. Check `/codex:status` for progress."
+
+**Focus text** — carry the analysis question and the DS failure modes:
+
+```bash
+node "$CODEX_SCRIPT" adversarial-review --wait "focus: data leakage between train/test, join row-count fan-out, filters applied after the split, parameters that contradict .planning/SPEC.md"
+```
+
+### 7. Parse verdict
+
+Codex returns JSON validated against its review-output schema: `verdict`
+(`approve` | `needs-attention`), `summary`, `findings[]`, `next_steps[]`. Each
+finding has `severity`, `title`, `body`, `file`, `line_start`, `line_end`,
+`confidence` (0-1 float), `recommendation`.
+
+**Apply the iron law: only `confidence >= 0.8` findings block.** Multiply by 100
+when displaying alongside Claude-style scores.
+
+| Codex result | Second-pass outcome |
+|--------------|---------------------|
+| `verdict: approve` | APPROVED — proceed to Phase Complete's APPROVED write |
+| `needs-attention` + any finding ≥ 0.8 confidence | CHANGES_REQUIRED — overrides the primary reviewer's APPROVED |
+| `needs-attention` + all findings < 0.8 | APPROVED (log advisory findings to LEARNINGS.md) |
+
+**A Codex CHANGES_REQUIRED overrides the primary APPROVED.** The primary
+reviewer does not get a veto over the second pass — if it did, the second pass
+would be decorative.
+
+If Codex fails to run (non-zero exit, unparseable output): record
+`codex_second_pass: error` and report the failure to the user. Do **not**
+silently treat a broken second pass as an approval — an unrun reviewer is not a
+passing reviewer.
+
+### 8. Tag findings to requirements
+
+Codex doesn't know SPEC.md REQ-IDs. For each blocking finding: read
+`.planning/SPEC.md`, tag it with the most likely REQ-ID (or `OUT-OF-SPEC`).
+`OUT-OF-SPEC` findings are advisory unless the user opts in.
+
+### 9. Report
+
+Use the same output structure as the Claude paths, with **Reviewer: Codex
+(second pass)** in the header. Each issue includes the Codex confidence (×100)
+and the REQ-ID you tagged in step 8.
+
+### 10. Iteration & re-review
+
+The second pass participates in the same `REVIEW_STATE.md` loop — a blocking
+second pass increments iteration and returns CHANGES_REQUIRED, escalating at
+iteration 3 like any other verdict. On the next iteration the order repeats in
+full: primary review first, second pass only if the primary approves.
 
 ---
 
@@ -200,11 +366,21 @@ After ALL reviewers message completion, the lead performs three passes.
    └──────────────────┘            ┌── yes ──┴── no ──┐
                                    ▼                  ▼
                           ┌────────────────┐ ┌────────────────┐
-                          │ CHANGES REQ'D →│ │ APPROVED →     │
-                          │ /ds-implement  │ │ ds-verify      │
-                          │ (max 3 cycles) │ └────────────────┘
-                          └────────────────┘
+                          │ CHANGES REQ'D →│ │ APPROVED       │
+                          │ /ds-implement  │ │ (primary only) │
+                          │ (max 3 cycles) │ └───────┬────────┘
+                          └────────────────┘         │
+                                                     ▼
+                                          ┌─────────────────────┐
+                                          │ Phase Complete      │
+                                          │ → Codex second pass │
+                                          │ → then ds-verify    │
+                                          └─────────────────────┘
 ```
+
+The primary APPROVED terminates at Phase Complete, not at ds-verify — Phase
+Complete is the only section that runs the second pass and writes
+`status: APPROVED`.
 
 <EXTREMELY-IMPORTANT>
 **Pass 1 — Deduplication:**
@@ -309,10 +485,16 @@ X critical and Y important issues must be addressed. Return to /ds-implement.
 
 After parallel review completes:
 
-**If APPROVED:** Immediately discover and load the ds-verify skill:
-Read `${CLAUDE_SKILL_DIR}/../../skills/ds-verify/SKILL.md` and follow its instructions.
+Parallel review produces a *primary* verdict — it is not a terminal state. Do
+NOT load ds-verify or write `status: APPROVED` from here.
 
-**If CHANGES REQUIRED:** Return to `/ds-implement` to fix reported issues.
+Go to [Phase Complete](#phase-complete) and follow it for every verdict. Phase
+Complete is the single authority that runs the Codex second pass, writes
+`.planning/REVIEW_STATE.md`, and invokes ds-verify.
+
+A branch-local "APPROVED → ds-verify" shortcut would let the parallel path reach
+verification without the second pass ever running, being declined, or being
+recorded — which is exactly the bypass the second pass exists to prevent.
 
 **Maximum 3 review cycles.** If issues persist after 3 rounds of review → implement → re-review, escalate to the user with a summary of unresolved issues. Do not loop indefinitely.
 
@@ -769,6 +951,17 @@ After review completes, handle verdict-specific transitions:
 
 ### If APPROVED (no issues >= 80 confidence)
 
+**STOP — run the [Codex Second Pass](#codex-second-pass) first.** A primary
+APPROVED is a candidate verdict, not a final one. Writing `status: APPROVED`
+before the second pass runs would hand ds-verify a gate that no second reviewer
+ever saw.
+
+Order of operations:
+
+1. Run the Codex second pass (it self-skips when Codex is unavailable or declined).
+2. If it returns **CHANGES_REQUIRED**, follow [If CHANGES REQUIRED](#if-changes-required-issues--80-confidence-found-iteration--3) instead of this section.
+3. Only if it returns **APPROVED** (or self-skipped), write the state below.
+
 Mark review complete in `.planning/REVIEW_STATE.md`:
 
 ```yaml
@@ -778,14 +971,65 @@ iteration: [N]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: 0
+codex_second_pass: enabled | declined | unavailable
 verdict: APPROVED
 ---
 ```
+
+`codex_second_pass` records what actually happened, so a later reader can tell
+"Codex approved this" from "Codex never ran." Never write `enabled` unless a
+Codex run actually returned a verdict.
+
+**`error` is not a valid value under `status: APPROVED`** — those three are the
+only ones. A failed second pass has no verdict, so it cannot support an
+approval; see [If the Codex second pass errored](#if-the-codex-second-pass-errored).
 
 **`status: APPROVED` is the structural gate field** — ds-verify declares a PreToolUse `phase-gate-guard.py` hook that blocks Agent dispatch until `.planning/REVIEW_STATE.md` shows `status: APPROVED`. While the review loop is unresolved (CHANGES_REQUIRED / ESCALATE), `status` is NOT `APPROVED`, so verification is structurally blocked.
 
 Immediately discover and load ds-verify:
 Read `${CLAUDE_SKILL_DIR}/../../skills/ds-verify/SKILL.md` and follow its instructions.
+
+### If the Codex second pass errored
+
+Codex ran but produced no verdict (non-zero exit, unparseable output). **This is
+not an approval and not a rejection — it is an absence of evidence.** Do NOT
+write `status: APPROVED` and do NOT load ds-verify.
+
+Record the attempt and leave the gate closed:
+
+```yaml
+---
+status: BLOCKED
+iteration: [N]          # unchanged — no review verdict was produced
+max_iterations: 3
+last_review_date: [date]
+issues_found_count: [count from the primary review]
+codex_second_pass: error
+verdict: BLOCKED
+---
+```
+
+Report the failure to the user and ask how to proceed:
+
+```python
+AskUserQuestion(questions=[{
+  "question": "The Codex second pass failed to produce a verdict. How should we proceed?",
+  "header": "Second Pass",
+  "options": [
+    {"label": "Retry the second pass", "description": "Re-run Codex. Transient failures (auth expiry, a dropped thread) usually clear on a retry."},
+    {"label": "Approve without it", "description": "Record codex_second_pass: declined and proceed to ds-verify on the primary review alone. The analysis is reviewed by Claude only."}
+  ],
+  "multiSelect": false
+}])
+```
+
+- **Retry** → return to [Codex Second Pass](#codex-second-pass) step 2.
+- **Approve without it** → rewrite `codex_second_pass: declined` and follow
+  [If APPROVED](#if-approved-no-issues--80-confidence) from the top.
+
+Only an explicit user decision converts an `error` into a path forward. Silently
+downgrading it to an approval is the fabricated-verdict failure this skill exists
+to prevent.
 
 ### If CHANGES REQUIRED (issues >= 80 confidence found, iteration < 3)
 
@@ -798,11 +1042,19 @@ iteration: [N+1]
 max_iterations: 3
 last_review_date: [date]
 issues_found_count: [count]
+codex_second_pass: enabled | declined | unavailable
 verdict: CHANGES_REQUIRED
 ---
 ```
 
+Carry `codex_second_pass` forward unchanged — the decision is made once per
+review loop, not re-asked on each iteration.
+
 Return to `/ds-implement` with specific issues. **Analyst MUST re-invoke /ds-review after fixes.**
+
+When the blocking findings came from the second pass, say so in the handoff
+("Codex second pass, REQ-DATA-03, confidence 91") — the analyst needs to know
+which reviewer to satisfy.
 
 **Critical:** When analyst returns claiming "fixed", you MUST re-run the FULL review. No shortcuts.
 
@@ -842,7 +1094,8 @@ Which option do you prefer?
 
 | Verdict | Next Action | Iteration Counter |
 |---------|-------------|-------------------|
-| APPROVED | Invoke /ds-verify immediately | Reset to 1 for next analysis |
+| APPROVED (primary) | Run the [Codex Second Pass](#codex-second-pass) before writing `status: APPROVED` | No change (not a terminal verdict) |
+| APPROVED (second pass done/skipped) | Invoke /ds-verify immediately | Reset to 1 for next analysis |
 | CHANGES REQUIRED | Return to /ds-implement, analyst fixes then re-invokes /ds-review | Increment |
 | ESCALATE | Ask user for direction | Keep at max |
 

--- a/skills/ds-verify/SKILL.md
+++ b/skills/ds-verify/SKILL.md
@@ -44,9 +44,9 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
-            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
+            GATE_REQUIRE_FIELDS="codex_second_pass:completed|declined|unavailable"
             GATE_DESCRIPTION="Review verdict"
-            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
+            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then. REVIEW_STATE.md must also record codex_second_pass: completed (Codex returned a verdict) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). codex_second_pass: requested means the second pass was launched but has not returned — join it (read the file named by codex_output_file) before verifying; a launched-but-unjoined pass is not a completed one. codex_second_pass: error is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             GATE_BLOCKED_TOOLS=Agent
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
 ---

--- a/skills/ds-verify/SKILL.md
+++ b/skills/ds-verify/SKILL.md
@@ -44,8 +44,9 @@ hooks:
           command: >-
             GATE_ARTIFACT=.planning/REVIEW_STATE.md
             GATE_STATUS=APPROVED
+            GATE_REQUIRE_FIELDS="codex_second_pass:enabled|declined|unavailable"
             GATE_DESCRIPTION="Review verdict"
-            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then."
+            GATE_REMEDY="Complete ds-review until REVIEW_STATE.md verdict is APPROVED; verification is gated until then. REVIEW_STATE.md must also record codex_second_pass: enabled (Codex ran) | declined (user opted out) | unavailable (Codex not installed/ready, or no git repo). An errored second pass (codex_second_pass: error) is an absence of evidence, not an approval — retry it or have the user explicitly decline."
             GATE_BLOCKED_TOOLS=Agent
             uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/phase-gate-guard.py
 ---

--- a/skills/workflow-creator/SKILL.md
+++ b/skills/workflow-creator/SKILL.md
@@ -1710,7 +1710,7 @@ If verification only checks Level 1 (exists), it's theater. A workflow that clai
 - Specifically check for: **phase gate enforcement** (prerequisite artifact checks), file extension guards, path guards, tool parameter validation, tool sequence enforcement, post-subagent restrictions
 - Behavioral/motivational constraints (rationalization tables, drive-aligned framing) should STAY as prompt — hooks can't teach reasoning
 - Score based on: how many mechanical constraints are prompt-only when they could be hooks?
-- **Mechanical sub-probe (COVERAGE, not presence — RUN it, do not eyeball):** P20 is NOT satisfied by the mere existence of some hooks. Grep the skill bodies for every IMPERATIVE script-step — bang-lines (`` !`…` ``) and phrases like "run `X`", "must run", "first run", "uv run", "run check-all", "run the … script". For each that is mechanically checkable (a script that exits non-zero / emits a checkable artifact), confirm a hook **or** bang-line actually guarantees it, matching the hook's **matcher + command** to the step. Two false-positives to reject: (a) other unrelated hooks do not cover this step; (b) a gate whose matcher is `Write|Edit|Agent` does NOT cover a step that must precede a **`Workflow`/`Agent` fan-out** (the matcher must include the gated tool). Any mechanically-checkable imperative step with no matching enforcing mechanism is a P20 gap — even when the skill has other hooks. (Real miss this encodes: "run check-all before the review fan-out" sat in skippable prose while a hook on `VALIDATION.md` existence looked like it satisfied "phase gate enforcement.")
+- **Mechanical sub-probe (COVERAGE, not presence — RUN it, do not eyeball):** P20 is NOT satisfied by the mere existence of some hooks. Grep the skill bodies for every IMPERATIVE script-step — bang-lines (`` !`…` ``) and phrases like "run `X`", "must run", "first run", "uv run", "run check-all", "run the … script". For each that is mechanically checkable (a script that exits non-zero / emits a checkable artifact), confirm a hook **or** bang-line actually guarantees it, matching the hook's **matcher + command** to the step. Two false-positives to reject: (a) other unrelated hooks do not cover this step; (b) a gate whose matcher is `Write|Edit|Agent` does NOT cover a step that must precede a **`Workflow`/`Agent` fan-out** (the matcher must include the gated tool). Any mechanically-checkable imperative step with no matching enforcing mechanism is a P20 gap — even when the skill has other hooks. **P20 scores COVERAGE, never VALIDITY:** a hook can cover its step perfectly and still emit a payload the harness discards, at which point it enforces nothing. That is Step 3c's job — score P20 on coverage and let the hook-contract harness decide whether the covering hook actually works. (Real miss this encodes: "run check-all before the review fan-out" sat in skippable prose while a hook on `VALIDATION.md` existence looked like it satisfied "phase gate enforcement.")
 
 **P21 — Auto-loader usage for constraints:**
 - Do phase skills that load constraint prose use the bang-invoked auto-loader?
@@ -1895,6 +1895,79 @@ affects: [.planning/wc/{name}/STATE.md]
 one-liner: "Path portability scored Clean/Partial/Broken; hook-command variable audit run; candidacy scan fed into Step 4."
 ```
 
+**Proceed to Step 3c.**
+
+### Step 3c: Validate the Hook OUTPUT Contract (RUN it — do not read the hooks)
+
+Steps 3a/3b and P20 all check a hook's **wiring**: does it exist, does its `command:` resolve,
+does its `matcher` cover the step it gates. **None of them check whether the hook's OUTPUT is
+legal for the event it is wired to** — and that is a distinct, entirely silent failure mode.
+
+**Why this is its own step.** When a hook emits a field its event does not accept, Claude Code
+rejects the **entire** payload (`Hook JSON output validation failed — (root): Invalid input`).
+The hook still runs, still exits 0, still prints nothing a human sees. A `deny` becomes an
+allow; an `additionalContext` never reaches Claude. The audit sees a hook wired to the right
+tool with a resolving path and scores it Present — while it enforces nothing. This is strictly
+worse than a missing hook, because the presence of the hook is what stops anyone looking.
+
+This is the same silent-failure family as the April 2026 `${CLAUDE_SKILL_DIR}` incident above —
+note that the guard quoted there defaults to `{"decision": "approve"}`, which is itself not a
+valid payload for any event. The class was diagnosed as a *path* problem; the *payload* half
+went unexamined for another year.
+
+**Real incident (July 2026).** `hooks/pre-compact.py` emitted
+`hookSpecificOutput.additionalContext` on `PreCompact`, which accepts no `hookSpecificOutput` at
+all. Its "the `/ds` workflow was active before compaction — reload it" instruction was dropped
+after **every** compaction, so the workflow's Iron Laws stopped being enforced for the rest of
+each session. Running the harness for the first time found **8 more broken scripts** in the same
+repo, including `ds-no-main-chat-code-guard.py` — the hook enforcing "YOU MUST NOT WRITE ANALYSIS
+CODE IN MAIN CHAT" — which emitted `{"decision": "block", "message": …}` on `PreToolUse`, an
+event with no top-level `decision` field. Every `deny` it ever issued was discarded.
+
+**How to score it — execute, do not eyeball:**
+
+```bash
+cd "$PROJECT" && ./scripts/check-hooks.sh --report
+```
+
+The harness (`tests/hook_output_schema_test.py` + `scripts/checks/hook_output_schema.py`)
+discovers every wiring from `hooks/hooks.json` **and** every `hooks:` frontmatter block in
+`skills/*/SKILL.md`, feeds each realistic payloads, and validates the emitted JSON against the
+per-event schema from <https://code.claude.com/docs/en/hooks.md>. Reading a hook cannot
+substitute for running it: the invalid branch is usually the *block* branch, which only a real
+payload reaches.
+
+Three defects it catches, none of which any other step sees:
+1. **Wrong shape for the event** — `hookSpecificOutput` on `PreCompact`/`SessionEnd`/`Notification`;
+   a top-level `decision` on `PreToolUse` (gates go through `hookSpecificOutput.permissionDecision`);
+   `decision: "allow"` anywhere (only `"block"` exists); invented fields like
+   `{"result": "continue"}` or `"message"`.
+2. **`hookEventName` disagreeing with the wiring** — including a hook wired to *two* events that
+   hardcodes one of them. Read `hook_event_name` off the payload instead.
+3. **Exit code used as a decision** — on `PreToolUse` only exit **2** blocks; any other non-zero
+   is a non-blocking error, so `sys.exit(1)` after printing a block message is a no-op.
+
+**Score:**
+- **Clean** — every wiring the harness exercised emits a payload its event accepts
+- **Broken** — one or more INVALID wirings. **Each is a critical finding** and fails the
+  substrate gate. Never downgrade one because the hook "looks correct" — the harness is the
+  authority, not a reading of the source.
+- **NotRun** — the audited repo has no harness. Note it as a minor finding and say plainly that
+  hook payload validity was **not** checked.
+
+**Gate: Hook Contract Validated** `[checkpoint: deterministic]`
+- `./scripts/check-hooks.sh` exits 0, or every INVALID wiring is recorded as a critical finding
+
+Update `.planning/wc/{name}/STATE.md`:
+```yaml
+step: 3c-hook-contract
+status: completed
+requires: [scripts/check-hooks.sh, all wired hooks]
+provides: [hook output-contract status]
+affects: [.planning/wc/{name}/STATE.md]
+one-liner: "Hook output contract executed against the per-event schema; INVALID wirings recorded as criticals."
+```
+
 #### Ultracode-Workflow Candidacy Scan (feeds Step 4 Recommendations — no separate gate)
 
 Before writing the report, scan every phase for **ultracode-workflow migration candidates** — fan-out phases that should be Claude Code ultracode workflows rather than in-skill agent dispatch. Read `${CLAUDE_SKILL_DIR}/references/dynamic-workflow-migration.md` §1 for the rubric. **Scan for BOTH worker modes — workflows are NOT read-only:**
@@ -1983,6 +2056,15 @@ Format:
 |------|---------|--------|
 | skills/X/SKILL.md | `uv run python3 scripts/foo.py` | ❌ Broken / ✅ Fixed |
 | skills/Y/SKILL.md | `Read("../../lib/...")` | ❌ Broken / ✅ Fixed |
+
+### Hook Output Contract
+| Hook | Event | Verdict | Violation |
+|------|-------|---------|-----------|
+| hooks/X.py | PreToolUse | ✅ Valid / ❌ INVALID | [the harness's verbatim message] |
+
+(From `./scripts/check-hooks.sh --report` — executed, not read. Every ❌ is a critical finding
+and fails the substrate gate: an invalid payload is discarded whole, so the hook silently stops
+enforcing while still appearing wired.)
 
 ### Ultracode-Workflow Migration Candidates
 | Phase | Fan-out? | Worker mode (review/transform) | Value driver | Recommend migrate? (strong/moderate) | Note |

--- a/tests/codex_second_pass_join_test.py
+++ b/tests/codex_second_pass_join_test.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env -S uv run python3
+"""The Codex second-pass join protocol, end-to-end against the real gate hook.
+
+Two bypasses motivate this file, both found by adversarial review:
+
+  1. The skill recorded consent (`enabled`) BEFORE invoking Codex, while the
+     verify gate treated that value as proof Codex had run. Combined with a
+     `status: APPROVED` left over from a previous task — the loop resets
+     `iteration`, not `status` — verification was reachable while Codex was
+     still running, had crashed, or had never started.
+  2. The background path launched a detached run and advanced straight to
+     "parse verdict" with no defined way to retrieve it.
+
+So the states are now: `requested` (launched, no answer) -> `completed` (answer
+parsed) | `error` (ran, failed). Only terminal states admit verify, and the
+skill writes a non-approved `status` BEFORE launching so the window in (1) never
+exists.
+
+This test drives the actual verdict-extraction snippet from the SKILL.md files
+against real payload shapes, and asserts the hook blocks at every non-terminal
+point. Run: uv run python3 tests/codex_second_pass_join_test.py
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / 'hooks' / 'phase-gate-guard.py'
+FIELDS = 'codex_second_pass:completed|declined|unavailable'
+
+F = []
+
+
+def check(name, cond):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}")
+    if not cond:
+        F.append(name)
+
+
+def gate_allows(body):
+    """Would dev-verify's Agent dispatch be allowed against this REVIEW_STATE.md?"""
+    with tempfile.TemporaryDirectory() as td:
+        art = Path(td) / 'REVIEW_STATE.md'
+        art.write_text(body)
+        env = {**os.environ, 'GATE_ARTIFACT': str(art), 'GATE_STATUS': 'APPROVED',
+               'GATE_BLOCKED_TOOLS': 'Agent', 'GATE_REQUIRE_FIELDS': FIELDS}
+        proc = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps({'tool_name': 'Agent', 'tool_input': {}}),
+            capture_output=True, text=True, env=env,
+        )
+        out = proc.stdout.strip()
+        if not out:
+            return True
+        return json.loads(out)['hookSpecificOutput'].get('permissionDecision') != 'deny'
+
+
+def extraction_snippet():
+    """The verdict-extraction script that dev-review actually tells agents to run.
+
+    Pulled from the SKILL.md rather than duplicated: if the documented snippet
+    and the tested one drift apart, the test is worthless.
+    """
+    text = (REPO / 'skills' / 'dev-review' / 'SKILL.md').read_text()
+    m = re.search(r"### 7\. Join the run.*?```bash\nuv run python3 - <<'PY'\n(.*?)\nPY\n```",
+                  text, re.S)
+    assert m, "could not find the join snippet in dev-review/SKILL.md"
+    return m.group(1)
+
+
+def run_extraction(output_file, handle='codex-second-pass-iter2.json',
+                   state_handle=None, extra_files=None, omit_handle=False):
+    """Run the documented snippet against a synthetic .planning/ directory.
+
+    handle       — where the payload is actually written
+    state_handle — what REVIEW_STATE.md claims the pass owns (defaults to handle)
+    extra_files  — {name: contents} written alongside, e.g. a previous
+                   iteration's leftover verdict
+    """
+    snippet = extraction_snippet()
+    with tempfile.TemporaryDirectory() as td:
+        planning = Path(td) / '.planning'
+        planning.mkdir()
+        claimed = state_handle or handle
+        handle_line = '' if omit_handle else f"codex_output_file: .planning/{claimed}\n"
+        (planning / 'REVIEW_STATE.md').write_text(
+            "---\nstatus: SECOND_PASS_PENDING\niteration: 2\n"
+            f"codex_second_pass: requested\n{handle_line}"
+            "verdict: SECOND_PASS_PENDING\n---\n"
+        )
+        if output_file is not None:
+            (planning / handle).write_text(output_file)
+        for name, body in (extra_files or {}).items():
+            (planning / name).write_text(body)
+        proc = subprocess.run([sys.executable, '-c', snippet],
+                              cwd=td, capture_output=True, text=True)
+        return proc.stdout.strip()
+
+
+
+def clear_command():
+    """The documented handle-clearing command from dev-review, iteration 2."""
+    text = (REPO / 'skills' / 'dev-review' / 'SKILL.md').read_text()
+    m = re.search(r"```bash\n# substitute this iteration's N\n(OUT=.*?)\n```", text, re.S)
+    assert m, "could not find the handle-clear command in dev-review/SKILL.md"
+    return m.group(1).replace('[N]', '2')
+
+
+def run_clear(make_undeletable, stale=None):
+    """Run the documented clear in a .planning/ that may refuse deletion.
+
+    Returns (exit_code, stdout, stale_file_survived).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        planning = Path(td) / '.planning'
+        planning.mkdir()
+        handle = planning / 'codex-second-pass-iter2.json'
+        if stale is not None:
+            handle.write_text(stale)
+        if make_undeletable:
+            os.chmod(planning, 0o500)      # read+execute: cannot unlink entries
+        try:
+            proc = subprocess.run(['bash', '-c', clear_command()],
+                                  cwd=td, capture_output=True, text=True)
+            return proc.returncode, proc.stdout.strip(), handle.exists()
+        finally:
+            os.chmod(planning, 0o700)      # let TemporaryDirectory clean up
+
+# The real envelope shape: codex.stdout is the verdict as a JSON *string*.
+def envelope(verdict_obj, status=0):
+    return json.dumps({
+        'review': 'Adversarial Review',
+        'target': {'mode': 'branch', 'label': 'branch diff against main'},
+        'threadId': '019f-test',
+        'codex': {'status': status, 'stderr': '', 'stdout': json.dumps(verdict_obj)},
+    })
+
+
+APPROVE = {'verdict': 'approve', 'summary': 'ok', 'findings': [], 'next_steps': []}
+BLOCKING = {
+    'verdict': 'needs-attention', 'summary': 'no', 'next_steps': [],
+    'findings': [{'severity': 'high', 'title': 'real bug', 'body': 'b',
+                  'file': 'x.py', 'line_start': 1, 'line_end': 2,
+                  'confidence': 0.94, 'recommendation': 'fix'}],
+}
+ADVISORY = {
+    'verdict': 'needs-attention', 'summary': 'maybe', 'next_steps': [],
+    'findings': [{'severity': 'low', 'title': 'nit', 'body': 'b',
+                  'file': 'x.py', 'line_start': 1, 'line_end': 2,
+                  'confidence': 0.4, 'recommendation': 'consider'}],
+}
+
+# --- The gate at every point in the state machine ------------------------------
+
+# The bypass: consent recorded before the run, stale APPROVED still on disk.
+check('requested + stale APPROVED -> BLOCKED (the reported bypass)',
+      not gate_allows("---\nstatus: APPROVED\ncodex_second_pass: requested\n---\n"))
+
+# The pending status the skill writes before launching.
+check('SECOND_PASS_PENDING -> blocked',
+      not gate_allows("---\nstatus: SECOND_PASS_PENDING\ncodex_second_pass: requested\n---\n"))
+
+check('IN_REVIEW (stale verdict invalidated at phase start) -> blocked',
+      not gate_allows("---\nstatus: IN_REVIEW\nverdict: IN_REVIEW\n---\n"))
+
+check('error (ran, no verdict) -> blocked',
+      not gate_allows("---\nstatus: APPROVED\ncodex_second_pass: error\n---\n"))
+
+check('retired `enabled` -> blocked',
+      not gate_allows("---\nstatus: APPROVED\ncodex_second_pass: enabled\n---\n"))
+
+# Terminal states that legitimately admit verify.
+for value in ('completed', 'declined', 'unavailable'):
+    check(f'{value} + APPROVED -> allowed',
+          gate_allows(f"---\nstatus: APPROVED\ncodex_second_pass: {value}\n---\n"))
+
+# A completed pass that BLOCKED must not admit verify either.
+check('completed + CHANGES_REQUIRED -> blocked',
+      not gate_allows("---\nstatus: CHANGES_REQUIRED\ncodex_second_pass: completed\n---\n"))
+
+# --- The documented extraction snippet, against real payloads ------------------
+
+out = run_extraction(envelope(APPROVE))
+check('join: approve verdict extracted', out.startswith('verdict: approve'))
+
+out = run_extraction(envelope(BLOCKING))
+check('join: needs-attention extracted', out.startswith('verdict: needs-attention'))
+check('join: confidence surfaced for the iron law', '0.94' in out)
+check('join: finding located', 'x.py:1' in out)
+
+out = run_extraction(envelope(ADVISORY))
+check('join: sub-threshold confidence surfaced', '0.40' in out)
+
+# Completion is not the only outcome. Each of these must be distinguishable
+# from a verdict, or the loop advances on nothing.
+check('join: missing output file -> PENDING (not a verdict)',
+      run_extraction(None).startswith('PENDING'))
+
+check('join: empty output file -> PENDING (still running / lost)',
+      run_extraction('').startswith('PENDING'))
+
+check('join: truncated JSON -> ERROR (not a verdict)',
+      run_extraction('{"codex": {"status": 0, "stdout": "{\\"verd').startswith('ERROR'))
+
+check('join: codex non-zero exit -> ERROR',
+      run_extraction(envelope(APPROVE, status=1)).startswith('ERROR'))
+
+check('join: envelope present but stdout not JSON -> ERROR',
+      run_extraction(json.dumps({'codex': {'status': 0, 'stdout': 'boom'}})).startswith('ERROR'))
+
+# --- A previous pass's verdict is not this pass's answer -----------------------
+#
+# The redirect only truncates the output when Codex is actually invoked. With a
+# single reused path, stopping between the `requested` write and the launch left
+# last iteration's `approve` on disk for the join to parse as the current answer.
+# The handle is now per-iteration and cleared before `requested` is recorded.
+
+stale_approve = envelope({'verdict': 'approve', 'summary': 'iteration 1 said yes',
+                          'findings': [], 'next_steps': []})
+
+check("stale: iteration 1's verdict is not joinable by iteration 2",
+      run_extraction(None, extra_files={'codex-second-pass-iter1.json': stale_approve})
+      .startswith('PENDING'))
+
+check('stale: a payload at some other path is never read',
+      run_extraction(stale_approve, handle='codex-second-pass.json',
+                     state_handle='codex-second-pass-iter2.json').startswith('PENDING'))
+
+check('handle: the join reads the path the state names, not a hardcoded one',
+      run_extraction(envelope(APPROVE), handle='codex-second-pass-iter7.json',
+                     state_handle='codex-second-pass-iter7.json')
+      .startswith('verdict: approve'))
+
+check('handle: no codex_output_file recorded -> ERROR, never a verdict',
+      run_extraction(stale_approve, handle='codex-second-pass-iter1.json',
+                     omit_handle=True).startswith('ERROR'))
+
+# --- The clear must be a verified precondition, not an assumption -------------
+#
+# `rm -f` is quiet both when the file never existed and when it cannot be
+# removed. If the clear silently fails, the launch redirect fails too, and the
+# join reads the OLD envelope as this pass's answer.
+
+code, out, survived = run_clear(make_undeletable=False, stale=None)
+check('clear: succeeds on a fresh handle', code == 0)
+
+code, out, survived = run_clear(make_undeletable=False, stale=stale_approve)
+check('clear: removes a stale handle', code == 0 and not survived)
+
+code, out, survived = run_clear(make_undeletable=True, stale=stale_approve)
+check('clear: FAILS LOUDLY when the handle cannot be removed', code != 0)
+check('clear: says why it refused', 'BLOCKED' in out)
+check('clear: the stale handle is still there (so requesting would be unsafe)', survived)
+
+# --- Resume: a fresh session finds `requested` and must not walk into verify ---
+check('resume: requested with no output file -> gate still shut',
+      not gate_allows("---\nstatus: SECOND_PASS_PENDING\ncodex_second_pass: requested\n"
+                      "codex_output_file: .planning/codex-second-pass.json\n---\n"))
+
+print()
+if F:
+    print(f"{len(F)} FAILED: {F}")
+    sys.exit(1)
+print('all codex second-pass join tests passed')
+sys.exit(0)

--- a/tests/hook_output_schema_test.py
+++ b/tests/hook_output_schema_test.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env -S uv run --with pytest --with pyyaml python3
+"""Contract test: every wired hook must emit a payload its event actually accepts.
+
+    Run:  ./scripts/check-hooks.sh
+    or:   uv run --with pytest --with pyyaml python3 -m pytest tests/hook_output_schema_test.py
+    or:   uv run --with pyyaml python3 tests/hook_output_schema_test.py     (prints a report table)
+
+WHAT IT CATCHES
+    An invalid hook payload does not raise, does not exit non-zero, and does not warn.
+    The harness rejects the whole object ("Hook JSON output validation failed --
+    (root): Invalid input") and the hook's message vanishes. hooks/pre-compact.py sat
+    broken in production this way: it emitted hookSpecificOutput.additionalContext on
+    PreCompact, which does not accept it, so the "reload the active workflow" reminder
+    never landed and the workflow Iron Laws stopped being enforced after compaction.
+
+HOW
+    1. Discover EVERY wiring -- hooks/hooks.json AND the `hooks:` frontmatter that each
+       skills/*/SKILL.md declares (the larger surface; most guards live only there).
+    2. Feed each (script, event, matcher) realistic stdin payloads inside a throwaway
+       project fixture, so the interesting branches actually fire.
+    3. Parse stdout; if it is a JSON object, validate against the per-event schema in
+       scripts/checks/hook_output_schema.py.
+    4. Also assert the hook exits 0 on payloads it should ignore -- a stray non-zero
+       exit is read as a decision (blocks the tool call on PreToolUse).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+try:
+    import pytest
+except ModuleNotFoundError:  # standalone report mode does not need pytest
+    pytest = None
+
+REPO = Path(__file__).resolve().parents[1]
+HOOKS = REPO / 'hooks'
+sys.path.insert(0, str(REPO / 'scripts' / 'checks'))
+from hook_output_schema import EVENTS, validate_payload  # noqa: E402
+
+TIMEOUT = 90
+
+
+# --------------------------------------------------------------------------- wiring
+
+def _wirings_from_hooks_json() -> list[tuple[str, str, str, str]]:
+    """(source, event, matcher, script) from hooks/hooks.json."""
+    out = []
+    cfg = json.loads((HOOKS / 'hooks.json').read_text())
+    for event, entries in cfg.get('hooks', {}).items():
+        for entry in entries:
+            matcher = entry.get('matcher', '*')
+            for h in entry.get('hooks', []):
+                script = _script_of(h.get('command', ''))
+                if script:
+                    out.append(('hooks.json', event, matcher, script))
+    return out
+
+
+def _wirings_from_skills() -> list[tuple[str, str, str, str]]:
+    """(source, event, matcher, script) from every skills/*/SKILL.md `hooks:` frontmatter."""
+    out = []
+    for skill_md in sorted((REPO / 'skills').glob('*/SKILL.md')):
+        text = skill_md.read_text(encoding='utf-8')
+        if not text.startswith('---'):
+            continue
+        parts = text.split('---', 2)
+        if len(parts) < 3:
+            continue
+        try:
+            fm = yaml.safe_load(parts[1]) or {}
+        except yaml.YAMLError:
+            continue
+        hooks = fm.get('hooks')
+        if not isinstance(hooks, dict):
+            continue
+        for event, entries in hooks.items():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                matcher = entry.get('matcher', '*')
+                for h in entry.get('hooks', []) or []:
+                    if not isinstance(h, dict):
+                        continue
+                    script = _script_of(h.get('command', ''))
+                    if script:
+                        out.append((f'skills/{skill_md.parent.name}', event, str(matcher), script))
+    return out
+
+
+def _script_of(command: str) -> str | None:
+    for token in command.split():
+        if token.endswith('.py') and '/hooks/' in token:
+            return token.rsplit('/hooks/', 1)[1]
+    return None
+
+
+def all_wirings() -> list[tuple[str, str, str, str]]:
+    seen, out = set(), []
+    for w in _wirings_from_hooks_json() + _wirings_from_skills():
+        key = (w[1], w[2], w[3])  # dedupe on event+matcher+script, keep first source
+        if key not in seen:
+            seen.add(key)
+            out.append(w)
+    return out
+
+
+WIRINGS = all_wirings()
+
+
+# -------------------------------------------------------------------------- payloads
+
+TOOL_FIXTURES = {
+    'Write': {'file_path': 'drafts/section-01.md', 'content': '# Draft\n\nSome prose here.\n'},
+    'Edit': {'file_path': 'analysis/model.py', 'old_string': 'a', 'new_string': 'b'},
+    'MultiEdit': {'file_path': 'drafts/section-01.md', 'edits': []},
+    'Read': {'file_path': 'figures/plot.png'},
+    'Bash': {'command': 'pixi run python analysis/model.py', 'description': 'run model'},
+    'Task': {'description': 'analyze', 'prompt': 'do the thing', 'subagent_type': 'general-purpose'},
+    'Agent': {'description': 'analyze', 'prompt': 'do the thing'},
+    'Grep': {'pattern': 'foo'},
+    'Glob': {'pattern': '**/*.py'},
+    'Workflow': {'workflow': 'ds-validate-coverage'},
+    'Skill': {'skill': 'wrds'},
+}
+
+# Tools worth exercising per event when the matcher is a wildcard.
+DEFAULT_TOOLS = ['Write', 'Edit', 'Bash', 'Read', 'Task']
+
+
+def tools_for(matcher: str) -> list[str]:
+    if not matcher or matcher in ('*', '.*'):
+        return DEFAULT_TOOLS
+    names = [t.strip() for t in matcher.split('|') if t.strip()]
+    known = [t for t in names if t in TOOL_FIXTURES]
+    return known or DEFAULT_TOOLS
+
+
+def payloads_for(event: str, matcher: str, cwd: str) -> list[dict]:
+    """Realistic stdin payloads for this event, covering the branches a hook may take."""
+    base = {
+        'session_id': 'test-session',
+        'transcript_path': str(Path(cwd) / 'transcript.jsonl'),
+        'cwd': cwd,
+        'hook_event_name': event,
+        'permission_mode': 'default',
+    }
+    if event in ('PreToolUse', 'PostToolUse', 'PostToolUseFailure'):
+        out = []
+        for tool in tools_for(matcher):
+            p = dict(base, tool_name=tool, tool_input=TOOL_FIXTURES[tool])
+            if event != 'PreToolUse':
+                p['tool_response'] = {'stdout': 'https://github.com/o/r/pull/12', 'output': 'ok'}
+                p['tool_result'] = p['tool_response']
+            out.append(p)
+        return out
+    if event == 'PostToolBatch':
+        return [dict(base, tool_uses=[{'tool_name': 'Write', 'tool_input': TOOL_FIXTURES['Write']}])]
+    if event == 'SessionStart':
+        return [dict(base, source=s) for s in ('startup', 'resume', 'clear', 'compact')]
+    if event == 'SessionEnd':
+        return [dict(base, reason=r) for r in ('clear', 'logout', 'other')]
+    if event == 'PreCompact':
+        return [dict(base, trigger=t, custom_instructions='') for t in ('manual', 'auto')]
+    if event in ('SubagentStart',):
+        return [dict(base, agent_type='general-purpose', prompt='write the pipeline')]
+    if event in ('Stop', 'SubagentStop'):
+        return [dict(base, stop_hook_active=False)]
+    if event == 'UserPromptSubmit':
+        return [dict(base, prompt='run the analysis')]
+    return [base]
+
+
+def make_project(root: Path) -> None:
+    """A throwaway project that looks live enough to fire the interesting branches."""
+    planning = root / '.planning'
+    planning.mkdir(parents=True, exist_ok=True)
+    (planning / 'PLAN.md').write_text(
+        '## DS Workflow\n\n/ds\n\n### Skills Touched\n\n- `wrds` — TAQ millisecond data\n'
+    )
+    (planning / 'SPEC.md').write_text('# SPEC\n\n- `wrds` — TAQ data model\n')
+    (planning / 'STATE.md').write_text('# STATE\n\n## Active workflow: /ds\n')
+    (planning / 'LEARNINGS.md').write_text('# LEARNINGS\n')
+    (planning / 'ACTIVE_WORKFLOW.md').write_text(
+        '---\nworkflow: writing\nphase: draft\nstyle: volokh\n'
+        'edits_since_verify: 9\nverify_threshold: 10\n---\n'
+    )
+    (planning / 'PRECIS.md').write_text('# PRECIS\n\n## Thesis\n\nx\n')
+    (root / '.claude').mkdir(exist_ok=True)
+    (root / '.claude' / 'LEARNINGS.md').write_text('# LEARNINGS\n')
+    (root / '.claude' / 'PLAN.md').write_text('## DS Workflow\n')
+    for d in ('drafts', 'outlines', 'analysis', 'figures'):
+        (root / d).mkdir(exist_ok=True)
+    (root / 'drafts' / 'section-01.md').write_text('# Section\n\nProse without a claim id.\n')
+    (root / 'analysis' / 'model.py').write_text('import pandas as pd\n')
+    (root / 'transcript.jsonl').write_text(
+        json.dumps({'type': 'human', 'content': "no, don't do that again"}) + '\n'
+        + json.dumps({'type': 'human', 'content': 'i already told you, wrong'}) + '\n'
+    )
+
+
+def run_hook(script: str, payload: dict, cwd: str) -> tuple[int, str, str]:
+    env = dict(os.environ)
+    env['CLAUDE_PLUGIN_ROOT'] = str(REPO)
+    env['CLAUDE_PROJECT_DIR'] = cwd
+    env['CLAUDE_SESSION_ID'] = 'hook-schema-test'
+    # Some hooks read tool input from this env var instead of stdin. Populate it so the
+    # test exercises whatever path they take -- the point is the OUTPUT shape.
+    env['CLAUDE_TOOL_INPUT'] = json.dumps(payload.get('tool_input', {}))
+    proc = subprocess.run(
+        ['uv', 'run', 'python3', str(HOOKS / script)],
+        input=json.dumps(payload), capture_output=True, text=True,
+        cwd=cwd, env=env, timeout=TIMEOUT,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def check_one(script: str, event: str, matcher: str) -> list[str]:
+    """Run every payload for this wiring; return schema/exit violations."""
+    problems: list[str] = []
+    tmp = tempfile.mkdtemp(prefix='hookcheck-')
+    try:
+        for payload in payloads_for(event, matcher, tmp):
+            make_project(Path(tmp))
+            try:
+                code, stdout, stderr = run_hook(script, payload, tmp)
+            except subprocess.TimeoutExpired:
+                problems.append(f'{script} [{event}] timed out after {TIMEOUT}s')
+                continue
+
+            tool = payload.get('tool_name', '-')
+            where = f'{script} [{event}/{tool}]'
+
+            if code not in (0, 2):
+                problems.append(f'{where} exited {code} (only 0, or a deliberate 2, are safe)\n{stderr[:400]}')
+
+            text = stdout.strip()
+            if not text:
+                continue
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                # Plain text on stdout is fine -- it is treated as context (or ignored).
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            for err in validate_payload(event, parsed):
+                problems.append(f'{where} {err}\n    emitted: {text[:300]}')
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return problems
+
+
+# ----------------------------------------------------------------------------- tests
+
+_parametrize = (
+    pytest.mark.parametrize(
+        'source,event,matcher,script',
+        WIRINGS,
+        ids=[f'{w[1]}:{w[3]}:{w[2]}' for w in WIRINGS],
+    )
+    if pytest is not None
+    else (lambda fn: fn)
+)
+
+
+@_parametrize
+def test_wired_hook_emits_valid_payload(source, event, matcher, script):
+    assert event in EVENTS, f'{source} wires an unknown event {event!r}'
+    assert (HOOKS / script).exists(), f'{source} wires a missing script hooks/{script}'
+    problems = check_one(script, event, matcher)
+    assert not problems, (
+        f'{script} wired to {event} (matcher {matcher!r}, from {source}) emits payloads '
+        f'the harness will reject:\n  - ' + '\n  - '.join(problems)
+    )
+
+
+def test_every_wiring_names_a_real_event_and_script():
+    """Cheap structural check -- catches typos in an event name or a renamed script."""
+    bad = [
+        f'{src}: {ev}/{scr}'
+        for src, ev, _m, scr in WIRINGS
+        if ev not in EVENTS or not (HOOKS / scr).exists()
+    ]
+    assert not bad, 'invalid hook wiring:\n  ' + '\n  '.join(bad)
+
+
+def test_hookeventname_matches_wired_event():
+    """A hookSpecificOutput.hookEventName that disagrees with the wiring is rejected too.
+
+    Static, because the runtime check only sees the branches a fixture happens to
+    reach. suggest-compact.py hid here: it hardcoded "PreToolUse" but is ALSO wired to
+    PostToolUse by skills/workshop, and only emits after 50 edits — no fixture was ever
+    going to trip it.
+    """
+    by_script: dict[str, set[str]] = {}
+    for _src, ev, _m, scr in WIRINGS:
+        by_script.setdefault(scr, set()).add(ev)
+    bad = []
+    for script, events in sorted(by_script.items()):
+        src = (HOOKS / script).read_text(encoding='utf-8')
+        declared = {
+            ev for ev in EVENTS
+            if f'"hookEventName": "{ev}"' in src or f"'hookEventName': '{ev}'" in src
+        }
+        if not declared:
+            continue
+        # A hook that reads the event off the payload adapts to any wiring.
+        if 'hook_event_name' in src:
+            continue
+        stray = declared - events
+        if stray:
+            bad.append(f'{script} hardcodes hookEventName {sorted(stray)} but is wired to {sorted(events)}')
+        unhandled = events - declared
+        if unhandled:
+            bad.append(
+                f'{script} is wired to {sorted(unhandled)} but only ever emits hookEventName '
+                f'{sorted(declared)} — the payload will be rejected under that wiring. '
+                f'Read hook_event_name from the payload.'
+            )
+    assert not bad, '\n'.join(bad)
+
+
+# ------------------------------------------------------------------- regression cases
+
+def test_precompact_rejects_hookspecificoutput():
+    """THE regression: PreCompact does not accept hookSpecificOutput -- at all.
+
+    This is the exact payload hooks/pre-compact.py used to emit. The harness rejected
+    the whole object, so the workflow-reload instruction was silently dropped after
+    every compaction.
+    """
+    broken = {
+        'hookSpecificOutput': {
+            'hookEventName': 'PreCompact',
+            'additionalContext': 'the /ds workflow was active before compaction, reload it',
+        }
+    }
+    errors = validate_payload('PreCompact', broken)
+    assert errors, 'the validator must reject hookSpecificOutput on PreCompact'
+    assert any('does not support hookSpecificOutput' in e for e in errors)
+
+
+def test_pretooluse_rejects_top_level_decision():
+    """PreToolUse gates go through hookSpecificOutput.permissionDecision, not `decision`."""
+    errors = validate_payload('PreToolUse', {'decision': 'block', 'message': 'nope'})
+    assert any('does not support a top-level "decision"' in e for e in errors)
+    assert any("unsupported top-level field 'message'" in e for e in errors)
+
+
+def test_result_continue_is_not_a_schema():
+    """`{"result": "continue"}` is invented -- no event accepts it."""
+    for event in ('PostToolUse', 'PreToolUse', 'Stop'):
+        assert validate_payload(event, {'result': 'continue', 'message': 'hi'}), event
+
+
+def test_valid_payloads_pass():
+    assert validate_payload('PreCompact', {'systemMessage': 'saved'}) == []
+    assert validate_payload('PreCompact', {'decision': 'block', 'reason': 'wait'}) == []
+    assert validate_payload('PostToolUse', {
+        'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': 'x'}}) == []
+    assert validate_payload('PreToolUse', {'hookSpecificOutput': {
+        'hookEventName': 'PreToolUse', 'permissionDecision': 'deny',
+        'permissionDecisionReason': 'r'}}) == []
+    assert validate_payload('SubagentStart', {
+        'hookSpecificOutput': {'hookEventName': 'SubagentStart', 'additionalContext': 'x'}}) == []
+
+
+def test_wc_audit_has_a_hook_contract_dimension():
+    """The audit that was supposed to catch this must actually check it.
+
+    workflow-creator's P01-P30 review scored hooks on COVERAGE (P20) and on whether their
+    command PATH resolves (path-portability). Neither ever executed a hook, so a hook that
+    ran fine and emitted a payload the harness discarded scored clean. This asserts the
+    deterministic leg that closes that gap stays wired.
+    """
+    audit = (REPO / 'workflows' / 'wc-audit.js').read_text(encoding='utf-8')
+    assert "key: 'hook-contract'" in audit, 'wc-audit.js lost its hook-contract dimension'
+    assert 'check-hooks.sh' in audit, 'the hook-contract dimension must RUN the harness, not read the hooks'
+    assert "byDim['hook-contract']" in audit, 'hook-contract results must reach the gate'
+    assert "hookStatus === 'Clean'" in audit, 'hook-contract must be part of the substrate gate'
+
+    runner = REPO / 'scripts' / 'check-hooks.sh'
+    assert runner.exists(), 'scripts/check-hooks.sh is the documented entry point'
+    assert os.access(runner, os.X_OK), 'scripts/check-hooks.sh must be executable'
+
+
+# ------------------------------------------------------------------- standalone report
+
+def _report() -> int:
+    rows, failed = [], 0
+    for source, event, matcher, script in WIRINGS:
+        if event not in EVENTS or not (HOOKS / script).exists():
+            rows.append((script, event, matcher, 'WIRING ERROR', source))
+            failed += 1
+            continue
+        problems = check_one(script, event, matcher)
+        rows.append((script, event, matcher, 'VALID' if not problems else 'INVALID', source))
+        if problems:
+            failed += 1
+            for p in problems:
+                print(f'  ! {p}')
+    print()
+    print(f'{"hook script":<38} {"event":<14} {"matcher":<26} {"verdict":<8} source')
+    print('-' * 120)
+    for r in rows:
+        print(f'{r[0]:<38} {r[1]:<14} {r[2][:25]:<26} {r[3]:<8} {r[4]}')
+    print()
+    print(f'{len(rows) - failed}/{len(rows)} wirings valid')
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(_report())

--- a/tests/phase_gate_guard_differential_test.py
+++ b/tests/phase_gate_guard_differential_test.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env -S uv run python3
+"""Differential test: hooks/phase-gate-guard.py's frontmatter reader vs PyYAML.
+
+The reader is hand-rolled on purpose — every hook here is dependency-free, and
+this one fires on every tool call, so a gate that must resolve a package before
+it can answer is a gate that can fail open. That buys safety at the cost of
+owning YAML's edge cases, so this pins the reader against the real parser over a
+generated corpus.
+
+The oracle is `safe_load_all`: `---` is YAML's own document separator, so
+frontmatter is exactly document #1. (`safe_load` raises on a `---`-delimited
+file — it's a multi-document stream.)
+
+The bar is NOT "matches PyYAML everywhere". It is "never accepts a value PyYAML
+disagrees with":
+
+  exact       — reader and PyYAML agree.
+  fail-closed — reader returns '' (gate blocks) where PyYAML has a value. Safe:
+                a phase is blocked, never falsely approved. Decorated YAML
+                (anchors, tags, aliases, flow collections) lands here by design.
+  lenient     — reader returns the same value PyYAML *would* mean, on a document
+                PyYAML rejects outright (only: a stray trailing tab). Cannot
+                smuggle a wrong value; `status: APPROVED\tx` still blocks.
+  UNSAFE      — reader hands back something that satisfies a gate while PyYAML
+                disagrees. Must be zero.
+
+Run: uv run --with pyyaml python3 tests/phase_gate_guard_differential_test.py
+Skips cleanly when PyYAML isn't installed.
+"""
+
+import importlib.util
+import itertools
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print('SKIP: PyYAML not installed (run with: uv run --with pyyaml python3 ...)')
+    sys.exit(0)
+
+HOOK = Path(__file__).resolve().parent.parent / 'hooks' / 'phase-gate-guard.py'
+spec = importlib.util.spec_from_file_location('gate', HOOK)
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+# Values that would actually satisfy a real gate in this repo.
+GATE_VALUES = {'approved', 'enabled', 'declined', 'unavailable'}
+
+# Documents PyYAML rejects but where the gate line itself genuinely says what
+# the reader reports. Accepting them tolerates a corrupt file; it cannot
+# fabricate a value the artifact does not contain.
+#
+#   - a stray trailing tab (PyYAML rejects any trailing tab after a scalar);
+#   - malformed content in INDENTED lines, which the reader skips by design
+#     because indented content belongs to a parent key. Closing this would mean
+#     validating the whole document — a real YAML parser, the dependency this
+#     hook avoids on purpose (see its docstring's KNOWN RESIDUAL).
+#
+# Pinned here so the residual stays a known, bounded fact instead of drifting.
+LENIENT = {'---\nstatus: APPROVED\t\n---\n',
+           '---\nother: 1\nstatus: APPROVED\t\n---\n',
+           '--- \nstatus: APPROVED\t\n--- \n',
+           "---\nstatus: APPROVED\nprior:\n  broken: 'x' junk\n---\n"}
+
+
+def oracle(text):
+    """The `status` of the first YAML document, or '' when there isn't one."""
+    try:
+        docs = list(yaml.safe_load_all(text))
+    except Exception:
+        return '<invalid>'
+    if not docs or not isinstance(docs[0], dict):
+        return ''                       # not a mapping -> no status key at all
+    value = docs[0].get('status')
+    return '' if value is None else str(value)
+
+
+VALUES = [
+    # YAML needs whitespace before a trailing comment, so `'APPROVED'#x` is a
+    # syntax error, not a value plus a note.
+    "'APPROVED'#x", '"APPROVED"#x', "'APPROVED' #x", "APPROVED#x",
+    "APPROVED", "'APPROVED'", '"APPROVED"', "APPROVED # c", "'APPROVED # c'",
+    "'APPROVED'' # c'", '"APPR\\nOVED"', '"A\\PPROVED"', "APPROVED---x",
+    "&anc APPROVED", "!!str APPROVED", "{a: b}", "[APPROVED]", "APPROVED  ",
+    "'APPROVED' junk", "'APPROVED", '"APPROVED', "", "~", "null", "APPROVED\t",
+    " APPROVED", "'APPROVED '", "APPROVED#x", "APPROVED\tx",
+]
+SHAPES = [
+    "---\nstatus: {v}\n---\n",              # canonical
+    "---\nstatus:{v}\n---\n",               # no space: not a mapping at all
+    "---\nstatus: {v}\n  cont\n---\n",      # plain-scalar continuation
+    "---\nother: 1\nstatus: {v}\n---\n",    # not the first key
+    "---\nstatus: {v}\n  ---\n",            # indented delimiter = continuation
+    "--- \nstatus: {v}\n--- \n",            # trailing space on delimiters
+    "---\nstatus: {v}\nstatus: OTHER\n---\n",   # duplicate keys
+]
+DOCS = [s.format(v=v) for s, v in itertools.product(SHAPES, VALUES)] + [
+    "---\nstatus: |\n  APPROVED\n---\n",        # block scalar
+    "---\nstatus: >-\n  APPROVED\n---\n",       # folded scalar
+    "---\nx: &a APPROVED\nstatus: *a\n---\n",   # alias
+    "---\nstatus_extra: APPROVED\n---\n",       # prefix collision
+    "---\n\tstatus: APPROVED\n---\n",           # tab indent
+    "﻿---\nstatus: APPROVED\n---\n",       # BOM
+    "---\r\nstatus: APPROVED\r\n---\r\n",       # CRLF
+    "---\nSTATUS: APPROVED\n---\n",             # case
+    "---\n---\nstatus: APPROVED\n---\n",        # empty first document
+    "---\nstatus: APPROVED\n...\n",             # explicit document end
+    "---\nstatus: APPROVED",                    # unterminated frontmatter
+    "status: APPROVED\n",                       # no frontmatter
+    # A construct opened on an earlier line captures the lines below it, so
+    # `status:` is not a top-level key in any of these.
+    "---\nbroken: [\nstatus: APPROVED\n---\n",
+    "---\nbroken: {\nstatus: APPROVED\n---\n",
+    "---\nbroken: 'oops\nstatus: APPROVED\n---\n",
+    '---\nbroken: "oops\nstatus: APPROVED\n---\n',
+    "---\nitems: [\nstatus: APPROVED ]\n---\n",
+    "---\nitems: {\nstatus: APPROVED }\n---\n",
+    "---\nstatus: APPROVED\nbroken: [\n---\n",
+    # A YAML property hides the opener from a first-character check.
+    "---\nbroken: !!str 'oops\nstatus: APPROVED # close'\n---\n",
+    "---\nbroken: &a 'oops\nstatus: APPROVED # close'\n---\n",
+    "---\nbroken: !!seq [\nstatus: APPROVED\n---\n",
+    # The known residual, pinned: malformed content in an INDENTED line the
+    # reader skips by design. Lands in LENIENT, not UNSAFE.
+    "---\nstatus: APPROVED\nprior:\n  broken: 'x' junk\n---\n",
+    # Malformed siblings: PyYAML rejects the whole document, so it assigns
+    # `status` no value and neither may we.
+    "---\nstatus: APPROVED\nbroken: 'x' junk\n---\n",
+    '---\nstatus: APPROVED\nbroken: "\\q"\n---\n',
+    "---\nstatus: APPROVED\nbroken: foo: bar\n---\n",
+    "---\n%TAG !e! tag:example.com,2020:\nstatus: APPROVED\n---\n",
+    "---\nstatus: APPROVED\nbroken\n---\n",
+    "---\nstatus: APPROVED\n- item\n---\n",
+    # ...and legitimate shapes that must NOT be rejected as unreadable.
+    "---\nnotes: |\n  status: NOT_THIS\nstatus: APPROVED\n---\n",
+    "---\nprior:\n  note: x\nstatus: APPROVED\n---\n",
+    "---\nstatus: APPROVED\nsummary: it's done\n---\n",
+    "---\nstatus: APPROVED\nurl: http://example.com/x\n---\n",
+    "---\nstatus: APPROVED\nlast_review_date: 2026-03-09\n---\n",
+    "---\nstatus: APPROVED\nnote: a, b\n---\n",
+    "---\nstatus: APPROVED\niteration: 2\nissues_found_count: 0\n---\n",
+    "---\nstatus: APPROVED\nnote: 'a: b'\n---\n",
+    "---\nstatus: APPROVED\nempty:\n---\n",
+    "---\nstatus: APPROVED\n# a comment\nverdict: APPROVED\n---\n",
+]
+
+# Legitimate artifacts the gate MUST still accept — an over-strict reader that
+# blocks real REVIEW_STATE.md files is its own outage.
+MUST_ACCEPT = [
+    "---\nstatus: APPROVED\niteration: 2\nmax_iterations: 3\n"
+    "last_review_date: 2026-03-09\nissues_found_count: 0\n"
+    "codex_second_pass: enabled\nverdict: APPROVED\n---\n",
+    "---\nstatus: APPROVED\ncodex_second_pass: declined\n"
+    "summary: it's done\nurl: http://example.com/x\n---\n",
+    "---\nstatus: APPROVED\nnotes: |\n  free text\ncodex_second_pass: unavailable\n---\n",
+]
+
+buckets = {'exact': 0, 'fail-closed': 0, 'lenient': 0}
+unsafe = []
+
+with tempfile.TemporaryDirectory() as td:
+    artifact = Path(td) / 'REVIEW_STATE.md'
+    for doc in DOCS:
+        artifact.write_text(doc)
+        mine = gate.frontmatter_value(gate.read_frontmatter(str(artifact)), 'status')
+        truth = oracle(doc)
+
+        if mine == truth:
+            buckets['exact'] += 1
+        elif mine == '':
+            buckets['fail-closed'] += 1
+        elif doc in LENIENT and mine.lower() in GATE_VALUES:
+            buckets['lenient'] += 1
+        elif mine.lower() in GATE_VALUES:
+            unsafe.append((doc, mine, truth))       # would satisfy a gate
+        else:
+            buckets['fail-closed'] += 1             # junk value -> blocks anyway
+
+# An allowlist's failure mode is over-blocking. Prove the reader still accepts
+# artifacts that are unremarkable and valid.
+over_blocked = []
+with tempfile.TemporaryDirectory() as td:
+    artifact = Path(td) / 'REVIEW_STATE.md'
+    for doc in MUST_ACCEPT:
+        artifact.write_text(doc)
+        mine = gate.frontmatter_value(gate.read_frontmatter(str(artifact)), 'status')
+        if mine != oracle(doc) or mine != 'APPROVED':
+            over_blocked.append((doc, mine, oracle(doc)))
+
+print(f"corpus            : {len(DOCS)} documents")
+print(f"  exact           : {buckets['exact']}")
+print(f"  fail-closed     : {buckets['fail-closed']}  (stricter than YAML — safe)")
+print(f"  lenient         : {buckets['lenient']}  (trailing tab; same value, YAML rejects doc)")
+print(f"  UNSAFE          : {len(unsafe)}")
+
+print(f"  over-blocked    : {len(over_blocked)}  (valid artifacts wrongly refused)")
+
+if unsafe:
+    print()
+    for doc, mine, truth in unsafe:
+        print(f"  doc={doc!r}\n    hook={mine!r}  yaml={truth!r}")
+    print("\nFAILED: the reader accepted a gate value PyYAML disagrees with")
+    sys.exit(1)
+
+if over_blocked:
+    print()
+    for doc, mine, truth in over_blocked:
+        print(f"  doc={doc!r}\n    hook={mine!r}  yaml={truth!r}")
+    print("\nFAILED: the reader refused a valid artifact — over-strict is an outage")
+    sys.exit(1)
+
+print("\nno unsafe divergence from PyYAML; no valid artifact over-blocked")
+sys.exit(0)

--- a/tests/phase_gate_guard_test.py
+++ b/tests/phase_gate_guard_test.py
@@ -302,6 +302,104 @@ codex_second_pass: 'declined'   # user opted out
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
     check('unterminated frontmatter -> blocked', not allowed)
 
+    # A construct opened on an earlier line captures the lines below it, so the
+    # `status:` here is NOT a top-level key — it belongs to `broken`.
+    art = write_state(td, "---\nbroken: [\nstatus: APPROVED\n---\n")
+    allowed, reason = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unterminated flow collection swallows status -> blocked', not allowed)
+    check('unreadable artifact says so', 'not readable' in reason)
+
+    art = write_state(td, "---\nbroken: 'oops\nstatus: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unterminated quote swallows status -> blocked', not allowed)
+
+    # A YAML tag/anchor sits before the value and hides the opener from a
+    # first-character check: pyyaml reads this whole thing as `broken`.
+    art = write_state(td, "---\nbroken: !!str 'oops\nstatus: APPROVED # close'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('tag-hidden multiline quote swallows status -> blocked', not allowed)
+
+    art = write_state(td, "---\nbroken: &a 'oops\nstatus: APPROVED # close'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('anchor-hidden multiline quote swallows status -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\nbroken: [\ncodex_second_pass: enabled\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('unterminated flow before field gate -> blocked', not allowed)
+
+    # ...and the readability rule must not reject legitimate artifacts.
+    art = write_state(td, """---
+status: APPROVED
+iteration: 2
+notes: |
+  a block scalar's content is indented, so it captures nothing at top level
+codex_second_pass: declined
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('block scalar sibling -> allowed (content is indented)', allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\ncodex_second_pass: enabled\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('nested mapping sibling -> allowed', allowed)
+
+    # `status:APPROVED` (no space) is NOT a mapping — YAML reads the whole line
+    # as the plain scalar "status:APPROVED", so the document has no status key.
+    # Matching it would open the gate on a doc that never recorded a status.
+    art = write_state(td, "---\nstatus:APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status:APPROVED (no space after colon) -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus:'APPROVED'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("status:'APPROVED' (no space, quoted) -> blocked", not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass:enabled\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('codex_second_pass:enabled (no space) -> blocked', not allowed)
+
+    # YAML requires whitespace before a trailing comment: `'APPROVED'#x` is a
+    # syntax error, so PyYAML never assigns status a value here.
+    art = write_state(td, "---\nstatus: 'APPROVED'#x\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("quoted status with unspaced '#' -> blocked", not allowed)
+
+    art = write_state(td, '---\nstatus: "APPROVED"#x\n---\n')
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('double-quoted status with unspaced # -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: 'enabled'#x\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check("field with unspaced '#' -> blocked", not allowed)
+
+    # ...but a properly separated comment is still a comment.
+    art = write_state(td, "---\nstatus: 'APPROVED' #x\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("quoted status with spaced '#' -> allowed", allowed)
+
+    # A tab after the colon is valid separation, unlike a missing space.
+    art = write_state(td, "---\nstatus:\tAPPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status:<tab>APPROVED -> allowed', allowed)
+
+    # Sibling keys sharing a prefix must not collide.
+    art = write_state(td, "---\nstatus_extra: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status_extra does not satisfy status gate -> blocked', not allowed)
+
+    # Decorated YAML (anchor, tag, alias, flow collection) is not a plain
+    # scalar. The hook fails closed rather than resolving it — REVIEW_STATE.md
+    # never legitimately uses these, and a resolver is surface to get wrong.
+    for label, body in [
+        ('anchor', "---\nstatus: &a APPROVED\n---\n"),
+        ('tag', "---\nstatus: !!str APPROVED\n---\n"),
+        ('alias', "---\nx: &a APPROVED\nstatus: *a\n---\n"),
+        ('flow seq', "---\nstatus: [APPROVED]\n---\n"),
+    ]:
+        art = write_state(td, body)
+        allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+        check(f'decorated YAML ({label}) -> blocked (fail closed)', not allowed)
+
     # An INDENTED `---` is a scalar continuation, not a delimiter: pyyaml reads
     # this status as `APPROVED ---`.
     art = write_state(td, "---\nstatus: APPROVED\n  ---\n")

--- a/tests/phase_gate_guard_test.py
+++ b/tests/phase_gate_guard_test.py
@@ -65,7 +65,7 @@ verdict: APPROVED
 ---
 """
 
-FIELDS = 'codex_second_pass:enabled|declined|unavailable'
+FIELDS = 'codex_second_pass:completed|declined|unavailable'
 
 with tempfile.TemporaryDirectory() as td:
     base = {'GATE_STATUS': 'APPROVED', 'GATE_BLOCKED_TOOLS': 'Agent'}
@@ -83,7 +83,7 @@ with tempfile.TemporaryDirectory() as td:
     check('missing artifact still blocked', not allowed)
 
     # --- The new check: every legal disposition passes ---
-    for value in ('enabled', 'declined', 'unavailable'):
+    for value in ('completed', 'declined', 'unavailable'):
         art = write_state(td, APPROVED_WITH.format(value=value))
         allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
         check(f'codex_second_pass: {value} -> allowed', allowed)
@@ -98,6 +98,27 @@ with tempfile.TemporaryDirectory() as td:
     art = write_state(td, APPROVED_WITH.format(value='error'))
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
     check('codex_second_pass: error -> blocked (not an approval)', not allowed)
+
+    # --- a launch is not a verdict: `requested` must never admit verify ---
+    # This is the partial-failure/resume bypass: Codex is still running, or
+    # crashed, or the session died mid-pass. Nothing answered.
+    art = write_state(td, APPROVED_WITH.format(value='requested'))
+    allowed, reason = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('codex_second_pass: requested -> blocked (launch is not an answer)', not allowed)
+    check('requested block reason names the field', 'codex_second_pass' in reason)
+
+    # --- the old `enabled` state is retired and must not admit verify either ---
+    art = write_state(td, APPROVED_WITH.format(value='enabled'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('retired codex_second_pass: enabled -> blocked', not allowed)
+
+    # --- the pending status alone blocks, whatever the field says ---
+    # Belt and braces: dev-review writes SECOND_PASS_PENDING before launching, so
+    # even a stale APPROVED from a previous task cannot leave the gate open.
+    for pending_status in ('SECOND_PASS_PENDING', 'IN_REVIEW'):
+        art = write_state(td, f"---\nstatus: {pending_status}\ncodex_second_pass: requested\n---\n")
+        allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+        check(f'status: {pending_status} -> blocked', not allowed)
 
     # --- an un-substituted SKILL.md template is not a real answer ---
     art = write_state(td, APPROVED_WITH.format(value='enabled | declined | unavailable'))
@@ -143,7 +164,7 @@ with tempfile.TemporaryDirectory() as td:
     art = write_state(td, """---
 status: APPROVED
 prior_review:
-  codex_second_pass: enabled
+  codex_second_pass: completed
 ---
 """)
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
@@ -162,7 +183,7 @@ codex_second_pass: 'enabled # error'
     art = write_state(td, """---
 status: APPROVED
 codex_second_pass: error
-codex_second_pass: enabled
+codex_second_pass: completed
 ---
 """)
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
@@ -179,7 +200,7 @@ codex_second_pass:
     check('non-scalar codex_second_pass -> blocked', not allowed)
 
     # No frontmatter at all.
-    art = write_state(td, "status: APPROVED\ncodex_second_pass: enabled\n")
+    art = write_state(td, "status: APPROVED\ncodex_second_pass: completed\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('no frontmatter delimiters -> blocked', not allowed)
 
@@ -222,10 +243,10 @@ codex_second_pass: "decli\\ned"
     check('escape-synthesized "decli\\ned" -> blocked', not allowed)
 
     # A plain scalar continues onto indented lines: this value is
-    # `enabled nope`, not `enabled`. (Verified against pyyaml.)
+    # `completed nope`, not `completed`. (Verified against pyyaml.)
     art = write_state(td, """---
 status: APPROVED
-codex_second_pass: enabled
+codex_second_pass: completed
   nope
 ---
 """)
@@ -293,7 +314,7 @@ codex_second_pass: 'declined'   # user opted out
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
     check('embedded --- in status scalar -> blocked', not allowed)
 
-    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: enabled---nope\n---\n")
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: completed---nope\n---\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('embedded --- in codex_second_pass -> blocked', not allowed)
 
@@ -323,7 +344,7 @@ codex_second_pass: 'declined'   # user opted out
     allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
     check('anchor-hidden multiline quote swallows status -> blocked', not allowed)
 
-    art = write_state(td, "---\nstatus: APPROVED\nbroken: [\ncodex_second_pass: enabled\n---\n")
+    art = write_state(td, "---\nstatus: APPROVED\nbroken: [\ncodex_second_pass: completed\n---\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('unterminated flow before field gate -> blocked', not allowed)
 
@@ -339,7 +360,7 @@ codex_second_pass: declined
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('block scalar sibling -> allowed (content is indented)', allowed)
 
-    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\ncodex_second_pass: enabled\n---\n")
+    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\ncodex_second_pass: completed\n---\n")
     allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
     check('nested mapping sibling -> allowed', allowed)
 
@@ -477,7 +498,7 @@ with tempfile.TemporaryDirectory() as td:
             value = got[0].split('=', 1)[1]
             check(f'{skill}: all three dispositions reach the hook',
                   set(value.split(':', 1)[1].split('|')) ==
-                  {'enabled', 'declined', 'unavailable'})
+                  {'completed', 'declined', 'unavailable'})
         check(f'{skill}: no stray shell errors from the assignment',
               'command not found' not in proc.stderr)
 

--- a/tests/phase_gate_guard_test.py
+++ b/tests/phase_gate_guard_test.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env -S uv run python3
+"""Tests for hooks/phase-gate-guard.py.
+
+Focus: GATE_REQUIRE_FIELDS (the recorded-decision check) and the backward
+compatibility of the 12+ skills that wire this hook without it.
+
+Run: uv run python3 tests/phase_gate_guard_test.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parent.parent / 'hooks' / 'phase-gate-guard.py'
+
+F = []
+
+
+def run_hook(env_extra, tool_name='Agent', tool_input=None):
+    """Invoke the hook; return (allowed: bool, reason: str)."""
+    env = {**os.environ, **env_extra}
+    payload = json.dumps({'tool_name': tool_name, 'tool_input': tool_input or {}})
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=payload, capture_output=True, text=True, env=env,
+    )
+    out = proc.stdout.strip()
+    if not out:
+        return True, ''
+    try:
+        decision = json.loads(out)['hookSpecificOutput']
+    except Exception:
+        return True, ''
+    allowed = decision.get('permissionDecision') != 'deny'
+    return allowed, decision.get('permissionDecisionReason', '')
+
+
+def write_state(tmpdir, body):
+    p = Path(tmpdir) / 'REVIEW_STATE.md'
+    p.write_text(body)
+    return str(p)
+
+
+def check(name, cond):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}")
+    if not cond:
+        F.append(name)
+
+
+APPROVED_WITH = """---
+status: APPROVED
+iteration: 2
+codex_second_pass: {value}
+verdict: APPROVED
+---
+"""
+
+APPROVED_WITHOUT = """---
+status: APPROVED
+iteration: 2
+verdict: APPROVED
+---
+"""
+
+FIELDS = 'codex_second_pass:enabled|declined|unavailable'
+
+with tempfile.TemporaryDirectory() as td:
+    base = {'GATE_STATUS': 'APPROVED', 'GATE_BLOCKED_TOOLS': 'Agent'}
+
+    # --- Backward compatibility: no GATE_REQUIRE_FIELDS => unchanged behavior ---
+    art = write_state(td, APPROVED_WITHOUT)
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('no GATE_REQUIRE_FIELDS: approved artifact still allowed', allowed)
+
+    art = write_state(td, "---\nstatus: CHANGES_REQUIRED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('no GATE_REQUIRE_FIELDS: wrong status still blocked', not allowed)
+
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': str(Path(td) / 'nope.md')})
+    check('missing artifact still blocked', not allowed)
+
+    # --- The new check: every legal disposition passes ---
+    for value in ('enabled', 'declined', 'unavailable'):
+        art = write_state(td, APPROVED_WITH.format(value=value))
+        allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+        check(f'codex_second_pass: {value} -> allowed', allowed)
+
+    # --- The bypass this closes: APPROVED with no recorded decision ---
+    art = write_state(td, APPROVED_WITHOUT)
+    allowed, reason = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('APPROVED without codex_second_pass -> blocked', not allowed)
+    check('block reason names the missing field', 'codex_second_pass' in reason)
+
+    # --- error is an absence of evidence, not an approval ---
+    art = write_state(td, APPROVED_WITH.format(value='error'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('codex_second_pass: error -> blocked (not an approval)', not allowed)
+
+    # --- an un-substituted SKILL.md template is not a real answer ---
+    art = write_state(td, APPROVED_WITH.format(value='enabled | declined | unavailable'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('literal template placeholder -> blocked', not allowed)
+
+    # --- empty value is as good as absent ---
+    art = write_state(td, APPROVED_WITH.format(value=''))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('empty codex_second_pass -> blocked', not allowed)
+
+    # --- presence-only syntax (no allowed-value list) ---
+    art = write_state(td, APPROVED_WITH.format(value='error'))
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': 'codex_second_pass'})
+    check('presence-only syntax accepts any non-empty value', allowed)
+
+    # --- unrelated tools are never gated ---
+    art = write_state(td, APPROVED_WITHOUT)
+    allowed, _ = run_hook(
+        {**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS}, tool_name='Read'
+    )
+    check('non-blocked tool passes through', allowed)
+
+    # --- value matching is case-insensitive, and quotes/comments tolerated ---
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: "Declined"   # user opted out
+---
+""")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art, 'GATE_REQUIRE_FIELDS': FIELDS})
+    check('quoted + commented + mixed-case value -> allowed', allowed)
+
+# --- Adversarial parsing: the gate must not be fooled by YAML shape ---
+#
+# The frontmatter reader is hand-rolled (hooks stay dependency-free), so each way
+# it could mis-read a value is pinned here. Every case below must BLOCK.
+
+with tempfile.TemporaryDirectory() as td:
+    base = {'GATE_STATUS': 'APPROVED', 'GATE_BLOCKED_TOOLS': 'Agent'}
+    gated = {**base, 'GATE_REQUIRE_FIELDS': FIELDS}
+
+    # A nested key must not satisfy a top-level requirement.
+    art = write_state(td, """---
+status: APPROVED
+prior_review:
+  codex_second_pass: enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('nested codex_second_pass does not satisfy top-level -> blocked', not allowed)
+
+    # A '#' inside a quoted scalar is literal text, not a comment.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled # error'
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check("quoted '#' is literal, not a comment -> blocked", not allowed)
+
+    # Duplicate keys are ambiguous — block rather than pick one.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: error
+codex_second_pass: enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('duplicate codex_second_pass keys -> blocked', not allowed)
+
+    # A key with no scalar (block/nested value) is not a recorded decision.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass:
+  - enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('non-scalar codex_second_pass -> blocked', not allowed)
+
+    # No frontmatter at all.
+    art = write_state(td, "status: APPROVED\ncodex_second_pass: enabled\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('no frontmatter delimiters -> blocked', not allowed)
+
+    # YAML doubles a quote to escape it: 'enabled'' # error' is the single value
+    # `enabled' # error`, NOT `enabled`.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled'' # error'
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check("doubled-quote escape not read as 'enabled' -> blocked", not allowed)
+
+    # Junk after a closing quote means this isn't a clean scalar.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled' and then some
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('trailing junk after closing quote -> blocked', not allowed)
+
+    # An unterminated quote is not a value.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'enabled
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('unterminated quote -> blocked', not allowed)
+
+    # YAML resolves \n to a newline, so "decli\ned" is NOT `declined`. A parser
+    # that just drops the backslash would let this through.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: "decli\\ned"
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('escape-synthesized "decli\\ned" -> blocked', not allowed)
+
+    # A plain scalar continues onto indented lines: this value is
+    # `enabled nope`, not `enabled`. (Verified against pyyaml.)
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: enabled
+  nope
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('multiline plain scalar continuation -> blocked', not allowed)
+
+    # A comment after a closing quote is still fine.
+    art = write_state(td, """---
+status: APPROVED
+codex_second_pass: 'declined'   # user opted out
+---
+""")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('comment after closing quote -> allowed', allowed)
+
+    # --- The same adversarial shapes against the EXISTING status gate ---
+    # These 12+ skills wire the hook without GATE_REQUIRE_FIELDS; the status gate
+    # must not be loosened by the parser rewrite.
+
+    art = write_state(td, "---\nnested:\n  status: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('nested status does not satisfy status gate -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: 'APPROVED # invalid'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("quoted status with literal '#' -> blocked", not allowed)
+
+    art = write_state(td, "---\nstatus: CHANGES_REQUIRED\nstatus: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('duplicate status keys -> blocked', not allowed)
+
+    # A bare inline comment IS a comment (YAML: whitespace before '#').
+    art = write_state(td, "---\nstatus: APPROVED # sign-off by RJ\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('bare status with trailing comment -> allowed (YAML semantics)', allowed)
+
+    # '#' with no leading whitespace is part of the value, not a comment.
+    art = write_state(td, "---\nstatus: APPROVED#nope\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check("status 'APPROVED#nope' is not APPROVED -> blocked", not allowed)
+
+    # The doubled-quote escape must not fool the status gate either.
+    art = write_state(td, "---\nstatus: 'APPROVED'' # invalid'\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('doubled-quote escape does not satisfy status gate -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: 'APPROVED' but actually not\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status with trailing junk after quote -> blocked', not allowed)
+
+    # Double-quoted with a backslash escape: the value is `APPROVED" x`.
+    art = write_state(td, '---\nstatus: "APPROVED\\" x"\n---\n')
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('backslash-escaped quote not read as APPROVED -> blocked', not allowed)
+
+    # An unknown escape must not collapse into a passing value: YAML rejects
+    # "A\PPROVED"; naive backslash-dropping would read it as APPROVED.
+    art = write_state(td, '---\nstatus: "A\\PPROVED"\n---\n')
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unknown escape "A\\PPROVED" -> blocked', not allowed)
+
+    # `---` inside a scalar is not a frontmatter delimiter: this value is
+    # `APPROVED---nope`, not `APPROVED`. (Pre-existing bug; verified vs pyyaml.)
+    art = write_state(td, "---\nstatus: APPROVED---nope\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('embedded --- in status scalar -> blocked', not allowed)
+
+    art = write_state(td, "---\nstatus: APPROVED\ncodex_second_pass: enabled---nope\n---\n")
+    allowed, _ = run_hook({**gated, 'GATE_ARTIFACT': art})
+    check('embedded --- in codex_second_pass -> blocked', not allowed)
+
+    # Unterminated frontmatter is not readable evidence.
+    art = write_state(td, "---\nstatus: APPROVED\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('unterminated frontmatter -> blocked', not allowed)
+
+    # An INDENTED `---` is a scalar continuation, not a delimiter: pyyaml reads
+    # this status as `APPROVED ---`.
+    art = write_state(td, "---\nstatus: APPROVED\n  ---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('indented closing --- -> blocked', not allowed)
+
+    art = write_state(td, "  ---\nstatus: APPROVED\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('indented opening --- -> blocked', not allowed)
+
+    # Trailing whitespace after a delimiter is still a delimiter.
+    art = write_state(td, "--- \nstatus: APPROVED\n--- \n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('delimiter with trailing whitespace -> allowed', allowed)
+
+    # The status gate must not fall for a continuation line either: this value
+    # is `APPROVED nope`. (Verified against pyyaml.)
+    art = write_state(td, "---\nstatus: APPROVED\n  nope\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('status multiline plain scalar -> blocked', not allowed)
+
+    # ...but a normal flat artifact with a following top-level key still passes.
+    art = write_state(td, "---\nstatus: APPROVED\niteration: 2\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('flat frontmatter with following key -> allowed', allowed)
+
+    # A nested block under a LATER key must not be mistaken for a continuation
+    # of an earlier one.
+    art = write_state(td, "---\nstatus: APPROVED\nprior:\n  note: x\n---\n")
+    allowed, _ = run_hook({**base, 'GATE_ARTIFACT': art})
+    check('nested block under a later key -> allowed', allowed)
+
+
+# --- The wiring is real: execute the command strings from SKILL.md frontmatter ---
+#
+# GATE_REQUIRE_FIELDS contains `|`. Unquoted, bash reads it as a pipeline, the env
+# var never reaches the hook, and the gate silently allows everything. Parsing the
+# YAML would not catch that — only running the command as a shell does.
+
+import re
+import shlex
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def gate_command(skill_path):
+    """Extract the phase-gate-guard command string from a SKILL.md frontmatter."""
+    text = (REPO / skill_path).read_text()
+    frontmatter = text.split('---', 2)[1]
+    for block in re.findall(r'command: >-\n((?:\s{12,}.*\n)+)', frontmatter):
+        joined = ' '.join(line.strip() for line in block.strip().splitlines())
+        if 'phase-gate-guard.py' in joined:
+            return joined
+    return ''
+
+
+with tempfile.TemporaryDirectory() as td:
+    for skill in ('skills/dev-verify/SKILL.md', 'skills/ds-verify/SKILL.md'):
+        cmd = gate_command(skill)
+        check(f'{skill}: gate command found', bool(cmd))
+        if not cmd:
+            continue
+
+        check(f'{skill}: GATE_REQUIRE_FIELDS present', 'GATE_REQUIRE_FIELDS' in cmd)
+
+        # Replace the interpreter invocation with `env` so the shell reports the
+        # environment the hook would actually receive.
+        env_probe = re.sub(r'uv run python3 \S+phase-gate-guard\.py', 'env', cmd)
+        env_probe = env_probe.replace('${CLAUDE_PLUGIN_ROOT}', str(REPO))
+        proc = subprocess.run(['bash', '-c', env_probe], capture_output=True, text=True)
+
+        got = [l for l in proc.stdout.splitlines() if l.startswith('GATE_REQUIRE_FIELDS=')]
+        check(f'{skill}: GATE_REQUIRE_FIELDS survives shell parsing (quoted)', len(got) == 1)
+        if got:
+            value = got[0].split('=', 1)[1]
+            check(f'{skill}: all three dispositions reach the hook',
+                  set(value.split(':', 1)[1].split('|')) ==
+                  {'enabled', 'declined', 'unavailable'})
+        check(f'{skill}: no stray shell errors from the assignment',
+              'command not found' not in proc.stderr)
+
+print()
+if F:
+    print(f"{len(F)} FAILED: {F}")
+    sys.exit(1)
+print('all phase-gate-guard tests passed')
+sys.exit(0)

--- a/tests/writing_guards_test.py
+++ b/tests/writing_guards_test.py
@@ -35,6 +35,16 @@ def run(cmd, stdin=None, env=None):
                           env={**os.environ, **(env or {})})
 
 
+def claim_payload(file_path: Path) -> str:
+    """A real PostToolUse payload. Hooks read stdin — there is no CLAUDE_TOOL_INPUT."""
+    return json.dumps({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(file_path)},
+        "tool_response": {},
+    })
+
+
 def make_project(tmp: Path, *, granular=True, claim_ok=True, stale=False):
     (tmp / ".planning").mkdir(parents=True)
     (tmp / "outlines").mkdir()
@@ -99,24 +109,28 @@ with tempfile.TemporaryDirectory() as td:
     # a draft with NO claim, inside a project ⇒ block
     bad_draft = proj / "drafts" / "Orphan (Draft).md"
     bad_draft.write_text("# Orphan\nProse with no claim id.\n")
-    r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
-            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(bad_draft)})})
+    r = run(["uv", "run", "python3", str(CLAIM_GUARD)], stdin=claim_payload(bad_draft))
     out = json.loads(r.stdout)
     ok("claim-guard: draft w/o claim in project ⇒ block", out.get("decision") == "block", r.stdout)
+    ok("claim-guard: block carries a reason (not `message`)",
+       isinstance(out.get("reason"), str) and "message" not in out, r.stdout)
 
-    # an outline with NO claim ⇒ warn (continue), never block
+    # an outline with NO claim ⇒ warn, never block. A warning on PostToolUse is
+    # hookSpecificOutput.additionalContext — `{"result": "continue"}` is not a thing,
+    # and asserting it here is what let the invalid payload survive in production.
     bad_outline = proj / "outlines" / "Orphan.md"
     bad_outline.write_text("- a point with no claim id\n")
-    r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
-            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(bad_outline)})})
+    r = run(["uv", "run", "python3", str(CLAIM_GUARD)], stdin=claim_payload(bad_outline))
     out = json.loads(r.stdout)
-    ok("claim-guard: outline w/o claim ⇒ continue (warn)", out.get("result") == "continue" and "message" in out)
+    hso = out.get("hookSpecificOutput", {})
+    ok("claim-guard: outline w/o claim ⇒ warn via additionalContext",
+       hso.get("hookEventName") == "PostToolUse" and "additionalContext" in hso
+       and "decision" not in out, r.stdout)
 
-    # a draft WITH a claim ⇒ continue, no block
+    # a draft WITH a claim ⇒ silence (nothing to say), never a block
     r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
-            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(proj / "drafts" / "Part I. Alpha (Draft).md")})})
-    out = json.loads(r.stdout)
-    ok("claim-guard: draft with claim ⇒ continue", out.get("result") == "continue" and "decision" not in out)
+            stdin=claim_payload(proj / "drafts" / "Part I. Alpha (Draft).md"))
+    ok("claim-guard: draft with claim ⇒ silent", r.stdout.strip() == "" and r.returncode == 0, r.stdout)
 
 print(f"\n{_p} passed, {_f} failed")
 sys.exit(1 if _f else 0)

--- a/workflows/wc-audit.js
+++ b/workflows/wc-audit.js
@@ -1,12 +1,12 @@
 export const meta = {
   name: 'wc-audit',
-  description: "workflow-creator's Mode 2 audit as an ultracode workflow: discover the target workflow's skill files, fan out one read-only reviewer per audit dimension (P01-P30 architecture incl. the runner-architecture/executionClass detector — recognizes BOTH the code and DATA compile variants, the 13-pattern enforcement checklist, path portability, the Ultracode-Workflow Candidacy Scan), adversarially verify critical/major gaps against the actual files, then compute the composite + verdict in pure JS. Flags the retired generic-interpreter shape as a critical. Honors workflow-creator's meta-tool exemptions. Read-only; does NOT fix.",
+  description: "workflow-creator's Mode 2 audit as an ultracode workflow: discover the target workflow's skill files, fan out one read-only reviewer per audit dimension (P01-P30 architecture incl. the runner-architecture/executionClass detector — recognizes BOTH the code and DATA compile variants, the 13-pattern enforcement checklist, path portability, the DETERMINISTIC hook output-contract leg, the Ultracode-Workflow Candidacy Scan), adversarially verify critical/major gaps against the actual files, then compute the composite + verdict in pure JS. Flags the retired generic-interpreter shape as a critical. Honors workflow-creator's meta-tool exemptions. Read-only; does NOT fix.",
   whenToUse: "Called by workflow-creator Mode 2 (Steps 1-4) and Mode 3 Phase A. Returns { overallPass, composite, verdict, scoreTable, reportMarkdown, candidacyTable, findings, reviews, reviewersThatFlagged }. The skill renders AUDIT.md from the result and drives the Mode 3 /goal fix loop; on a re-audit it passes onlyChecks (flagged dimension keys) + priorReviews. The workflow never fixes and the gate is computed in JS — never trust a self-reported composite.",
   phases: [
     { title: 'Discover', detail: "enumerate the target workflow's entry/midpoint/phase skills + references; resolve Mode 2 criteria, enforcement-checklist, migration playbook; detect the meta-tool" },
-    { title: 'Review', detail: 'one read-only reviewer per dimension (4 architecture clusters + enforcement + portability + candidacy), in parallel — RAW per-principle scores, never a composite' },
+    { title: 'Review', detail: 'one read-only reviewer per dimension (4 architecture clusters + enforcement + portability + hook-contract + candidacy), in parallel — RAW per-principle scores, never a composite' },
     { title: 'Verify', detail: 'adversarially re-check each critical/major gap against the cited files; drop unconfirmed (the verifier supplies a corrected score)' },
-    { title: 'Gate', detail: 'composite = mean of non-exempt, non-ceiling principle scores, computed in JS; verdict + AUDIT.md report + candidacy table' },
+    { title: 'Gate', detail: 'composite = mean of non-exempt, non-ceiling principle scores, computed in JS; the substrate gate additionally requires portability Clean AND hook-contract Clean (a deterministic harness exit, not a judgment); verdict + AUDIT.md report + candidacy table' },
   ],
 }
 
@@ -117,6 +117,33 @@ const ENFORCEMENT_SCHEMA = {
 }
 
 // Path-portability reviewer.
+// Hook OUTPUT-CONTRACT validity. Separate from path-portability (which only checks that a
+// hook command RESOLVES) and from P20 (which only checks that a hook EXISTS and covers the
+// step). Neither notices a hook that runs, is wired correctly, and emits a payload the
+// harness throws away — the exact defect that disabled pre-compact.py's workflow-reload for
+// an unknown length of time, and that had silently broken 8 more scripts alongside it.
+const HOOK_CONTRACT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['dimension', 'status', 'wiringsChecked', 'invalidWirings', 'findings'],
+  properties: {
+    dimension: { type: 'string' },
+    status: { type: 'string', enum: ['Clean', 'Broken', 'NotRun'] },
+    wiringsChecked: { type: 'number', description: 'total (script, event, matcher) wirings the harness exercised' },
+    invalidWirings: {
+      type: 'array', items: {
+        type: 'object', additionalProperties: false, required: ['script', 'event', 'detail'],
+        properties: {
+          script: { type: 'string' }, event: { type: 'string' },
+          detail: { type: 'string', description: 'the schema violation verbatim from the harness' },
+        },
+      },
+      description: 'every wiring the harness reported INVALID — each is a silently-dead hook',
+    },
+    harnessOutput: { type: 'string', description: 'the last ~40 lines of harness output, for evidence' },
+    findings: { type: 'array', items: FINDING },
+  },
+}
+
 const PORTABILITY_SCHEMA = {
   type: 'object', additionalProperties: false, required: ['dimension', 'status', 'violations', 'hookCommandViolations', 'contentPluginRootViolations', 'findings'],
   properties: {
@@ -308,6 +335,33 @@ Scan every SKILL.md and references/*.md for path-portability defects (Mode 2 Ste
 status: Clean (no broken paths AND no \${CLAUDE_SKILL_DIR} in hook commands AND no \${CLAUDE_PLUGIN_ROOT} in skill content), Partial (some fixed, some remain), Broken (relative paths in skill instructions OR \${CLAUDE_SKILL_DIR} in hook commands OR \${CLAUDE_PLUGIN_ROOT} in skill content). Each violation → a findings[] entry (hook-command + content-plugin-root violations are critical). Return PORTABILITY_SCHEMA.`,
   },
   {
+    key: 'hook-contract', schema: HOOK_CONTRACT_SCHEMA,
+    prompt:
+`${READONLY}
+Set dimension="hook-contract" verbatim.
+You are a MECHANICAL verifier. Do NOT reason about hook payloads yourself and do NOT read the
+hooks to judge them — RUN the harness and report its RAW output. A hook whose payload the
+harness rejects fails silently: no exception, no warning, exit 0, message discarded. Eyeballing
+does not find these; only executing them does.
+
+1. Run: \`cd "${PROJECT}" && ./scripts/check-hooks.sh --report\`
+   It discovers every hook wiring — hooks/hooks.json AND the \`hooks:\` frontmatter of every
+   skills/*/SKILL.md — feeds each one realistic payloads, and validates the emitted JSON against
+   the per-event schema in scripts/checks/hook_output_schema.py (transcribed from
+   https://code.claude.com/docs/en/hooks.md).
+2. If the script does not exist, set status="NotRun", wiringsChecked=0, invalidWirings=[], and
+   add ONE minor finding saying the audited repo has no hook-contract harness. Do not improvise
+   a substitute check.
+3. Otherwise parse the printed table. Set wiringsChecked = total rows. For EVERY row whose
+   verdict is INVALID (or WIRING ERROR), add an invalidWirings[] entry with the script, the
+   event, and the violation text the harness printed above the table (the \`! ...\` lines).
+   status = "Clean" iff zero INVALID rows, else "Broken".
+4. Put the tail of the harness output in harnessOutput.
+
+Report raw counts. Do NOT soften, do NOT excuse an INVALID row because the hook "looks right" —
+the harness is the authority here, not your reading of the source. Return HOOK_CONTRACT_SCHEMA.`,
+  },
+  {
     key: 'candidacy-scan', schema: CANDIDACY_SCHEMA,
     prompt:
 `${READONLY}
@@ -471,6 +525,17 @@ for (const id of ALL_IDS) {
 const port = byDim['path-portability']
 for (const hv of (port?.hookCommandViolations || [])) findings.push({ severity: 'critical', dimension: 'path-portability', location: hv, detail: `hook command uses \${CLAUDE_SKILL_DIR} — silent-failure landmine; use \${CLAUDE_PLUGIN_ROOT}` })
 for (const cv of (port?.contentPluginRootViolations || [])) findings.push({ severity: 'critical', dimension: 'path-portability', location: cv, detail: `\${CLAUDE_PLUGIN_ROOT} in skill content — substituted only in hook commands, stays literal here; use \${CLAUDE_SKILL_DIR}/../..` })
+// Hook OUTPUT-CONTRACT violations are always critical, and the verdict comes from the harness's
+// exit — never from a reviewer's reading. A hook emitting a payload its event does not accept is
+// a dead hook: it exits 0, prints nothing anyone sees, and whatever it was enforcing stops being
+// enforced. That is strictly worse than a missing hook, because the audit sees a hook there.
+const hookc = byDim['hook-contract']
+for (const iw of (hookc?.invalidWirings || [])) {
+  findings.push({
+    severity: 'critical', dimension: 'hook-contract', location: `hooks/${iw.script} [${iw.event}]`,
+    detail: `hook payload is invalid for ${iw.event} — the harness rejects it wholesale and the hook silently stops enforcing: ${iw.detail}`,
+  })
+}
 findings.sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity])
 const criticalCount = findings.filter(f => f.severity === 'critical').length
 
@@ -483,7 +548,12 @@ const criticalCount = findings.filter(f => f.severity === 'critical').length
 const enfDim = byDim['enforcement-checklist']
 const enfAbsent = (enfDim?.patterns || []).filter(p => p.status === 'Absent').map(p => p.pattern)
 const portStatus = port ? port.status : 'n/a'
-const substratePass = criticalCount === 0 && enfAbsent.length === 0 && (portStatus === 'Clean' || portStatus === 'n/a')
+// Hook-contract is a DETERMINISTIC leg (a harness exit, not a judgment), so it belongs in the
+// substrate alongside portability rather than in the noisy composite.
+const hookStatus = hookc ? hookc.status : 'n/a'
+const substratePass = criticalCount === 0 && enfAbsent.length === 0
+  && (portStatus === 'Clean' || portStatus === 'n/a')
+  && (hookStatus === 'Clean' || hookStatus === 'NotRun' || hookStatus === 'n/a')
 const overallPass = substratePass && counted.length > 0 && composite >= THRESHOLD
 const verdict = overallPass ? 'PASS' : 'NEEDS WORK'
 
@@ -526,6 +596,16 @@ const portTable = port
         : 'No path-portability defects found.')
   : '(path portability not scored this run)'
 
+const hookTable = hookc
+  ? `Status: **${hookc.status}** (${hookc.wiringsChecked} wiring(s) executed against the per-event schema)\n\n` + (
+      (hookc.invalidWirings || []).length
+        ? ['| Hook | Event | Violation |', '|------|-------|-----------|',
+           ...(hookc.invalidWirings || []).map(i => `| hooks/${i.script} | ${i.event} | ${(i.detail || '').replace(/\|/g, '\\|').slice(0, 160)} |`)].join('\n')
+        : (hookc.status === 'NotRun'
+            ? 'Harness not present in this repo — hook payload validity was NOT checked.'
+            : 'Every wired hook emits a payload its event accepts.'))
+  : '(hook contract not checked this run)'
+
 const cand = byDim['candidacy-scan']
 const candidacyTable = cand
   ? ['| Phase | Fan-out? | Worker mode | Value driver | Recommend | Note |', '|-------|----------|-------------|--------------|-----------|------|',
@@ -553,8 +633,8 @@ const scoreTable = [
 const reportMarkdown = [
   `## Audit: ${TARGET}${disc.isMetaTool ? ' (meta-tool — P01/P06 exempt)' : ''}`,
   ``,
-  `**Verdict:** ${verdict} &nbsp;·&nbsp; **Substrate gate:** ${substratePass ? '✅ clean' : '❌ ' + criticalCount + ' crit / ' + enfAbsent.length + ' enf-Absent / portability ' + portStatus} &nbsp;·&nbsp; **Composite:** ${composite} / 10 (advisory; threshold ${THRESHOLD}) &nbsp;·&nbsp; **Critical:** ${criticalCount}`,
-  `\n_The substrate gate (0 critical · no enforcement Absent · portability Clean) is the convergence signal. The composite is an advisory ±0.2 LLM proxy — see project_wc_mode3_asymptote; do not chase it past the substrate gate._`,
+  `**Verdict:** ${verdict} &nbsp;·&nbsp; **Substrate gate:** ${substratePass ? '✅ clean' : '❌ ' + criticalCount + ' crit / ' + enfAbsent.length + ' enf-Absent / portability ' + portStatus + ' / hook-contract ' + hookStatus} &nbsp;·&nbsp; **Composite:** ${composite} / 10 (advisory; threshold ${THRESHOLD}) &nbsp;·&nbsp; **Critical:** ${criticalCount}`,
+  `\n_The substrate gate (0 critical · no enforcement Absent · portability Clean · hook contract Clean) is the convergence signal. The composite is an advisory ±0.2 LLM proxy — see project_wc_mode3_asymptote; do not chase it past the substrate gate._`,
   excluded.length ? `\n_Excluded from composite (deterministic meta-tool exemptions): ${excluded.join(', ')}._` : '',
   ceilingNoted.length ? `_Domain-ceiling-flagged (kept in composite, not penalized as gaps): ${ceilingNoted.join(', ')}._` : '',
   ``,
@@ -576,6 +656,11 @@ const reportMarkdown = [
   ``,
   `### Path Portability`,
   portTable,
+  ``,
+  `### Hook Output Contract`,
+  `_Executed, not eyeballed: every wiring in hooks.json + skill frontmatter is run and its emitted JSON validated against the event's schema. An invalid payload is discarded whole by the harness — the hook exits 0 and silently stops enforcing._`,
+  ``,
+  hookTable,
   ``,
   `### Ultracode-Workflow Migration Candidates`,
   candidacyTable,


### PR DESCRIPTION
> **⚠️ BASE-BRANCH WARNING — read before merging.** This branch was cut from `feat/codex-second-pass`'s HEAD (`199f8ed`) as instructed. That branch is **not on origin**, so the only available PR base is `main` — which means this PR carries **4 pre-existing commits that are not mine and were not reviewed here**: `199f8ed`, `d637d20`, `5cca68f`, `dad24da` (the Codex second-pass work). **Merging this PR merges those too.** My change is the single commit `f1a0b7c`. If that is not intended, push `feat/codex-second-pass` and retarget this PR onto it, or cherry-pick `f1a0b7c` onto `main`.

## The finding

`ds-no-main-chat-code-guard.py`, `ds-reviewer-readonly-guard.py` and `ds-read-after-subagent-guard.py` all emitted

```json
{"decision": "block", "message": "🛑 Iron Law: No analysis code in main chat…"}
```

on **PreToolUse**. PreToolUse has no top-level `decision` and no `message` — gates go through `hookSpecificOutput.permissionDecision`. Claude Code rejects the **entire** payload (`Hook JSON output validation failed — (root): Invalid input`), so **every deny these guards ever issued was thrown away.** All three of the ds workflow's hard boundaries — no analysis code in main chat, reviewers are read-only, no reading source files after a subagent returns — have been no-ops. The hooks ran, exited 0, printed nothing anyone saw, and enforced nothing.

Found while fixing the same class of bug in `pre-compact.py` (`hookSpecificOutput` on `PreCompact`, which accepts none), which had silently dropped the post-compaction workflow-reload instruction.

**15 broken wirings across 8 scripts. 56/56 now valid.**

The wiring surface is much larger than `hooks/hooks.json`: **42 of the 56 wirings come from `hooks:` frontmatter in `skills/*/SKILL.md`.**

## Audit table

| Hook script | Wired event | Payload shape emitted (before) | Verdict | Fix applied |
|---|---|---|---|---|
| `ds-no-main-chat-code-guard.py` | PreToolUse ×3 (6 skills) | `{"decision":"block"\|"allow","message":…}` | **INVALID** | → `hookSpecificOutput.permissionDecision: deny` / silence |
| `ds-reviewer-readonly-guard.py` | PreToolUse ×2 | same | **INVALID** | same |
| `ds-read-after-subagent-guard.py` | PreToolUse ×3 | same | **INVALID** | same |
| `ds-brainstorm-no-exploration-guard.py` | PreToolUse | same | **INVALID** | same |
| `ds-pre-subagent-clear.py` | PreToolUse | `{"decision":"allow"}` | **INVALID** | silence (exit 0) |
| `ds-post-subagent-guard.py` | PostToolUse | `{"decision":"allow"}` — only `"block"` exists | **INVALID** | silence (exit 0) |
| `writing-suggest-verify.py` | PostToolUse (hooks.json + 3 skills) | `{"result":"continue","message":…}`; input read from nonexistent `CLAUDE_TOOL_INPUT` env var | **INVALID ×2** | stdin + `additionalContext` |
| `writing-claim-id-guard.py` | PostToolUse ×2 (4 skills) | same env var + `{"result":"continue"}` | **INVALID ×2** | stdin + `additionalContext` (its `decision:"block"` path was already legal) |
| `writing-precis-guard.py` | PostToolUse | same | **INVALID ×2** | stdin + `additionalContext` |
| `writing-outline-guard.py` | PreToolUse | stderr + `sys.exit(1)` — on PreToolUse only exit **2** blocks | **INVALID** | `permissionDecision: deny` |
| `suggest-compact.py` | PreToolUse **and** PostToolUse | hardcoded `hookEventName:"PreToolUse"` → rejected under the workshop wiring | **INVALID** | reads `hook_event_name` off the payload |
| `pre-compact.py`, `subagent-start.py` | PreCompact / SubagentStart | `systemMessage` / `SubagentStart.additionalContext` | **VALID** | reviewed, unchanged |
| `session-start.py`, `image-read-guard.py`, `lint-check.py`, `atomic-constraint-guard.py`, `writing-prose-check.py`, `cite-fidelity-lint.py`, `pr-url-logger.py`, `overflow-check.py`, `session-end.py`, `pattern-scan.py`, `phase-gate-guard.py`, `dev-*`, `workshop-*`, `wc-*`, `plugin-validate.py`, `validate-skill-paths.py`, `mechanical-floor-gate.py`, `typst-convention-guard.py`, `find-slide-page-inject.py`, `*-executable-guard.py`, `writing-mechanical-gate.py` | various | valid | **VALID** | untouched |

Shared helper `hooks/_gate_common.py` gained `allow()` (silence *is* the allow) and `context(event, text)` beside the existing `deny()`.

## Root cause: why workflow-creator never caught it

The audit checks hooks in exactly three places, and **all three are static wiring checks**:

- **P20 "Hooks over prompt"** — scores *coverage*: does a mechanically-checkable step have a hook whose matcher covers it. Its sub-probe even says "do NOT score on hook PRESENCE, score on COVERAGE" — still never asks whether the hook *works*.
- **P03 "Structural gate enforcement"** — gates exist.
- **path-portability** — the only hook-*correctness* check, and it is entirely about `${CLAUDE_SKILL_DIR}` vs `${CLAUDE_PLUGIN_ROOT}` substitution.

**Nothing in the audit ever executed a hook, and the per-event output schema was written down nowhere in the repo.** A hook that is present, correctly matched, path-portable, and emits a rejected payload scored 10/10 on P20 and Clean on portability. There was no dimension it could fail.

Sharper: the repo already documents the April 2026 `${CLAUDE_SKILL_DIR}` incident, and the guard quoted in that write-up defaults to `{"decision": "approve"}` — itself an invalid payload. The class was diagnosed as a *path* problem; the *payload* half went unexamined for another year.

Second reason it survived: **an existing test asserted the broken contract.** `tests/writing_guards_test.py` fed `CLAUDE_TOOL_INPUT` and asserted `out["result"] == "continue"`. Those cases now assert the real contract.

### What was added

- `scripts/checks/hook_output_schema.py` — per-event schema + `validate_payload()`, transcribed from <https://code.claude.com/docs/en/hooks.md>
- `tests/hook_output_schema_test.py` — discovers every wiring from `hooks.json` **and** all skill frontmatter, runs each hook against realistic payloads in a throwaway project, validates emitted JSON. Also catches non-zero exits misread as decisions, and `hookEventName` disagreeing with the wiring (static — `suggest-compact.py` only emits after 50 edits, so no fixture would reach it). Regression case for the exact PreCompact bug.
- `scripts/check-hooks.sh` — one command; `--report` prints the audit table
- `workflows/wc-audit.js` — new **deterministic** `hook-contract` dimension that RUNS the harness (mechanical leg, like workshop-verify's compile leg). Every INVALID wiring is a **critical** finding, folded into the **substrate gate** beside portability rather than the noisy composite.
- `skills/workflow-creator/SKILL.md` — **Step 3c: Validate the Hook OUTPUT Contract**; P20 amended with "P20 scores COVERAGE, never VALIDITY."
- `references/enforcement-checklist.md` — under Gate Functions: if the gate is a hook, its output must be valid for its event, or it is not a gate at all.

## Test results (run on this committed branch)

```
$ ./scripts/check-hooks.sh
63 passed in 4.27s

$ ./scripts/check-hooks.sh --report
56/56 wirings valid
```

Other suites re-run clean: `writing_guards_test.py` 13/13 · `workshop_guard_test.py` 4/4 · `test_prose_lint_hook.py` 32/32 · `wc-audit-verify-batch.test.mjs` 12/12.

## Caveats

1. **The repo has no aggregate test runner, and I did not add one.** `pytest tests/` fails at collection because six test files call `sys.exit()` at module scope (`codex_second_pass_join_test.py`, `dev_plan_table_test.py`, `overflow_check_test.py`, `test_mechanical_floor_gate.py`, `test_writing_mechanical_gate.py`, `writing_gate_probe_test.py`). Pre-existing, not caused by this PR, out of scope. `check-hooks.sh` therefore runs only the hook harness.
2. **The `hook-contract` wc-audit dimension is code-reviewed and syntax-checked but not executed end-to-end** — running it means a live `Workflow()` fan-out with real agents. The existing mock test covers the surrounding gate logic (12/12) and the dimension is backward-compatible: absent → `n/a` → does not block the substrate gate.
3. **The schema is a snapshot** of the hooks docs as of 2026-07-21. If the docs change, `hook_output_schema.py` must be updated; the harness cannot detect drift on its own.
4. **`hooks/pre-compact.py` and `hooks/subagent-start.py` were authored separately** (not by me) and are carried in this commit because the harness must cover them. Both validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Mof5i8SUKnoX3f2mUYony
