### PR TITLE
fix(hooks): the ds Iron Law guards were emitting a payload the harness discards

### DIFF
--- a/hooks/_gate_common.py
+++ b/hooks/_gate_common.py
@@ -22,6 +22,32 @@ def deny(reason: str):
     sys.exit(0)
 
 
+def allow():
+    """PreToolUse: silence IS the allow.
+
+    There is no `{"decision": "allow"}` in the hook contract. Emitting one gets the
+    WHOLE payload rejected ("Hook JSON output validation failed"), which is harmless
+    for an allow but means the same code path's *block* is rejected too — the guard
+    silently stops guarding. Print nothing and exit 0.
+    """
+    sys.exit(0)
+
+
+def context(event: str, text: str):
+    """Non-blocking feedback to Claude, on any event that accepts additionalContext.
+
+    `event` MUST equal the event the hook is wired to: a hookEventName that disagrees
+    with the wiring is rejected exactly like an unsupported field. Read it from the
+    payload's `hook_event_name` rather than hardcoding it when a hook is wired to more
+    than one event.
+    """
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": event,
+        "additionalContext": text,
+    }}))
+    sys.exit(0)
+
+
 def _project_from_args(tool_input: dict, hook_input: Optional[dict] = None) -> str:
     """Resolve the project directory the gate should audit.
 

--- a/hooks/ds-brainstorm-no-exploration-guard.py
+++ b/hooks/ds-brainstorm-no-exploration-guard.py
@@ -7,6 +7,16 @@ Block Bash commands that look like data analysis during brainstorm.
 import json
 import os
 import sys
+from pathlib import Path
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -14,8 +24,7 @@ def main():
     tool_params = tool_input.get("tool_input", {})
 
     if tool_name != "Bash":
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     command = tool_params.get("command", "")
 
@@ -34,17 +43,12 @@ def main():
         spec_path = os.path.join(os.getcwd(), ".planning", "SPEC.md")
         if os.path.exists(spec_path):
             # Brainstorm complete, allow exploration
-            print(json.dumps({"decision": "allow"}))
-            return
+            allow()
 
-        print(json.dumps({
-            "decision": "block",
-            "message": "\ud83d\uded1 Iron Law: No data exploration before asking questions. Complete the brainstorm interview and write SPEC.md first. Data exploration happens in ds-plan (Phase 2)."
-        }))
-        return
+        deny("\ud83d\uded1 Iron Law: No data exploration before asking questions. Complete the brainstorm interview and write SPEC.md first. Data exploration happens in ds-plan (Phase 2).")
 
     # Allow non-analysis bash commands
-    print(json.dumps({"decision": "allow"}))
+    allow()
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-no-main-chat-code-guard.py
+++ b/hooks/ds-no-main-chat-code-guard.py
@@ -7,6 +7,16 @@ Analysis code must be written by delegated subagents, not the orchestrator.
 import json
 import os
 import sys
+from pathlib import Path
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -15,8 +25,7 @@ def main():
 
     # Only check Write, Edit, and Bash
     if tool_name not in ("Write", "Edit", "Bash"):
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # For Bash, check if command contains analysis-related operations
     if tool_name == "Bash":
@@ -24,21 +33,14 @@ def main():
         # Allow git, ls, cat .planning/, check-all-ds.sh, and other orchestration commands
         safe_prefixes = ["git ", "ls ", "cat .planning/", "head ", "tail ", "wc ", "mkdir ", "chmod ", "bash scripts/"]
         if any(command.strip().startswith(p) for p in safe_prefixes):
-            print(json.dumps({"decision": "allow"}))
-            return
+            allow()
         # Allow pixi/python commands that are just running scripts
         if "check-all-ds" in command or "check-ds-" in command:
-            print(json.dumps({"decision": "allow"}))
-            return
+            allow()
         # Block python/pixi run commands that look like analysis
         if any(kw in command for kw in ["python3 -c", "pixi run python", "import pandas", "import numpy"]):
-            print(json.dumps({
-                "decision": "block",
-                "message": "🛑 Iron Law: No analysis code in main chat. Delegate to a subagent via ds-delegate."
-            }))
-            return
-        print(json.dumps({"decision": "allow"}))
-        return
+            deny("🛑 Iron Law: No analysis code in main chat. Delegate to a subagent via ds-delegate.")
+        allow()
 
     # For Write/Edit, check if target is an analysis file
     path = tool_params.get("file_path", "")
@@ -46,19 +48,14 @@ def main():
     # Allow writes to state files, planning, config
     allowed_patterns = [".planning/", ".claude/", "CLAUDE.md", "scripts/", "hooks/", "references/", "skills/"]
     if any(pattern in path for pattern in allowed_patterns):
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Block writes to analysis files (.py, .ipynb, .R, .sas, .sql in project dirs)
     analysis_extensions = [".py", ".ipynb", ".R", ".r", ".sas", ".sql", ".qmd"]
     if any(path.endswith(ext) for ext in analysis_extensions):
-        print(json.dumps({
-            "decision": "block",
-            "message": "🛑 Iron Law: No analysis code in main chat. This file should be written by a delegated subagent. Use ds-delegate to dispatch a Task agent."
-        }))
-        return
+        deny("🛑 Iron Law: No analysis code in main chat. This file should be written by a delegated subagent. Use ds-delegate to dispatch a Task agent.")
 
-    print(json.dumps({"decision": "allow"}))
+    allow()
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-post-subagent-guard.py
+++ b/hooks/ds-post-subagent-guard.py
@@ -27,8 +27,10 @@ def main():
     with open(flag_file, "w") as f:
         f.write("1")
 
-    # Allow the tool use to proceed
-    print(json.dumps({"decision": "allow"}))
+    # Nothing to say. PostToolUse accepts a top-level "decision", but ONLY the value
+    # "block" -- {"decision": "allow"} is rejected as invalid and the whole payload is
+    # dropped. Staying silent is how a PostToolUse hook says "carry on".
+    sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-pre-subagent-clear.py
+++ b/hooks/ds-pre-subagent-clear.py
@@ -7,7 +7,17 @@ reads needed to prepare the subagent prompt are not blocked.
 import json
 import os
 import sys
+from pathlib import Path
 import tempfile
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 
 def main():
@@ -19,7 +29,7 @@ def main():
     if os.path.exists(flag_file):
         os.remove(flag_file)
 
-    print(json.dumps({"decision": "allow"}))
+    allow()
 
 
 if __name__ == "__main__":

--- a/hooks/ds-read-after-subagent-guard.py
+++ b/hooks/ds-read-after-subagent-guard.py
@@ -7,7 +7,17 @@ Read/Grep on paths that are NOT under .planning/.
 import json
 import os
 import sys
+from pathlib import Path
 import tempfile
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -21,8 +31,7 @@ def main():
 
     if not os.path.exists(flag_file):
         # No subagent has returned yet — allow everything
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Subagent has returned — check if this is a read on non-state files
     path = ""
@@ -34,20 +43,15 @@ def main():
         path = tool_params.get("path", "")
 
     if not path:
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Allow reads of state files (.planning/), plugin files, and common config
     allowed_patterns = [".planning/", ".claude/", "CLAUDE.md", "plugins/cache/"]
     if any(pattern in path for pattern in allowed_patterns):
-        print(json.dumps({"decision": "allow"}))
-        return
+        allow()
 
     # Block reads of source/data files after subagent return
-    print(json.dumps({
-        "decision": "block",
-        "message": "\ud83d\uded1 Post-subagent boundary (C5): After a subagent returns, main chat must NOT read source/data files. Verify via .planning/ state files only. If you need to investigate further, dispatch a NEW subagent."
-    }))
+    deny("\ud83d\uded1 Post-subagent boundary (C5): After a subagent returns, main chat must NOT read source/data files. Verify via .planning/ state files only. If you need to investigate further, dispatch a NEW subagent.")
 
 if __name__ == "__main__":
     main()

--- a/hooks/ds-reviewer-readonly-guard.py
+++ b/hooks/ds-reviewer-readonly-guard.py
@@ -6,6 +6,16 @@ tool calls to prevent reviewers from "fixing" issues they find.
 """
 import json
 import sys
+from pathlib import Path
+
+# PreToolUse has NO top-level `decision` field -- gates go through
+# hookSpecificOutput.permissionDecision. Emitting {"decision": ...} gets the whole
+# payload rejected by the harness ("Hook JSON output validation failed"), silently
+# disabling this guard. Use the shared helpers.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import allow, deny  # noqa: E402
+
 
 def main():
     tool_input = json.loads(sys.stdin.read())
@@ -19,14 +29,10 @@ def main():
         path = tool_input.get("tool_input", {}).get("file_path", "")
         parts = [p for p in path.replace("\\", "/").split("/") if p and p != "."]
         if parts and parts[0] in (".planning", ".claude"):
-            print(json.dumps({"decision": "allow"}))
-            return
-        print(json.dumps({
-            "decision": "block",
-            "message": "\ud83d\uded1 Reviewer read-only enforcement: Review/verification agents must NOT modify files. Report findings back to the orchestrator for planned fixes. (Writes to .planning/ verdict sentinels are allowed.)"
-        }))
+            allow()
+        deny("\ud83d\uded1 Reviewer read-only enforcement: Review/verification agents must NOT modify files. Report findings back to the orchestrator for planned fixes. (Writes to .planning/ verdict sentinels are allowed.)")
     else:
-        print(json.dumps({"decision": "allow"}))
+        allow()
 
 if __name__ == "__main__":
     main()

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -106,6 +106,16 @@
           }
         ]
       }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python3 ${CLAUDE_PLUGIN_ROOT}/hooks/subagent-start.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/pre-compact.py
+++ b/hooks/pre-compact.py
@@ -78,6 +78,64 @@ def append_compaction_marker(learnings_path: Path, workflow: str | None) -> bool
         return False
 
 
+def domain_skills_from_spec() -> list[str]:
+    """Skills listed under a 'Skills Touched'-style section of SPEC.md / PLAN.md.
+
+    ds-plan Step 5b globs these skills' references/ ONCE while drafting the plan. That is
+    plan-time only -- nothing re-reads them during implementation, which is how stale
+    domain knowledge slips through. Persisting them here lets SubagentStart re-assert it.
+    """
+    skills: list[str] = []
+    for name in ('SPEC.md', 'PLAN.md'):
+        p = Path.cwd() / '.planning' / name
+        if not p.exists():
+            continue
+        try:
+            text = p.read_text(encoding='utf-8')
+        except (IOError, OSError):
+            continue
+        # lines like:  - `wrds` -- TAQ millisecond data, SAS on the WRDS grid
+        for m in re.finditer(r'^\s*[-*]\s+`([a-z0-9][a-z0-9:_-]*)`\s*[-—]', text, re.M):
+            s = m.group(1)
+            if s not in skills:
+                skills.append(s)
+    return skills
+
+
+def write_state_file(workflow: str | None, instructions: list[str]) -> None:
+    """Persist workflow state so it survives compaction AND reaches spawned subagents."""
+    planning = Path.cwd() / '.planning'
+    if not planning.is_dir():
+        return
+    skills = domain_skills_from_spec()
+    ts = datetime.now().strftime('%Y-%m-%d %H:%M')
+    lines = [
+        "# STATE (auto-written by pre-compact.py -- safe to edit by hand)",
+        "",
+        f"_Last updated: {ts}_",
+        "",
+        f"## Active workflow: {'/' + workflow if workflow else 'UNKNOWN'}",
+        "",
+        *(f"- {i}" for i in instructions),
+        "",
+    ]
+    if skills:
+        lines += [
+            "## Domain knowledge — READ BEFORE WRITING CODE",
+            "",
+            "These skills' `references/` and `examples/` hold verified, project-specific",
+            "facts that supersede training data. Re-read them at implementation time, not",
+            "just at plan time:",
+            "",
+            *(f"- `{s}` — see `~/projects/workflows/skills/{s}/references/`" for s in skills),
+            "",
+        ]
+    try:
+        (planning / 'STATE.md').write_text("\n".join(lines), encoding='utf-8')
+    except (IOError, OSError) as e:
+        print(f"[PreCompact] Failed to write STATE.md: {e}", file=sys.stderr)
+
+
 def main():
     # Read hook input
     try:
@@ -122,15 +180,20 @@ def main():
             f"Read {learnings_loc} for session context and recent progress."
         )
 
-    # Output additionalContext to be included in compaction summary
+    # PreCompact does NOT support hookSpecificOutput.additionalContext -- the harness
+    # rejects the whole payload ("Hook JSON output validation failed"), silently dropping
+    # the reload instruction. Per https://code.claude.com/docs/en/hooks.md PreCompact only
+    # accepts top-level `decision`/`reason` plus universal fields (systemMessage, continue,
+    # suppressOutput, stopReason, terminalSequence).
+    #
+    # So PERSIST the state to .planning/STATE.md instead. SessionStart surfaces .planning/
+    # on the next session, and subagent-start.py reads STATE.md to brief spawned agents.
     if reload_instructions:
-        result = {
-            "hookSpecificOutput": {
-                "hookEventName": "PreCompact",
-                "additionalContext": "\n".join(reload_instructions)
-            }
-        }
-        print(json.dumps(result))
+        write_state_file(active_workflow, reload_instructions)
+        print(json.dumps({
+            "systemMessage": f"Workflow state saved to .planning/STATE.md"
+                             + (f" (/{active_workflow} active)" if active_workflow else "")
+        }))
 
     sys.exit(0)
 

--- a/hooks/subagent-start.py
+++ b/hooks/subagent-start.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env -S uv run python3
+"""
+SubagentStart hook: brief every spawned subagent with the project's domain knowledge.
+
+WHY THIS EXISTS
+    Domain references (e.g. wrds/references/taq.md) are globbed ONCE by ds-plan Step 5b
+    while drafting the plan. Nothing re-reads them during implementation, so a subagent
+    spawned to write code starts with no idea that verified, project-specific facts exist
+    -- and re-derives (or contradicts) them. Observed 2026-07-21: a TAQ pipeline was
+    rebuilt from scratch when taq.md already documented the correct pattern WITH
+    benchmarks, and a reference file's own validation numbers were treated as ground
+    truth when they were provisional.
+
+    SubagentStart is one of the events that DOES support
+    hookSpecificOutput.additionalContext (unlike PreCompact), so it is the right place
+    to re-assert this. See https://code.claude.com/docs/en/hooks.md
+
+WHAT IT INJECTS
+    - the active workflow + phase, from .planning/STATE.md
+    - the domain skills listed in SPEC.md/PLAN.md, with their references/ paths
+    - a hard instruction to READ them before writing code in that domain
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SKILLS_ROOT = Path.home() / 'projects' / 'workflows' / 'skills'
+
+
+def read(p: Path) -> str:
+    try:
+        return p.read_text(encoding='utf-8')
+    except (IOError, OSError):
+        return ''
+
+
+def domain_skills() -> list[str]:
+    """Skill names listed in .planning/SPEC.md or PLAN.md (the 'Skills Touched' section)."""
+    skills: list[str] = []
+    for name in ('STATE.md', 'SPEC.md', 'PLAN.md'):
+        text = read(Path.cwd() / '.planning' / name)
+        for m in re.finditer(r'^\s*[-*]\s+`([a-z0-9][a-z0-9:_-]*)`\s*[-—]', text, re.M):
+            s = m.group(1)
+            if s not in skills:
+                skills.append(s)
+    return skills
+
+
+def reference_files(skill: str) -> list[str]:
+    d = SKILLS_ROOT / skill / 'references'
+    if not d.is_dir():
+        return []
+    return sorted(p.name for p in d.glob('*.md'))
+
+
+def active_workflow() -> str | None:
+    m = re.search(r'^## Active workflow:\s*/?(\S+)', read(Path.cwd() / '.planning' / 'STATE.md'), re.M)
+    if m and m.group(1).upper() != 'UNKNOWN':
+        return m.group(1).lstrip('/')
+    return None
+
+
+def main():
+    try:
+        json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    if not (Path.cwd() / '.planning').is_dir():
+        sys.exit(0)
+
+    parts: list[str] = []
+
+    wf = active_workflow()
+    if wf:
+        parts.append(
+            f"ACTIVE WORKFLOW: /{wf}. This task is part of that workflow -- follow its "
+            f"conventions, and read .planning/STATE.md, SPEC.md and PLAN.md for the "
+            f"current phase, constraints and decisions already made."
+        )
+
+    skills = domain_skills()
+    if skills:
+        lines = [
+            "DOMAIN KNOWLEDGE -- READ BEFORE WRITING ANY CODE IN THESE AREAS.",
+            "",
+            "These reference files contain VERIFIED, project-specific facts (data-model",
+            "gotchas, validated patterns, measured benchmarks) that SUPERSEDE your training",
+            "data. They are frequently updated. Re-derived answers have repeatedly been wrong",
+            "or slower than the documented pattern. Read the relevant file FIRST, and treat",
+            "numbers in them as provisional if they are the project's own (not published)",
+            "results.",
+            "",
+        ]
+        for s in skills:
+            refs = reference_files(s)
+            base = SKILLS_ROOT / s / 'references'
+            if refs:
+                lines.append(f"- `{s}` -> {base}/")
+                lines.append(f"    {', '.join(refs)}")
+            else:
+                lines.append(f"- `{s}` (skill: {SKILLS_ROOT / s})")
+        parts.append("\n".join(lines))
+
+    if not parts:
+        sys.exit(0)
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SubagentStart",
+            "additionalContext": "\n\n".join(parts),
+        }
+    }))
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/hooks/suggest-compact.py
+++ b/hooks/suggest-compact.py
@@ -76,10 +76,15 @@ def main():
         message = f"[StrategicCompact] {count} edits - good checkpoint for /compact if context is stale"
 
     if message:
-        # Output as additionalContext to inform Claude
+        # hookEventName MUST match the event this hook was actually invoked on, or the
+        # harness rejects the payload and the suggestion is dropped. This hook is wired
+        # to PreToolUse (hooks/hooks.json) AND to PostToolUse (skills/workshop,
+        # skills/workshop-revise), so hardcoding "PreToolUse" silently broke it under
+        # the workshop wiring. Read the event from the payload instead.
+        event = hook_input.get('hook_event_name') or 'PreToolUse'
         result = {
             "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
+                "hookEventName": event,
                 "additionalContext": message
             }
         }

--- a/hooks/writing-claim-id-guard.py
+++ b/hooks/writing-claim-id-guard.py
@@ -15,10 +15,18 @@ risk flagged in DESIGN D-w-3):
 Only enforced inside a writing PROJECT (a .planning/ dir present).
 """
 import json
-import os
 import re
 import sys
 from pathlib import Path
+
+# Hooks read their payload from STDIN -- CLAUDE_TOOL_INPUT does not exist -- and there
+# is no {"result": ...} field in the hook contract. This hook used both, so it saw an
+# empty tool_input on every call and its output was rejected wholesale. Warnings go
+# through hookSpecificOutput.additionalContext; a hard stop on PostToolUse is
+# top-level decision:"block" + reason.
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import context  # noqa: E402
 
 CLAIM_PATTERN = re.compile(r'CLAIM-\d+')
 
@@ -28,17 +36,18 @@ def _in_writing_project(p: Path) -> bool:
 
 
 def main():
-    tool_input_str = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
     try:
-        tool_input = json.loads(tool_input_str)
-    except json.JSONDecodeError:
-        print(json.dumps({"result": "continue"}))
-        return
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
 
+    if hook_input.get('tool_name', '') not in ('Write', 'Edit', 'MultiEdit'):
+        sys.exit(0)
+
+    tool_input = hook_input.get('tool_input', {}) or {}
     file_path = tool_input.get('file_path', '')
     if not file_path:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     p = Path(file_path)
     parts = p.parts
@@ -48,26 +57,22 @@ def main():
     is_draft = 'drafts' in parts
 
     if not (is_outline or is_draft):
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Check if the file exists and contains CLAIM-XX references
     if not p.exists():
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     try:
         content = p.read_text()
     except Exception:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     claims = CLAIM_PATTERN.findall(content)
     artifact_type = "outline" if is_outline else "draft"
 
     if claims:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     remedy = (
         f"No CLAIM-XX IDs found in {artifact_type} file: {file_path}\n"
@@ -89,7 +94,7 @@ def main():
         return
 
     # Outlines (or non-project files) → warn only; the outline-executable guard hard-gates at approval.
-    print(json.dumps({"result": "continue", "message": remedy}))
+    context('PostToolUse', remedy)
 
 
 if __name__ == '__main__':

--- a/hooks/writing-outline-guard.py
+++ b/hooks/writing-outline-guard.py
@@ -7,9 +7,12 @@ without a matching outline — the Iron Law in the prompt handles hard enforceme
 """
 
 import json
-import os
 import sys
 from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import deny  # noqa: E402
 
 
 def main():
@@ -63,16 +66,19 @@ def main():
     if outline_found:
         sys.exit(0)  # Outline exists, allow
 
-    # Hard block — NO PROSE WITHOUT OUTLINE (Iron Law enforcement)
-    error = (
+    # Hard block — NO PROSE WITHOUT OUTLINE (Iron Law enforcement).
+    #
+    # This used to be `print(..., file=sys.stderr); sys.exit(1)`, which does NOT block:
+    # on PreToolUse only exit code 2 blocks the tool call, and every other non-zero code
+    # is a "non-blocking error". The Write went through and the message never reached
+    # Claude. The contract-correct hard stop is permissionDecision "deny".
+    deny(
         f"BLOCKED: No outline found for this draft.\n\n"
         f"Writing to `{file_path}` but no matching outline in `{outlines_dir}/`.\n"
         f"Expected: `{outlines_dir}/{section_name}.md`\n\n"
         f"Create the outline first. Prose without structure produces wandering drafts "
         f"that require full rewrites — that's anti-helpful, not efficient."
     )
-    print(error, file=sys.stderr)
-    sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/hooks/writing-precis-guard.py
+++ b/hooks/writing-precis-guard.py
@@ -6,10 +6,18 @@ Fires after Write to .planning/PRECIS.md. Checks that all required sections
 (Thesis, Key Claims with CLAIM-XX IDs, Audience, Scope) are present.
 """
 import json
-import os
 import re
 import sys
 from pathlib import Path
+
+# Hooks receive their payload as JSON on STDIN -- there is no CLAUDE_TOOL_INPUT env
+# var, and there is no {"result": "continue"} in the hook contract. This hook used
+# both, so it read an empty input on every call and then emitted a payload the harness
+# rejected outright. Non-blocking feedback on PostToolUse goes through
+# hookSpecificOutput.additionalContext; saying nothing is how a hook says "carry on".
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import context  # noqa: E402
 
 REQUIRED_SECTIONS = {
     'thesis': re.compile(r'(?:^|\n)#+\s*thesis|(?:^|\n)\*\*thesis', re.IGNORECASE),
@@ -19,33 +27,31 @@ REQUIRED_SECTIONS = {
 
 
 def main():
-    tool_input_str = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
     try:
-        tool_input = json.loads(tool_input_str)
-    except json.JSONDecodeError:
-        print(json.dumps({"result": "continue"}))
-        return
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
 
+    if hook_input.get('tool_name', '') not in ('Write', 'Edit', 'MultiEdit'):
+        sys.exit(0)
+
+    tool_input = hook_input.get('tool_input', {}) or {}
     file_path = tool_input.get('file_path', '')
     if not file_path:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Only check PRECIS.md writes
     p = Path(file_path)
     if p.name != 'PRECIS.md' or '.planning' not in str(p):
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     if not p.exists():
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     try:
         content = p.read_text()
     except Exception:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     missing = []
     for section, pattern in REQUIRED_SECTIONS.items():
@@ -53,17 +59,13 @@ def main():
             missing.append(section)
 
     if missing:
-        print(json.dumps({
-            "result": "continue",
-            "message": (
-                f"PRECIS.md is missing required sections: {', '.join(missing)}\n"
-                f"A complete PRECIS needs: Thesis (main argument), "
-                f"Key Claims (with CLAIM-XX IDs), and Audience.\n"
-                f"Add the missing sections before proceeding to outline."
-            )
-        }))
-    else:
-        print(json.dumps({"result": "continue"}))
+        context('PostToolUse', (
+            f"PRECIS.md is missing required sections: {', '.join(missing)}\n"
+            f"A complete PRECIS needs: Thesis (main argument), "
+            f"Key Claims (with CLAIM-XX IDs), and Audience.\n"
+            f"Add the missing sections before proceeding to outline."
+        ))
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/hooks/writing-suggest-verify.py
+++ b/hooks/writing-suggest-verify.py
@@ -6,10 +6,20 @@ Only fires for Edit/Write on .md files when an active writing workflow exists.
 Tracks edit count in ACTIVE_WORKFLOW.md and suggests edit loop at threshold.
 """
 import json
-import os
 import re
 import sys
 from pathlib import Path
+
+# Hooks read their payload from STDIN -- CLAUDE_TOOL_INPUT does not exist -- and
+# {"result": "continue"} is not part of the hook contract. This hook used both, so it
+# saw an empty file_path on EVERY Edit/Write, took the early-return branch, and then
+# emitted a payload the harness rejected outright ("Hook JSON output validation
+# failed"). Net effect: the verify-nudge never fired and the edit counter never moved.
+# Non-blocking feedback on PostToolUse is hookSpecificOutput.additionalContext;
+# printing nothing is how a hook says "carry on".
+HOOKS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(HOOKS_DIR))
+from _gate_common import context  # noqa: E402
 
 
 def parse_yaml_value(content: str, key: str, default=None):
@@ -40,37 +50,35 @@ def update_yaml_value(content: str, key: str, new_value) -> str:
 
 
 def main():
-    # Read tool input
-    tool_input_str = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
     try:
-        tool_input = json.loads(tool_input_str)
-    except json.JSONDecodeError:
-        tool_input = {}
+        hook_input = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
 
+    if hook_input.get('tool_name', '') not in ('Write', 'Edit', 'MultiEdit'):
+        sys.exit(0)
+
+    tool_input = hook_input.get('tool_input', {}) or {}
     file_path = tool_input.get('file_path', '')
 
     # Only process markdown files
     if not file_path.endswith('.md'):
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Check for active writing workflow
     workflow_path = Path.cwd() / '.planning' / 'ACTIVE_WORKFLOW.md'
     if not workflow_path.exists():
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     try:
         content = workflow_path.read_text()
     except Exception:
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Check if this is a writing workflow
     workflow_type = parse_yaml_value(content, 'workflow')
     if workflow_type != 'writing':
-        print(json.dumps({"result": "continue"}))
-        return
+        sys.exit(0)
 
     # Get current edit count and threshold
     edits = int(parse_yaml_value(content, 'edits_since_verify', '0'))
@@ -87,15 +95,16 @@ def main():
         style = parse_yaml_value(content, 'style', 'general')
         phase = parse_yaml_value(content, 'phase', 'edit')
 
-        print(json.dumps({
-            "result": "continue",
-            "message": f"📝 {edits} edits since last verify (style: {style}, phase: {phase}). Consider `/writing-revise` to apply fixes and polish."
-        }))
+        context(
+            'PostToolUse',
+            f"📝 {edits} edits since last verify (style: {style}, phase: {phase}). "
+            f"Consider `/writing-revise` to apply fixes and polish."
+        )
     else:
         # Just increment counter
         new_content = update_yaml_value(content, 'edits_since_verify', str(edits))
         workflow_path.write_text(new_content)
-        print(json.dumps({"result": "continue"}))
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/references/enforcement-checklist.md
+++ b/references/enforcement-checklist.md
@@ -110,6 +110,23 @@ Before proceeding to [next phase]:
 
 **Key insight:** Gates must be *programmatically verifiable*. "Quality is sufficient" is not a gate. "File X contains string Y" is a gate.
 
+**If the gate is a HOOK, its OUTPUT must be valid for its event — or it is not a gate at all.**
+A hook that emits a field its event does not accept has its **entire** payload rejected by the
+harness (`Hook JSON output validation failed — (root): Invalid input`). It still runs, still
+exits 0, prints nothing anyone sees, and its `deny` silently becomes an allow. Checking that the
+hook exists, that its `command:` resolves, and that its `matcher` covers the step does **not**
+catch this — all three pass on a hook that enforces nothing.
+
+The three that keep recurring:
+- top-level `decision` on `PreToolUse` (gates use `hookSpecificOutput.permissionDecision`)
+- `hookSpecificOutput` on `PreCompact` / `SessionEnd` / `Notification`, which accept none
+- `decision: "allow"` or an invented `{"result": "continue"}` / `"message"` — no event has these
+
+Validate by EXECUTION, never by reading: `./scripts/check-hooks.sh` runs every wiring (from
+`hooks/hooks.json` **and** every skill's `hooks:` frontmatter) against the per-event schema. See
+workflow-creator Mode 2 **Step 3c**. Reading the hook is not enough — the invalid branch is
+usually the *block* branch, which only a real payload reaches.
+
 ---
 
 ### 5. Flowcharts as Spec

--- a/scripts/check-hooks.sh
+++ b/scripts/check-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Validate every wired hook's output against the per-event schema from
+# https://code.claude.com/docs/en/hooks.md
+#
+#   ./scripts/check-hooks.sh            # pytest: one case per wiring, fails loudly
+#   ./scripts/check-hooks.sh --report   # human table: script | event | matcher | verdict
+#
+# An invalid hook payload is rejected wholesale by the harness ("Hook JSON output
+# validation failed — (root): Invalid input") without raising, warning, or exiting
+# non-zero. Nothing else in this repo notices. This does.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ "${1:-}" = "--report" ]; then
+    exec uv run --with pyyaml python3 tests/hook_output_schema_test.py
+fi
+
+exec uv run --with pytest --with pyyaml python3 -m pytest \
+    tests/hook_output_schema_test.py "${@}"

--- a/scripts/checks/hook_output_schema.py
+++ b/scripts/checks/hook_output_schema.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Per-event output schema for Claude Code hooks, plus a validator.
+
+WHY THIS EXISTS
+    A hook that emits a field the harness does not recognise for its event gets its
+    ENTIRE payload rejected -- "Hook JSON output validation failed -- (root): Invalid
+    input" -- and whatever it was trying to say is silently dropped. Nothing fails
+    loudly, so a broken hook can sit in production indefinitely. That is exactly what
+    happened to hooks/pre-compact.py, which emitted
+    hookSpecificOutput.additionalContext on PreCompact (an event that does not accept
+    it), so the "reload the active workflow after compaction" instruction never
+    reached Claude and the workflow Iron Laws stopped being enforced after every
+    compaction.
+
+SOURCE OF TRUTH
+    https://code.claude.com/docs/en/hooks.md -- transcribed 2026-07-21. When the docs
+    change, update EVENTS here and the harness (tests/hook_output_schema_test.py)
+    picks it up.
+"""
+
+from __future__ import annotations
+
+# Fields accepted on EVERY event.
+UNIVERSAL_FIELDS = {
+    'continue',
+    'stopReason',
+    'suppressOutput',
+    'systemMessage',
+    'terminalSequence',
+}
+
+
+class Event:
+    __slots__ = ('top', 'hso', 'decision', 'stdout_is_context')
+
+    def __init__(self, top=(), hso=None, decision=(), stdout_is_context=False):
+        # Extra top-level fields beyond UNIVERSAL_FIELDS.
+        self.top = frozenset(top)
+        # None => hookSpecificOutput is NOT supported for this event.
+        self.hso = None if hso is None else frozenset(hso)
+        # Allowed values for a top-level "decision". Empty => decision unsupported.
+        self.decision = frozenset(decision)
+        self.stdout_is_context = stdout_is_context
+
+
+EVENTS: dict[str, Event] = {
+    'SessionStart': Event(
+        top={'additionalContext', 'initialUserMessage', 'sessionTitle', 'watchPaths', 'reloadSkills'},
+        hso={'additionalContext', 'watchPaths', 'reloadSkills'},
+        stdout_is_context=True,
+    ),
+    'Setup': Event(
+        top={'additionalContext'},
+        hso={'additionalContext'},
+        stdout_is_context=True,
+    ),
+    'UserPromptSubmit': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'UserPromptExpansion': Event(
+        top={'decision', 'reason'},
+        hso=None,
+        decision={'block'},
+    ),
+    'PreToolUse': Event(
+        top=set(),
+        hso={'permissionDecision', 'permissionDecisionReason', 'updatedInput', 'additionalContext'},
+        decision=set(),  # PreToolUse uses hookSpecificOutput.permissionDecision, NOT decision
+    ),
+    'PostToolUse': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'updatedToolOutput', 'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'PostToolUseFailure': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'PostToolBatch': Event(
+        top={'decision', 'reason', 'additionalContext'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'Stop': Event(
+        top={'decision', 'reason'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'SubagentStop': Event(
+        top={'decision', 'reason'},
+        hso={'additionalContext'},
+        decision={'block'},
+        stdout_is_context=True,
+    ),
+    'SubagentStart': Event(
+        top={'additionalContext'},
+        hso={'additionalContext'},
+        stdout_is_context=True,
+    ),
+    'PreCompact': Event(
+        top={'decision', 'reason'},
+        hso=None,  # <- the pre-compact.py bug: hookSpecificOutput is NOT accepted here
+        decision={'block'},
+    ),
+    'PostCompact': Event(hso=None),
+    'SessionEnd': Event(hso=None),
+    'Notification': Event(hso=None),
+    'PermissionRequest': Event(hso={'decision'}),
+    'PermissionDenied': Event(hso={'retry'}),
+}
+
+# permissionDecision values, PreToolUse only.
+PERMISSION_DECISIONS = frozenset({'allow', 'deny', 'ask', 'defer'})
+
+
+def validate_payload(event: str, payload: dict) -> list[str]:
+    """Return a list of schema violations for `payload` emitted on `event`.
+
+    Empty list == valid. Mirrors the harness-side check whose failure produces
+    "Hook JSON output validation failed -- (root): Invalid input".
+    """
+    if event not in EVENTS:
+        return [f'unknown hook event {event!r}']
+    spec = EVENTS[event]
+    errors: list[str] = []
+
+    if not isinstance(payload, dict):
+        return [f'top-level output must be a JSON object, got {type(payload).__name__}']
+
+    allowed_top = UNIVERSAL_FIELDS | spec.top | {'hookSpecificOutput'}
+    for key in payload:
+        if key == 'hookSpecificOutput':
+            continue
+        if key not in allowed_top:
+            errors.append(
+                f'unsupported top-level field {key!r} on {event} '
+                f'(allowed: {", ".join(sorted(allowed_top))})'
+            )
+
+    if 'decision' in payload:
+        if not spec.decision:
+            hint = (
+                ' — PreToolUse uses hookSpecificOutput.permissionDecision'
+                if event == 'PreToolUse' else ''
+            )
+            errors.append(f'{event} does not support a top-level "decision" field{hint}')
+        elif payload['decision'] not in spec.decision:
+            errors.append(
+                f'decision={payload["decision"]!r} not allowed on {event} '
+                f'(allowed: {", ".join(sorted(spec.decision))})'
+            )
+
+    if 'hookSpecificOutput' in payload:
+        hso = payload['hookSpecificOutput']
+        if spec.hso is None:
+            errors.append(
+                f'{event} does not support hookSpecificOutput at all '
+                f'(this rejects the WHOLE payload — the pre-compact.py bug)'
+            )
+        elif not isinstance(hso, dict):
+            errors.append('hookSpecificOutput must be a JSON object')
+        else:
+            name = hso.get('hookEventName')
+            if name is None:
+                errors.append('hookSpecificOutput is missing hookEventName')
+            elif name != event:
+                errors.append(
+                    f'hookSpecificOutput.hookEventName={name!r} but the hook is wired to {event}'
+                )
+            for key in hso:
+                if key == 'hookEventName':
+                    continue
+                if key not in spec.hso:
+                    errors.append(
+                        f'unsupported hookSpecificOutput field {key!r} on {event} '
+                        f'(allowed: {", ".join(sorted(spec.hso))})'
+                    )
+            pd = hso.get('permissionDecision')
+            if pd is not None and pd not in PERMISSION_DECISIONS:
+                errors.append(
+                    f'permissionDecision={pd!r} invalid '
+                    f'(allowed: {", ".join(sorted(PERMISSION_DECISIONS))})'
+                )
+
+    return errors

--- a/skills/workflow-creator/SKILL.md
+++ b/skills/workflow-creator/SKILL.md
@@ -1710,7 +1710,7 @@ If verification only checks Level 1 (exists), it's theater. A workflow that clai
 - Specifically check for: **phase gate enforcement** (prerequisite artifact checks), file extension guards, path guards, tool parameter validation, tool sequence enforcement, post-subagent restrictions
 - Behavioral/motivational constraints (rationalization tables, drive-aligned framing) should STAY as prompt — hooks can't teach reasoning
 - Score based on: how many mechanical constraints are prompt-only when they could be hooks?
-- **Mechanical sub-probe (COVERAGE, not presence — RUN it, do not eyeball):** P20 is NOT satisfied by the mere existence of some hooks. Grep the skill bodies for every IMPERATIVE script-step — bang-lines (`` !`…` ``) and phrases like "run `X`", "must run", "first run", "uv run", "run check-all", "run the … script". For each that is mechanically checkable (a script that exits non-zero / emits a checkable artifact), confirm a hook **or** bang-line actually guarantees it, matching the hook's **matcher + command** to the step. Two false-positives to reject: (a) other unrelated hooks do not cover this step; (b) a gate whose matcher is `Write|Edit|Agent` does NOT cover a step that must precede a **`Workflow`/`Agent` fan-out** (the matcher must include the gated tool). Any mechanically-checkable imperative step with no matching enforcing mechanism is a P20 gap — even when the skill has other hooks. (Real miss this encodes: "run check-all before the review fan-out" sat in skippable prose while a hook on `VALIDATION.md` existence looked like it satisfied "phase gate enforcement.")
+- **Mechanical sub-probe (COVERAGE, not presence — RUN it, do not eyeball):** P20 is NOT satisfied by the mere existence of some hooks. Grep the skill bodies for every IMPERATIVE script-step — bang-lines (`` !`…` ``) and phrases like "run `X`", "must run", "first run", "uv run", "run check-all", "run the … script". For each that is mechanically checkable (a script that exits non-zero / emits a checkable artifact), confirm a hook **or** bang-line actually guarantees it, matching the hook's **matcher + command** to the step. Two false-positives to reject: (a) other unrelated hooks do not cover this step; (b) a gate whose matcher is `Write|Edit|Agent` does NOT cover a step that must precede a **`Workflow`/`Agent` fan-out** (the matcher must include the gated tool). Any mechanically-checkable imperative step with no matching enforcing mechanism is a P20 gap — even when the skill has other hooks. **P20 scores COVERAGE, never VALIDITY:** a hook can cover its step perfectly and still emit a payload the harness discards, at which point it enforces nothing. That is Step 3c's job — score P20 on coverage and let the hook-contract harness decide whether the covering hook actually works. (Real miss this encodes: "run check-all before the review fan-out" sat in skippable prose while a hook on `VALIDATION.md` existence looked like it satisfied "phase gate enforcement.")
 
 **P21 — Auto-loader usage for constraints:**
 - Do phase skills that load constraint prose use the bang-invoked auto-loader?
@@ -1895,6 +1895,79 @@ affects: [.planning/wc/{name}/STATE.md]
 one-liner: "Path portability scored Clean/Partial/Broken; hook-command variable audit run; candidacy scan fed into Step 4."
 ```
 
+**Proceed to Step 3c.**
+
+### Step 3c: Validate the Hook OUTPUT Contract (RUN it — do not read the hooks)
+
+Steps 3a/3b and P20 all check a hook's **wiring**: does it exist, does its `command:` resolve,
+does its `matcher` cover the step it gates. **None of them check whether the hook's OUTPUT is
+legal for the event it is wired to** — and that is a distinct, entirely silent failure mode.
+
+**Why this is its own step.** When a hook emits a field its event does not accept, Claude Code
+rejects the **entire** payload (`Hook JSON output validation failed — (root): Invalid input`).
+The hook still runs, still exits 0, still prints nothing a human sees. A `deny` becomes an
+allow; an `additionalContext` never reaches Claude. The audit sees a hook wired to the right
+tool with a resolving path and scores it Present — while it enforces nothing. This is strictly
+worse than a missing hook, because the presence of the hook is what stops anyone looking.
+
+This is the same silent-failure family as the April 2026 `${CLAUDE_SKILL_DIR}` incident above —
+note that the guard quoted there defaults to `{"decision": "approve"}`, which is itself not a
+valid payload for any event. The class was diagnosed as a *path* problem; the *payload* half
+went unexamined for another year.
+
+**Real incident (July 2026).** `hooks/pre-compact.py` emitted
+`hookSpecificOutput.additionalContext` on `PreCompact`, which accepts no `hookSpecificOutput` at
+all. Its "the `/ds` workflow was active before compaction — reload it" instruction was dropped
+after **every** compaction, so the workflow's Iron Laws stopped being enforced for the rest of
+each session. Running the harness for the first time found **8 more broken scripts** in the same
+repo, including `ds-no-main-chat-code-guard.py` — the hook enforcing "YOU MUST NOT WRITE ANALYSIS
+CODE IN MAIN CHAT" — which emitted `{"decision": "block", "message": …}` on `PreToolUse`, an
+event with no top-level `decision` field. Every `deny` it ever issued was discarded.
+
+**How to score it — execute, do not eyeball:**
+
+```bash
+cd "$PROJECT" && ./scripts/check-hooks.sh --report
+```
+
+The harness (`tests/hook_output_schema_test.py` + `scripts/checks/hook_output_schema.py`)
+discovers every wiring from `hooks/hooks.json` **and** every `hooks:` frontmatter block in
+`skills/*/SKILL.md`, feeds each realistic payloads, and validates the emitted JSON against the
+per-event schema from <https://code.claude.com/docs/en/hooks.md>. Reading a hook cannot
+substitute for running it: the invalid branch is usually the *block* branch, which only a real
+payload reaches.
+
+Three defects it catches, none of which any other step sees:
+1. **Wrong shape for the event** — `hookSpecificOutput` on `PreCompact`/`SessionEnd`/`Notification`;
+   a top-level `decision` on `PreToolUse` (gates go through `hookSpecificOutput.permissionDecision`);
+   `decision: "allow"` anywhere (only `"block"` exists); invented fields like
+   `{"result": "continue"}` or `"message"`.
+2. **`hookEventName` disagreeing with the wiring** — including a hook wired to *two* events that
+   hardcodes one of them. Read `hook_event_name` off the payload instead.
+3. **Exit code used as a decision** — on `PreToolUse` only exit **2** blocks; any other non-zero
+   is a non-blocking error, so `sys.exit(1)` after printing a block message is a no-op.
+
+**Score:**
+- **Clean** — every wiring the harness exercised emits a payload its event accepts
+- **Broken** — one or more INVALID wirings. **Each is a critical finding** and fails the
+  substrate gate. Never downgrade one because the hook "looks correct" — the harness is the
+  authority, not a reading of the source.
+- **NotRun** — the audited repo has no harness. Note it as a minor finding and say plainly that
+  hook payload validity was **not** checked.
+
+**Gate: Hook Contract Validated** `[checkpoint: deterministic]`
+- `./scripts/check-hooks.sh` exits 0, or every INVALID wiring is recorded as a critical finding
+
+Update `.planning/wc/{name}/STATE.md`:
+```yaml
+step: 3c-hook-contract
+status: completed
+requires: [scripts/check-hooks.sh, all wired hooks]
+provides: [hook output-contract status]
+affects: [.planning/wc/{name}/STATE.md]
+one-liner: "Hook output contract executed against the per-event schema; INVALID wirings recorded as criticals."
+```
+
 #### Ultracode-Workflow Candidacy Scan (feeds Step 4 Recommendations — no separate gate)
 
 Before writing the report, scan every phase for **ultracode-workflow migration candidates** — fan-out phases that should be Claude Code ultracode workflows rather than in-skill agent dispatch. Read `${CLAUDE_SKILL_DIR}/references/dynamic-workflow-migration.md` §1 for the rubric. **Scan for BOTH worker modes — workflows are NOT read-only:**
@@ -1983,6 +2056,15 @@ Format:
 |------|---------|--------|
 | skills/X/SKILL.md | `uv run python3 scripts/foo.py` | ❌ Broken / ✅ Fixed |
 | skills/Y/SKILL.md | `Read("../../lib/...")` | ❌ Broken / ✅ Fixed |
+
+### Hook Output Contract
+| Hook | Event | Verdict | Violation |
+|------|-------|---------|-----------|
+| hooks/X.py | PreToolUse | ✅ Valid / ❌ INVALID | [the harness's verbatim message] |
+
+(From `./scripts/check-hooks.sh --report` — executed, not read. Every ❌ is a critical finding
+and fails the substrate gate: an invalid payload is discarded whole, so the hook silently stops
+enforcing while still appearing wired.)
 
 ### Ultracode-Workflow Migration Candidates
 | Phase | Fan-out? | Worker mode (review/transform) | Value driver | Recommend migrate? (strong/moderate) | Note |

--- a/tests/hook_output_schema_test.py
+++ b/tests/hook_output_schema_test.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env -S uv run --with pytest --with pyyaml python3
+"""Contract test: every wired hook must emit a payload its event actually accepts.
+
+    Run:  ./scripts/check-hooks.sh
+    or:   uv run --with pytest --with pyyaml python3 -m pytest tests/hook_output_schema_test.py
+    or:   uv run --with pyyaml python3 tests/hook_output_schema_test.py     (prints a report table)
+
+WHAT IT CATCHES
+    An invalid hook payload does not raise, does not exit non-zero, and does not warn.
+    The harness rejects the whole object ("Hook JSON output validation failed --
+    (root): Invalid input") and the hook's message vanishes. hooks/pre-compact.py sat
+    broken in production this way: it emitted hookSpecificOutput.additionalContext on
+    PreCompact, which does not accept it, so the "reload the active workflow" reminder
+    never landed and the workflow Iron Laws stopped being enforced after compaction.
+
+HOW
+    1. Discover EVERY wiring -- hooks/hooks.json AND the `hooks:` frontmatter that each
+       skills/*/SKILL.md declares (the larger surface; most guards live only there).
+    2. Feed each (script, event, matcher) realistic stdin payloads inside a throwaway
+       project fixture, so the interesting branches actually fire.
+    3. Parse stdout; if it is a JSON object, validate against the per-event schema in
+       scripts/checks/hook_output_schema.py.
+    4. Also assert the hook exits 0 on payloads it should ignore -- a stray non-zero
+       exit is read as a decision (blocks the tool call on PreToolUse).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+try:
+    import pytest
+except ModuleNotFoundError:  # standalone report mode does not need pytest
+    pytest = None
+
+REPO = Path(__file__).resolve().parents[1]
+HOOKS = REPO / 'hooks'
+sys.path.insert(0, str(REPO / 'scripts' / 'checks'))
+from hook_output_schema import EVENTS, validate_payload  # noqa: E402
+
+TIMEOUT = 90
+
+
+# --------------------------------------------------------------------------- wiring
+
+def _wirings_from_hooks_json() -> list[tuple[str, str, str, str]]:
+    """(source, event, matcher, script) from hooks/hooks.json."""
+    out = []
+    cfg = json.loads((HOOKS / 'hooks.json').read_text())
+    for event, entries in cfg.get('hooks', {}).items():
+        for entry in entries:
+            matcher = entry.get('matcher', '*')
+            for h in entry.get('hooks', []):
+                script = _script_of(h.get('command', ''))
+                if script:
+                    out.append(('hooks.json', event, matcher, script))
+    return out
+
+
+def _wirings_from_skills() -> list[tuple[str, str, str, str]]:
+    """(source, event, matcher, script) from every skills/*/SKILL.md `hooks:` frontmatter."""
+    out = []
+    for skill_md in sorted((REPO / 'skills').glob('*/SKILL.md')):
+        text = skill_md.read_text(encoding='utf-8')
+        if not text.startswith('---'):
+            continue
+        parts = text.split('---', 2)
+        if len(parts) < 3:
+            continue
+        try:
+            fm = yaml.safe_load(parts[1]) or {}
+        except yaml.YAMLError:
+            continue
+        hooks = fm.get('hooks')
+        if not isinstance(hooks, dict):
+            continue
+        for event, entries in hooks.items():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                matcher = entry.get('matcher', '*')
+                for h in entry.get('hooks', []) or []:
+                    if not isinstance(h, dict):
+                        continue
+                    script = _script_of(h.get('command', ''))
+                    if script:
+                        out.append((f'skills/{skill_md.parent.name}', event, str(matcher), script))
+    return out
+
+
+def _script_of(command: str) -> str | None:
+    for token in command.split():
+        if token.endswith('.py') and '/hooks/' in token:
+            return token.rsplit('/hooks/', 1)[1]
+    return None
+
+
+def all_wirings() -> list[tuple[str, str, str, str]]:
+    seen, out = set(), []
+    for w in _wirings_from_hooks_json() + _wirings_from_skills():
+        key = (w[1], w[2], w[3])  # dedupe on event+matcher+script, keep first source
+        if key not in seen:
+            seen.add(key)
+            out.append(w)
+    return out
+
+
+WIRINGS = all_wirings()
+
+
+# -------------------------------------------------------------------------- payloads
+
+TOOL_FIXTURES = {
+    'Write': {'file_path': 'drafts/section-01.md', 'content': '# Draft\n\nSome prose here.\n'},
+    'Edit': {'file_path': 'analysis/model.py', 'old_string': 'a', 'new_string': 'b'},
+    'MultiEdit': {'file_path': 'drafts/section-01.md', 'edits': []},
+    'Read': {'file_path': 'figures/plot.png'},
+    'Bash': {'command': 'pixi run python analysis/model.py', 'description': 'run model'},
+    'Task': {'description': 'analyze', 'prompt': 'do the thing', 'subagent_type': 'general-purpose'},
+    'Agent': {'description': 'analyze', 'prompt': 'do the thing'},
+    'Grep': {'pattern': 'foo'},
+    'Glob': {'pattern': '**/*.py'},
+    'Workflow': {'workflow': 'ds-validate-coverage'},
+    'Skill': {'skill': 'wrds'},
+}
+
+# Tools worth exercising per event when the matcher is a wildcard.
+DEFAULT_TOOLS = ['Write', 'Edit', 'Bash', 'Read', 'Task']
+
+
+def tools_for(matcher: str) -> list[str]:
+    if not matcher or matcher in ('*', '.*'):
+        return DEFAULT_TOOLS
+    names = [t.strip() for t in matcher.split('|') if t.strip()]
+    known = [t for t in names if t in TOOL_FIXTURES]
+    return known or DEFAULT_TOOLS
+
+
+def payloads_for(event: str, matcher: str, cwd: str) -> list[dict]:
+    """Realistic stdin payloads for this event, covering the branches a hook may take."""
+    base = {
+        'session_id': 'test-session',
+        'transcript_path': str(Path(cwd) / 'transcript.jsonl'),
+        'cwd': cwd,
+        'hook_event_name': event,
+        'permission_mode': 'default',
+    }
+    if event in ('PreToolUse', 'PostToolUse', 'PostToolUseFailure'):
+        out = []
+        for tool in tools_for(matcher):
+            p = dict(base, tool_name=tool, tool_input=TOOL_FIXTURES[tool])
+            if event != 'PreToolUse':
+                p['tool_response'] = {'stdout': 'https://github.com/o/r/pull/12', 'output': 'ok'}
+                p['tool_result'] = p['tool_response']
+            out.append(p)
+        return out
+    if event == 'PostToolBatch':
+        return [dict(base, tool_uses=[{'tool_name': 'Write', 'tool_input': TOOL_FIXTURES['Write']}])]
+    if event == 'SessionStart':
+        return [dict(base, source=s) for s in ('startup', 'resume', 'clear', 'compact')]
+    if event == 'SessionEnd':
+        return [dict(base, reason=r) for r in ('clear', 'logout', 'other')]
+    if event == 'PreCompact':
+        return [dict(base, trigger=t, custom_instructions='') for t in ('manual', 'auto')]
+    if event in ('SubagentStart',):
+        return [dict(base, agent_type='general-purpose', prompt='write the pipeline')]
+    if event in ('Stop', 'SubagentStop'):
+        return [dict(base, stop_hook_active=False)]
+    if event == 'UserPromptSubmit':
+        return [dict(base, prompt='run the analysis')]
+    return [base]
+
+
+def make_project(root: Path) -> None:
+    """A throwaway project that looks live enough to fire the interesting branches."""
+    planning = root / '.planning'
+    planning.mkdir(parents=True, exist_ok=True)
+    (planning / 'PLAN.md').write_text(
+        '## DS Workflow\n\n/ds\n\n### Skills Touched\n\n- `wrds` — TAQ millisecond data\n'
+    )
+    (planning / 'SPEC.md').write_text('# SPEC\n\n- `wrds` — TAQ data model\n')
+    (planning / 'STATE.md').write_text('# STATE\n\n## Active workflow: /ds\n')
+    (planning / 'LEARNINGS.md').write_text('# LEARNINGS\n')
+    (planning / 'ACTIVE_WORKFLOW.md').write_text(
+        '---\nworkflow: writing\nphase: draft\nstyle: volokh\n'
+        'edits_since_verify: 9\nverify_threshold: 10\n---\n'
+    )
+    (planning / 'PRECIS.md').write_text('# PRECIS\n\n## Thesis\n\nx\n')
+    (root / '.claude').mkdir(exist_ok=True)
+    (root / '.claude' / 'LEARNINGS.md').write_text('# LEARNINGS\n')
+    (root / '.claude' / 'PLAN.md').write_text('## DS Workflow\n')
+    for d in ('drafts', 'outlines', 'analysis', 'figures'):
+        (root / d).mkdir(exist_ok=True)
+    (root / 'drafts' / 'section-01.md').write_text('# Section\n\nProse without a claim id.\n')
+    (root / 'analysis' / 'model.py').write_text('import pandas as pd\n')
+    (root / 'transcript.jsonl').write_text(
+        json.dumps({'type': 'human', 'content': "no, don't do that again"}) + '\n'
+        + json.dumps({'type': 'human', 'content': 'i already told you, wrong'}) + '\n'
+    )
+
+
+def run_hook(script: str, payload: dict, cwd: str) -> tuple[int, str, str]:
+    env = dict(os.environ)
+    env['CLAUDE_PLUGIN_ROOT'] = str(REPO)
+    env['CLAUDE_PROJECT_DIR'] = cwd
+    env['CLAUDE_SESSION_ID'] = 'hook-schema-test'
+    # Some hooks read tool input from this env var instead of stdin. Populate it so the
+    # test exercises whatever path they take -- the point is the OUTPUT shape.
+    env['CLAUDE_TOOL_INPUT'] = json.dumps(payload.get('tool_input', {}))
+    proc = subprocess.run(
+        ['uv', 'run', 'python3', str(HOOKS / script)],
+        input=json.dumps(payload), capture_output=True, text=True,
+        cwd=cwd, env=env, timeout=TIMEOUT,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def check_one(script: str, event: str, matcher: str) -> list[str]:
+    """Run every payload for this wiring; return schema/exit violations."""
+    problems: list[str] = []
+    tmp = tempfile.mkdtemp(prefix='hookcheck-')
+    try:
+        for payload in payloads_for(event, matcher, tmp):
+            make_project(Path(tmp))
+            try:
+                code, stdout, stderr = run_hook(script, payload, tmp)
+            except subprocess.TimeoutExpired:
+                problems.append(f'{script} [{event}] timed out after {TIMEOUT}s')
+                continue
+
+            tool = payload.get('tool_name', '-')
+            where = f'{script} [{event}/{tool}]'
+
+            if code not in (0, 2):
+                problems.append(f'{where} exited {code} (only 0, or a deliberate 2, are safe)\n{stderr[:400]}')
+
+            text = stdout.strip()
+            if not text:
+                continue
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                # Plain text on stdout is fine -- it is treated as context (or ignored).
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            for err in validate_payload(event, parsed):
+                problems.append(f'{where} {err}\n    emitted: {text[:300]}')
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return problems
+
+
+# ----------------------------------------------------------------------------- tests
+
+_parametrize = (
+    pytest.mark.parametrize(
+        'source,event,matcher,script',
+        WIRINGS,
+        ids=[f'{w[1]}:{w[3]}:{w[2]}' for w in WIRINGS],
+    )
+    if pytest is not None
+    else (lambda fn: fn)
+)
+
+
+@_parametrize
+def test_wired_hook_emits_valid_payload(source, event, matcher, script):
+    assert event in EVENTS, f'{source} wires an unknown event {event!r}'
+    assert (HOOKS / script).exists(), f'{source} wires a missing script hooks/{script}'
+    problems = check_one(script, event, matcher)
+    assert not problems, (
+        f'{script} wired to {event} (matcher {matcher!r}, from {source}) emits payloads '
+        f'the harness will reject:\n  - ' + '\n  - '.join(problems)
+    )
+
+
+def test_every_wiring_names_a_real_event_and_script():
+    """Cheap structural check -- catches typos in an event name or a renamed script."""
+    bad = [
+        f'{src}: {ev}/{scr}'
+        for src, ev, _m, scr in WIRINGS
+        if ev not in EVENTS or not (HOOKS / scr).exists()
+    ]
+    assert not bad, 'invalid hook wiring:\n  ' + '\n  '.join(bad)
+
+
+def test_hookeventname_matches_wired_event():
+    """A hookSpecificOutput.hookEventName that disagrees with the wiring is rejected too.
+
+    Static, because the runtime check only sees the branches a fixture happens to
+    reach. suggest-compact.py hid here: it hardcoded "PreToolUse" but is ALSO wired to
+    PostToolUse by skills/workshop, and only emits after 50 edits — no fixture was ever
+    going to trip it.
+    """
+    by_script: dict[str, set[str]] = {}
+    for _src, ev, _m, scr in WIRINGS:
+        by_script.setdefault(scr, set()).add(ev)
+    bad = []
+    for script, events in sorted(by_script.items()):
+        src = (HOOKS / script).read_text(encoding='utf-8')
+        declared = {
+            ev for ev in EVENTS
+            if f'"hookEventName": "{ev}"' in src or f"'hookEventName': '{ev}'" in src
+        }
+        if not declared:
+            continue
+        # A hook that reads the event off the payload adapts to any wiring.
+        if 'hook_event_name' in src:
+            continue
+        stray = declared - events
+        if stray:
+            bad.append(f'{script} hardcodes hookEventName {sorted(stray)} but is wired to {sorted(events)}')
+        unhandled = events - declared
+        if unhandled:
+            bad.append(
+                f'{script} is wired to {sorted(unhandled)} but only ever emits hookEventName '
+                f'{sorted(declared)} — the payload will be rejected under that wiring. '
+                f'Read hook_event_name from the payload.'
+            )
+    assert not bad, '\n'.join(bad)
+
+
+# ------------------------------------------------------------------- regression cases
+
+def test_precompact_rejects_hookspecificoutput():
+    """THE regression: PreCompact does not accept hookSpecificOutput -- at all.
+
+    This is the exact payload hooks/pre-compact.py used to emit. The harness rejected
+    the whole object, so the workflow-reload instruction was silently dropped after
+    every compaction.
+    """
+    broken = {
+        'hookSpecificOutput': {
+            'hookEventName': 'PreCompact',
+            'additionalContext': 'the /ds workflow was active before compaction, reload it',
+        }
+    }
+    errors = validate_payload('PreCompact', broken)
+    assert errors, 'the validator must reject hookSpecificOutput on PreCompact'
+    assert any('does not support hookSpecificOutput' in e for e in errors)
+
+
+def test_pretooluse_rejects_top_level_decision():
+    """PreToolUse gates go through hookSpecificOutput.permissionDecision, not `decision`."""
+    errors = validate_payload('PreToolUse', {'decision': 'block', 'message': 'nope'})
+    assert any('does not support a top-level "decision"' in e for e in errors)
+    assert any("unsupported top-level field 'message'" in e for e in errors)
+
+
+def test_result_continue_is_not_a_schema():
+    """`{"result": "continue"}` is invented -- no event accepts it."""
+    for event in ('PostToolUse', 'PreToolUse', 'Stop'):
+        assert validate_payload(event, {'result': 'continue', 'message': 'hi'}), event
+
+
+def test_valid_payloads_pass():
+    assert validate_payload('PreCompact', {'systemMessage': 'saved'}) == []
+    assert validate_payload('PreCompact', {'decision': 'block', 'reason': 'wait'}) == []
+    assert validate_payload('PostToolUse', {
+        'hookSpecificOutput': {'hookEventName': 'PostToolUse', 'additionalContext': 'x'}}) == []
+    assert validate_payload('PreToolUse', {'hookSpecificOutput': {
+        'hookEventName': 'PreToolUse', 'permissionDecision': 'deny',
+        'permissionDecisionReason': 'r'}}) == []
+    assert validate_payload('SubagentStart', {
+        'hookSpecificOutput': {'hookEventName': 'SubagentStart', 'additionalContext': 'x'}}) == []
+
+
+def test_wc_audit_has_a_hook_contract_dimension():
+    """The audit that was supposed to catch this must actually check it.
+
+    workflow-creator's P01-P30 review scored hooks on COVERAGE (P20) and on whether their
+    command PATH resolves (path-portability). Neither ever executed a hook, so a hook that
+    ran fine and emitted a payload the harness discarded scored clean. This asserts the
+    deterministic leg that closes that gap stays wired.
+    """
+    audit = (REPO / 'workflows' / 'wc-audit.js').read_text(encoding='utf-8')
+    assert "key: 'hook-contract'" in audit, 'wc-audit.js lost its hook-contract dimension'
+    assert 'check-hooks.sh' in audit, 'the hook-contract dimension must RUN the harness, not read the hooks'
+    assert "byDim['hook-contract']" in audit, 'hook-contract results must reach the gate'
+    assert "hookStatus === 'Clean'" in audit, 'hook-contract must be part of the substrate gate'
+
+    runner = REPO / 'scripts' / 'check-hooks.sh'
+    assert runner.exists(), 'scripts/check-hooks.sh is the documented entry point'
+    assert os.access(runner, os.X_OK), 'scripts/check-hooks.sh must be executable'
+
+
+# ------------------------------------------------------------------- standalone report
+
+def _report() -> int:
+    rows, failed = [], 0
+    for source, event, matcher, script in WIRINGS:
+        if event not in EVENTS or not (HOOKS / script).exists():
+            rows.append((script, event, matcher, 'WIRING ERROR', source))
+            failed += 1
+            continue
+        problems = check_one(script, event, matcher)
+        rows.append((script, event, matcher, 'VALID' if not problems else 'INVALID', source))
+        if problems:
+            failed += 1
+            for p in problems:
+                print(f'  ! {p}')
+    print()
+    print(f'{"hook script":<38} {"event":<14} {"matcher":<26} {"verdict":<8} source')
+    print('-' * 120)
+    for r in rows:
+        print(f'{r[0]:<38} {r[1]:<14} {r[2][:25]:<26} {r[3]:<8} {r[4]}')
+    print()
+    print(f'{len(rows) - failed}/{len(rows)} wirings valid')
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(_report())

--- a/tests/writing_guards_test.py
+++ b/tests/writing_guards_test.py
@@ -35,6 +35,16 @@ def run(cmd, stdin=None, env=None):
                           env={**os.environ, **(env or {})})
 
 
+def claim_payload(file_path: Path) -> str:
+    """A real PostToolUse payload. Hooks read stdin — there is no CLAUDE_TOOL_INPUT."""
+    return json.dumps({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(file_path)},
+        "tool_response": {},
+    })
+
+
 def make_project(tmp: Path, *, granular=True, claim_ok=True, stale=False):
     (tmp / ".planning").mkdir(parents=True)
     (tmp / "outlines").mkdir()
@@ -99,24 +109,28 @@ with tempfile.TemporaryDirectory() as td:
     # a draft with NO claim, inside a project ⇒ block
     bad_draft = proj / "drafts" / "Orphan (Draft).md"
     bad_draft.write_text("# Orphan\nProse with no claim id.\n")
-    r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
-            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(bad_draft)})})
+    r = run(["uv", "run", "python3", str(CLAIM_GUARD)], stdin=claim_payload(bad_draft))
     out = json.loads(r.stdout)
     ok("claim-guard: draft w/o claim in project ⇒ block", out.get("decision") == "block", r.stdout)
+    ok("claim-guard: block carries a reason (not `message`)",
+       isinstance(out.get("reason"), str) and "message" not in out, r.stdout)
 
-    # an outline with NO claim ⇒ warn (continue), never block
+    # an outline with NO claim ⇒ warn, never block. A warning on PostToolUse is
+    # hookSpecificOutput.additionalContext — `{"result": "continue"}` is not a thing,
+    # and asserting it here is what let the invalid payload survive in production.
     bad_outline = proj / "outlines" / "Orphan.md"
     bad_outline.write_text("- a point with no claim id\n")
-    r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
-            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(bad_outline)})})
+    r = run(["uv", "run", "python3", str(CLAIM_GUARD)], stdin=claim_payload(bad_outline))
     out = json.loads(r.stdout)
-    ok("claim-guard: outline w/o claim ⇒ continue (warn)", out.get("result") == "continue" and "message" in out)
+    hso = out.get("hookSpecificOutput", {})
+    ok("claim-guard: outline w/o claim ⇒ warn via additionalContext",
+       hso.get("hookEventName") == "PostToolUse" and "additionalContext" in hso
+       and "decision" not in out, r.stdout)
 
-    # a draft WITH a claim ⇒ continue, no block
+    # a draft WITH a claim ⇒ silence (nothing to say), never a block
     r = run(["uv", "run", "python3", str(CLAIM_GUARD)],
-            env={"CLAUDE_TOOL_INPUT": json.dumps({"file_path": str(proj / "drafts" / "Part I. Alpha (Draft).md")})})
-    out = json.loads(r.stdout)
-    ok("claim-guard: draft with claim ⇒ continue", out.get("result") == "continue" and "decision" not in out)
+            stdin=claim_payload(proj / "drafts" / "Part I. Alpha (Draft).md"))
+    ok("claim-guard: draft with claim ⇒ silent", r.stdout.strip() == "" and r.returncode == 0, r.stdout)
 
 print(f"\n{_p} passed, {_f} failed")
 sys.exit(1 if _f else 0)

--- a/workflows/wc-audit.js
+++ b/workflows/wc-audit.js
@@ -1,12 +1,12 @@
 export const meta = {
   name: 'wc-audit',
-  description: "workflow-creator's Mode 2 audit as an ultracode workflow: discover the target workflow's skill files, fan out one read-only reviewer per audit dimension (P01-P30 architecture incl. the runner-architecture/executionClass detector — recognizes BOTH the code and DATA compile variants, the 13-pattern enforcement checklist, path portability, the Ultracode-Workflow Candidacy Scan), adversarially verify critical/major gaps against the actual files, then compute the composite + verdict in pure JS. Flags the retired generic-interpreter shape as a critical. Honors workflow-creator's meta-tool exemptions. Read-only; does NOT fix.",
+  description: "workflow-creator's Mode 2 audit as an ultracode workflow: discover the target workflow's skill files, fan out one read-only reviewer per audit dimension (P01-P30 architecture incl. the runner-architecture/executionClass detector — recognizes BOTH the code and DATA compile variants, the 13-pattern enforcement checklist, path portability, the DETERMINISTIC hook output-contract leg, the Ultracode-Workflow Candidacy Scan), adversarially verify critical/major gaps against the actual files, then compute the composite + verdict in pure JS. Flags the retired generic-interpreter shape as a critical. Honors workflow-creator's meta-tool exemptions. Read-only; does NOT fix.",
   whenToUse: "Called by workflow-creator Mode 2 (Steps 1-4) and Mode 3 Phase A. Returns { overallPass, composite, verdict, scoreTable, reportMarkdown, candidacyTable, findings, reviews, reviewersThatFlagged }. The skill renders AUDIT.md from the result and drives the Mode 3 /goal fix loop; on a re-audit it passes onlyChecks (flagged dimension keys) + priorReviews. The workflow never fixes and the gate is computed in JS — never trust a self-reported composite.",
   phases: [
     { title: 'Discover', detail: "enumerate the target workflow's entry/midpoint/phase skills + references; resolve Mode 2 criteria, enforcement-checklist, migration playbook; detect the meta-tool" },
-    { title: 'Review', detail: 'one read-only reviewer per dimension (4 architecture clusters + enforcement + portability + candidacy), in parallel — RAW per-principle scores, never a composite' },
+    { title: 'Review', detail: 'one read-only reviewer per dimension (4 architecture clusters + enforcement + portability + hook-contract + candidacy), in parallel — RAW per-principle scores, never a composite' },
     { title: 'Verify', detail: 'adversarially re-check each critical/major gap against the cited files; drop unconfirmed (the verifier supplies a corrected score)' },
-    { title: 'Gate', detail: 'composite = mean of non-exempt, non-ceiling principle scores, computed in JS; verdict + AUDIT.md report + candidacy table' },
+    { title: 'Gate', detail: 'composite = mean of non-exempt, non-ceiling principle scores, computed in JS; the substrate gate additionally requires portability Clean AND hook-contract Clean (a deterministic harness exit, not a judgment); verdict + AUDIT.md report + candidacy table' },
   ],
 }
 
@@ -117,6 +117,33 @@ const ENFORCEMENT_SCHEMA = {
 }
 
 // Path-portability reviewer.
+// Hook OUTPUT-CONTRACT validity. Separate from path-portability (which only checks that a
+// hook command RESOLVES) and from P20 (which only checks that a hook EXISTS and covers the
+// step). Neither notices a hook that runs, is wired correctly, and emits a payload the
+// harness throws away — the exact defect that disabled pre-compact.py's workflow-reload for
+// an unknown length of time, and that had silently broken 8 more scripts alongside it.
+const HOOK_CONTRACT_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['dimension', 'status', 'wiringsChecked', 'invalidWirings', 'findings'],
+  properties: {
+    dimension: { type: 'string' },
+    status: { type: 'string', enum: ['Clean', 'Broken', 'NotRun'] },
+    wiringsChecked: { type: 'number', description: 'total (script, event, matcher) wirings the harness exercised' },
+    invalidWirings: {
+      type: 'array', items: {
+        type: 'object', additionalProperties: false, required: ['script', 'event', 'detail'],
+        properties: {
+          script: { type: 'string' }, event: { type: 'string' },
+          detail: { type: 'string', description: 'the schema violation verbatim from the harness' },
+        },
+      },
+      description: 'every wiring the harness reported INVALID — each is a silently-dead hook',
+    },
+    harnessOutput: { type: 'string', description: 'the last ~40 lines of harness output, for evidence' },
+    findings: { type: 'array', items: FINDING },
+  },
+}
+
 const PORTABILITY_SCHEMA = {
   type: 'object', additionalProperties: false, required: ['dimension', 'status', 'violations', 'hookCommandViolations', 'contentPluginRootViolations', 'findings'],
   properties: {
@@ -308,6 +335,33 @@ Scan every SKILL.md and references/*.md for path-portability defects (Mode 2 Ste
 status: Clean (no broken paths AND no \${CLAUDE_SKILL_DIR} in hook commands AND no \${CLAUDE_PLUGIN_ROOT} in skill content), Partial (some fixed, some remain), Broken (relative paths in skill instructions OR \${CLAUDE_SKILL_DIR} in hook commands OR \${CLAUDE_PLUGIN_ROOT} in skill content). Each violation → a findings[] entry (hook-command + content-plugin-root violations are critical). Return PORTABILITY_SCHEMA.`,
   },
   {
+    key: 'hook-contract', schema: HOOK_CONTRACT_SCHEMA,
+    prompt:
+`${READONLY}
+Set dimension="hook-contract" verbatim.
+You are a MECHANICAL verifier. Do NOT reason about hook payloads yourself and do NOT read the
+hooks to judge them — RUN the harness and report its RAW output. A hook whose payload the
+harness rejects fails silently: no exception, no warning, exit 0, message discarded. Eyeballing
+does not find these; only executing them does.
+
+1. Run: \`cd "${PROJECT}" && ./scripts/check-hooks.sh --report\`
+   It discovers every hook wiring — hooks/hooks.json AND the \`hooks:\` frontmatter of every
+   skills/*/SKILL.md — feeds each one realistic payloads, and validates the emitted JSON against
+   the per-event schema in scripts/checks/hook_output_schema.py (transcribed from
+   https://code.claude.com/docs/en/hooks.md).
+2. If the script does not exist, set status="NotRun", wiringsChecked=0, invalidWirings=[], and
+   add ONE minor finding saying the audited repo has no hook-contract harness. Do not improvise
+   a substitute check.
+3. Otherwise parse the printed table. Set wiringsChecked = total rows. For EVERY row whose
+   verdict is INVALID (or WIRING ERROR), add an invalidWirings[] entry with the script, the
+   event, and the violation text the harness printed above the table (the \`! ...\` lines).
+   status = "Clean" iff zero INVALID rows, else "Broken".
+4. Put the tail of the harness output in harnessOutput.
+
+Report raw counts. Do NOT soften, do NOT excuse an INVALID row because the hook "looks right" —
+the harness is the authority here, not your reading of the source. Return HOOK_CONTRACT_SCHEMA.`,
+  },
+  {
     key: 'candidacy-scan', schema: CANDIDACY_SCHEMA,
     prompt:
 `${READONLY}
@@ -471,6 +525,17 @@ for (const id of ALL_IDS) {
 const port = byDim['path-portability']
 for (const hv of (port?.hookCommandViolations || [])) findings.push({ severity: 'critical', dimension: 'path-portability', location: hv, detail: `hook command uses \${CLAUDE_SKILL_DIR} — silent-failure landmine; use \${CLAUDE_PLUGIN_ROOT}` })
 for (const cv of (port?.contentPluginRootViolations || [])) findings.push({ severity: 'critical', dimension: 'path-portability', location: cv, detail: `\${CLAUDE_PLUGIN_ROOT} in skill content — substituted only in hook commands, stays literal here; use \${CLAUDE_SKILL_DIR}/../..` })
+// Hook OUTPUT-CONTRACT violations are always critical, and the verdict comes from the harness's
+// exit — never from a reviewer's reading. A hook emitting a payload its event does not accept is
+// a dead hook: it exits 0, prints nothing anyone sees, and whatever it was enforcing stops being
+// enforced. That is strictly worse than a missing hook, because the audit sees a hook there.
+const hookc = byDim['hook-contract']
+for (const iw of (hookc?.invalidWirings || [])) {
+  findings.push({
+    severity: 'critical', dimension: 'hook-contract', location: `hooks/${iw.script} [${iw.event}]`,
+    detail: `hook payload is invalid for ${iw.event} — the harness rejects it wholesale and the hook silently stops enforcing: ${iw.detail}`,
+  })
+}
 findings.sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity])
 const criticalCount = findings.filter(f => f.severity === 'critical').length
 
@@ -483,7 +548,12 @@ const criticalCount = findings.filter(f => f.severity === 'critical').length
 const enfDim = byDim['enforcement-checklist']
 const enfAbsent = (enfDim?.patterns || []).filter(p => p.status === 'Absent').map(p => p.pattern)
 const portStatus = port ? port.status : 'n/a'
-const substratePass = criticalCount === 0 && enfAbsent.length === 0 && (portStatus === 'Clean' || portStatus === 'n/a')
+// Hook-contract is a DETERMINISTIC leg (a harness exit, not a judgment), so it belongs in the
+// substrate alongside portability rather than in the noisy composite.
+const hookStatus = hookc ? hookc.status : 'n/a'
+const substratePass = criticalCount === 0 && enfAbsent.length === 0
+  && (portStatus === 'Clean' || portStatus === 'n/a')
+  && (hookStatus === 'Clean' || hookStatus === 'NotRun' || hookStatus === 'n/a')
 const overallPass = substratePass && counted.length > 0 && composite >= THRESHOLD
 const verdict = overallPass ? 'PASS' : 'NEEDS WORK'
 
@@ -526,6 +596,16 @@ const portTable = port
         : 'No path-portability defects found.')
   : '(path portability not scored this run)'
 
+const hookTable = hookc
+  ? `Status: **${hookc.status}** (${hookc.wiringsChecked} wiring(s) executed against the per-event schema)\n\n` + (
+      (hookc.invalidWirings || []).length
+        ? ['| Hook | Event | Violation |', '|------|-------|-----------|',
+           ...(hookc.invalidWirings || []).map(i => `| hooks/${i.script} | ${i.event} | ${(i.detail || '').replace(/\|/g, '\\|').slice(0, 160)} |`)].join('\n')
+        : (hookc.status === 'NotRun'
+            ? 'Harness not present in this repo — hook payload validity was NOT checked.'
+            : 'Every wired hook emits a payload its event accepts.'))
+  : '(hook contract not checked this run)'
+
 const cand = byDim['candidacy-scan']
 const candidacyTable = cand
   ? ['| Phase | Fan-out? | Worker mode | Value driver | Recommend | Note |', '|-------|----------|-------------|--------------|-----------|------|',
@@ -553,8 +633,8 @@ const scoreTable = [
 const reportMarkdown = [
   `## Audit: ${TARGET}${disc.isMetaTool ? ' (meta-tool — P01/P06 exempt)' : ''}`,
   ``,
-  `**Verdict:** ${verdict} &nbsp;·&nbsp; **Substrate gate:** ${substratePass ? '✅ clean' : '❌ ' + criticalCount + ' crit / ' + enfAbsent.length + ' enf-Absent / portability ' + portStatus} &nbsp;·&nbsp; **Composite:** ${composite} / 10 (advisory; threshold ${THRESHOLD}) &nbsp;·&nbsp; **Critical:** ${criticalCount}`,
-  `\n_The substrate gate (0 critical · no enforcement Absent · portability Clean) is the convergence signal. The composite is an advisory ±0.2 LLM proxy — see project_wc_mode3_asymptote; do not chase it past the substrate gate._`,
+  `**Verdict:** ${verdict} &nbsp;·&nbsp; **Substrate gate:** ${substratePass ? '✅ clean' : '❌ ' + criticalCount + ' crit / ' + enfAbsent.length + ' enf-Absent / portability ' + portStatus + ' / hook-contract ' + hookStatus} &nbsp;·&nbsp; **Composite:** ${composite} / 10 (advisory; threshold ${THRESHOLD}) &nbsp;·&nbsp; **Critical:** ${criticalCount}`,
+  `\n_The substrate gate (0 critical · no enforcement Absent · portability Clean · hook contract Clean) is the convergence signal. The composite is an advisory ±0.2 LLM proxy — see project_wc_mode3_asymptote; do not chase it past the substrate gate._`,
   excluded.length ? `\n_Excluded from composite (deterministic meta-tool exemptions): ${excluded.join(', ')}._` : '',
   ceilingNoted.length ? `_Domain-ceiling-flagged (kept in composite, not penalized as gaps): ${ceilingNoted.join(', ')}._` : '',
   ``,
@@ -576,6 +656,11 @@ const reportMarkdown = [
   ``,
   `### Path Portability`,
   portTable,
+  ``,
+  `### Hook Output Contract`,
+  `_Executed, not eyeballed: every wiring in hooks.json + skill frontmatter is run and its emitted JSON validated against the event's schema. An invalid payload is discarded whole by the harness — the hook exits 0 and silently stops enforcing._`,
+  ``,
+  hookTable,
   ``,
   `### Ultracode-Workflow Migration Candidates`,
   candidacyTable,


### PR DESCRIPTION
## The finding

`ds-no-main-chat-code-guard.py`, `ds-reviewer-readonly-guard.py` and `ds-read-after-subagent-guard.py` all emitted

```json
{"decision": "block", "message": "🛑 Iron Law: No analysis code in main chat…"}
```

on **PreToolUse**. PreToolUse has no top-level `decision` and no `message` — gates go through `hookSpecificOutput.permissionDecision`. Claude Code rejects the **entire** payload (`Hook JSON output validation failed — (root): Invalid input`), so **every deny these guards ever issued was thrown away.** All three of the ds workflow's hard boundaries — no analysis code in main chat, reviewers are read-only, no reading source files after a subagent returns — have been no-ops. The hooks ran, exited 0, printed nothing anyone saw, and enforced nothing.

Found while fixing the same class of bug in `pre-compact.py` (`hookSpecificOutput` on `PreCompact`, which accepts none), which had silently dropped the post-compaction workflow-reload instruction.

**15 broken wirings across 8 scripts. 56/56 now valid.**

The wiring surface is much larger than `hooks/hooks.json`: **42 of the 56 wirings come from `hooks:` frontmatter in `skills/*/SKILL.md`.**

## Audit table

| Hook script | Wired event | Payload shape emitted (before) | Verdict | Fix applied |
|---|---|---|---|---|
| `ds-no-main-chat-code-guard.py` | PreToolUse ×3 (6 skills) | `{"decision":"block"\|"allow","message":…}` | **INVALID** | → `hookSpecificOutput.permissionDecision: deny` / silence |
| `ds-reviewer-readonly-guard.py` | PreToolUse ×2 | same | **INVALID** | same |
| `ds-read-after-subagent-guard.py` | PreToolUse ×3 | same | **INVALID** | same |
| `ds-brainstorm-no-exploration-guard.py` | PreToolUse | same | **INVALID** | same |
| `ds-pre-subagent-clear.py` | PreToolUse | `{"decision":"allow"}` | **INVALID** | silence (exit 0) |
| `ds-post-subagent-guard.py` | PostToolUse | `{"decision":"allow"}` — only `"block"` exists | **INVALID** | silence (exit 0) |
| `writing-suggest-verify.py` | PostToolUse (hooks.json + 3 skills) | `{"result":"continue","message":…}`; input read from nonexistent `CLAUDE_TOOL_INPUT` env var | **INVALID ×2** | stdin + `additionalContext` |
| `writing-claim-id-guard.py` | PostToolUse ×2 (4 skills) | same env var + `{"result":"continue"}` | **INVALID ×2** | stdin + `additionalContext` (its `decision:"block"` path was already legal) |
| `writing-precis-guard.py` | PostToolUse | same | **INVALID ×2** | stdin + `additionalContext` |
| `writing-outline-guard.py` | PreToolUse | stderr + `sys.exit(1)` — on PreToolUse only exit **2** blocks | **INVALID** | `permissionDecision: deny` |
| `suggest-compact.py` | PreToolUse **and** PostToolUse | hardcoded `hookEventName:"PreToolUse"` → rejected under the workshop wiring | **INVALID** | reads `hook_event_name` off the payload |
| `pre-compact.py`, `subagent-start.py` | PreCompact / SubagentStart | `systemMessage` / `SubagentStart.additionalContext` | **VALID** | reviewed, unchanged |
| `session-start.py`, `image-read-guard.py`, `lint-check.py`, `atomic-constraint-guard.py`, `writing-prose-check.py`, `cite-fidelity-lint.py`, `pr-url-logger.py`, `overflow-check.py`, `session-end.py`, `pattern-scan.py`, `phase-gate-guard.py`, `dev-*`, `workshop-*`, `wc-*`, `plugin-validate.py`, `validate-skill-paths.py`, `mechanical-floor-gate.py`, `typst-convention-guard.py`, `find-slide-page-inject.py`, `*-executable-guard.py`, `writing-mechanical-gate.py` | various | valid | **VALID** | untouched |

Shared helper `hooks/_gate_common.py` gained `allow()` (silence *is* the allow) and `context(event, text)` beside the existing `deny()`.

## Root cause: why workflow-creator never caught it

The audit checks hooks in exactly three places, and **all three are static wiring checks**:

- **P20 "Hooks over prompt"** — scores *coverage*: does a mechanically-checkable step have a hook whose matcher covers it. Its sub-probe even says "do NOT score on hook PRESENCE, score on COVERAGE" — still never asks whether the hook *works*.
- **P03 "Structural gate enforcement"** — gates exist.
- **path-portability** — the only hook-*correctness* check, and it is entirely about `${CLAUDE_SKILL_DIR}` vs `${CLAUDE_PLUGIN_ROOT}` substitution.

**Nothing in the audit ever executed a hook, and the per-event output schema was written down nowhere in the repo.** A hook that is present, correctly matched, path-portable, and emits a rejected payload scored 10/10 on P20 and Clean on portability. There was no dimension it could fail.

Sharper: the repo already documents the April 2026 `${CLAUDE_SKILL_DIR}` incident, and the guard quoted in that write-up defaults to `{"decision": "approve"}` — itself an invalid payload. The class was diagnosed as a *path* problem; the *payload* half went unexamined for another year.

Second reason it survived: **an existing test asserted the broken contract.** `tests/writing_guards_test.py` fed `CLAUDE_TOOL_INPUT` and asserted `out["result"] == "continue"`. Those cases now assert the real contract.

### What was added

- `scripts/checks/hook_output_schema.py` — per-event schema + `validate_payload()`, transcribed from <https://code.claude.com/docs/en/hooks.md>
- `tests/hook_output_schema_test.py` — discovers every wiring from `hooks.json` **and** all skill frontmatter, runs each hook against realistic payloads in a throwaway project, validates emitted JSON. Also catches non-zero exits misread as decisions, and `hookEventName` disagreeing with the wiring (static — `suggest-compact.py` only emits after 50 edits, so no fixture would reach it). Regression case for the exact PreCompact bug.
- `scripts/check-hooks.sh` — one command; `--report` prints the audit table
- `workflows/wc-audit.js` — new **deterministic** `hook-contract` dimension that RUNS the harness (mechanical leg, like workshop-verify's compile leg). Every INVALID wiring is a **critical** finding, folded into the **substrate gate** beside portability rather than the noisy composite.
- `skills/workflow-creator/SKILL.md` — **Step 3c: Validate the Hook OUTPUT Contract**; P20 amended with "P20 scores COVERAGE, never VALIDITY."
- `references/enforcement-checklist.md` — under Gate Functions: if the gate is a hook, its output must be valid for its event, or it is not a gate at all.

## Test results (run on this committed branch)

```
$ ./scripts/check-hooks.sh
63 passed in 4.27s

$ ./scripts/check-hooks.sh --report
56/56 wirings valid
```

Other suites re-run clean: `writing_guards_test.py` 13/13 · `workshop_guard_test.py` 4/4 · `test_prose_lint_hook.py` 32/32 · `wc-audit-verify-batch.test.mjs` 12/12.

## Caveats

1. **The repo has no aggregate test runner, and I did not add one.** `pytest tests/` fails at collection because six test files call `sys.exit()` at module scope (`codex_second_pass_join_test.py`, `dev_plan_table_test.py`, `overflow_check_test.py`, `test_mechanical_floor_gate.py`, `test_writing_mechanical_gate.py`, `writing_gate_probe_test.py`). Pre-existing, not caused by this PR, out of scope. `check-hooks.sh` therefore runs only the hook harness.
2. **The `hook-contract` wc-audit dimension is code-reviewed and syntax-checked but not executed end-to-end** — running it means a live `Workflow()` fan-out with real agents. The existing mock test covers the surrounding gate logic (12/12) and the dimension is backward-compatible: absent → `n/a` → does not block the substrate gate.
3. **The schema is a snapshot** of the hooks docs as of 2026-07-21. If the docs change, `hook_output_schema.py` must be updated; the harness cannot detect drift on its own.
4. **`hooks/pre-compact.py` and `hooks/subagent-start.py` were authored separately** (not by me) and are carried in this commit because the harness must cover them. Both validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Mof5i8SUKnoX3f2mUYony
