### PR TITLE
feat(skills): promote fuzzy-name-matching into a standalone skill (v5.73.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.72.1"
+    "version": "5.73.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.72.1",
+      "version": "5.73.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.72.1",
+  "version": "5.73.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [5.73.0] - 2026-07-22
+
+### Added
+- **`fuzzy-name-matching` skill**: promotes the ING-banks entity-resolution recipe (char n-gram TF-IDF + `sparse_dot_topn` top-k cosine) out of the repo-root `references/` into a real skill. The two files had **no callers anywhere** — `rg -l 'fuzzy-name-matching|fuzzy_name_match_sample'` hit only themselves — so no skill loaded them and a session needing the recipe rebuilt it from memory. Packaging fix, not a content change.
+  - `skills/fuzzy-name-matching/references/fuzzy-name-matching.md` — moved via `git mv` from `references/`; recipe preserved verbatim (threshold guide, normalize-first rule, scoped + global two-pass, gotchas, alternatives). Only edit: the worked-example pointer now resolves in-repo (`skills/wrds/examples/blockholders_pipeline/redo_bridge.py`) instead of the dangling `mirror/scripts/redo_bridge.py`.
+  - `skills/fuzzy-name-matching/examples/fuzzy_name_match_sample.py` — moved via `git mv`; runnable template (`normalize`, `fuzzy_match`, `fuzzy_match_scoped` + toy demo).
+  - `SKILL.md` — trigger-heavy description (entity resolution, record linkage, fuzzy match, TF-IDF, `sparse_dot_topn`, CIK/permno/gvkey/wficn/EIN bridging, deduping names). **IRON LAW: no fuzzy match without normalization first** — exact scoped join and its measured hit rate come before TF-IDF; fuzzy runs on the residual only. Facts + Red Flags cover the two failure modes that actually bite: fitting the vectorizer inside the per-key loop (IDF becomes corpus-dependent — the same pair scores 0.69 in a toy fit and 0.84 in a 600K-row fit) and reporting a hit rate without inspecting pairs at the threshold.
+
+### Changed
+- `skills/wrds/references/linkage.md`: the "identifiers that DON'T cross vendors" section now routes to `fuzzy-name-matching` — that paragraph is exactly where a WRDS linkage bottoms out in a name match.
+- `skills/ds-tools/SKILL.md`, `README.md`: list the new skill so it's discoverable without already knowing it exists.
+
 ## [5.72.1] - 2026-07-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requires `gh` (GitHub CLI). Tools already on your `$PATH` are skipped.
 
 ---
 
-## User Commands (15)
+## User Commands (16)
 
 These are the skills you invoke directly with `/name`:
 
@@ -61,6 +61,12 @@ Anthropic Office skills with this project's repair/build/render tooling.
 | `/law-review-docx` | Markdown/legal draft → law-review-styled Word doc |
 
 > Office format skills sourced from [anthropics/skills](https://github.com/anthropics/skills) via git submodule. Shared converters + the Google-export **OOXML package repair** (`scripts/docx_repair.py`) live in `scripts/`. See **[references/document-skills.md](references/document-skills.md)** for the full group and how the stages decouple.
+
+### Data
+
+| Skill | Purpose |
+|-------|---------|
+| `/fuzzy-name-matching` | Entity resolution / record linkage by name — char n-gram TF-IDF + `sparse_dot_topn` top-k cosine, normalize-first, scoped + global two-pass |
 
 ### Meta
 

--- a/skills/ds-tools/SKILL.md
+++ b/skills/ds-tools/SKILL.md
@@ -26,6 +26,7 @@ These are skills, not plugins - already available:
 | `/lseg-data` | LSEG Data Library (formerly Refinitiv) |
 | `/gemini-batch` | Gemini Batch API for large-scale LLM processing |
 | `/data-context` | Extract tribal knowledge about datasets, generate data context skills |
+| `/fuzzy-name-matching` | Entity resolution / record linkage when datasets share only a name (TF-IDF + `sparse_dot_topn`) |
 
 ## Notebook & Format Skills (Built-in)
 

--- a/skills/fuzzy-name-matching/SKILL.md
+++ b/skills/fuzzy-name-matching/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: fuzzy-name-matching
+version: 1.0
+description: "Use when linking or deduping datasets by entity name rather than a shared key — 'fuzzy match', 'fuzzy name matching', 'entity resolution', 'record linkage', 'match company/person names', 'dedupe entity names', 'name-based join', 'bridge identifiers' (CIK ↔ permno ↔ gvkey ↔ wficn ↔ EIN ↔ personid), or any use of char n-gram TF-IDF, cosine similarity on names, `sparse_dot_topn`, or RapidFuzz at scale."
+user-invocable: true
+---
+
+## Contents
+
+- [Match Enforcement](#match-enforcement)
+- [When to Use](#when-to-use)
+- [The Pipeline](#the-pipeline)
+- [Packages](#packages)
+- [Additional Resources](#additional-resources)
+
+# Fuzzy Name Matching
+
+Fast many-to-many fuzzy entity matching: char n-gram TF-IDF + sparse top-k
+cosine similarity (the ING banks recipe). Scales to ~10⁵ × 10⁵ on a laptop
+in seconds, ~10⁶ × 10⁶ with chunking.
+
+The full recipe — code, threshold guide, gotchas, alternatives considered —
+is in **`references/fuzzy-name-matching.md`**. Read it before writing match
+code; a runnable template is in **`examples/fuzzy_name_match_sample.py`**.
+
+## Match Enforcement
+
+### IRON LAW: NO FUZZY MATCH WITHOUT NORMALIZATION FIRST
+
+Fuzzy matching is the *last* step of a linkage, never the first:
+
+1. **NORMALIZE** both sides (uppercase, punctuation → space, strip entity
+   suffixes/titles) — see the `normalize()` function in the reference
+2. **JOIN** exactly on the normalized name, scoped by a secondary key
+3. **MEASURE** the exact-join hit rate
+4. **FUZZY-MATCH** only the residual rows
+5. **INSPECT** a sample of accepted pairs at the chosen threshold
+6. **CLAIM** a hit rate only after inspecting matched pairs
+
+Skipping straight to TF-IDF is NOT HELPFUL — every deterministic rule you
+skip upfront comes back as false positives the user has to find later, in a
+join they now believe is clean.
+
+### Fuzzy Matching Facts
+
+- If the normalized-name exact join yields <70% on ground truth, normalization is leaving money on the table — fix that before reaching for TF-IDF. Fuzzy matching a badly normalized field buys false positives, not coverage.
+- IDF weights are corpus-dependent: fitting a fresh vectorizer per scoped subset makes scores incomparable across subsets. `"GABELLI MARIO JOSEPH"` ↔ `"GABELLI MARIO J"` scores 0.69 in a 2-row toy fit and 0.84 in a 600K-corpus fit — same pair, different context. Fit once on `pd.concat([left_all, right_all])`, reuse `.transform()` everywhere.
+- Scoping is where the signal lives. On the 13,663-row blockholder bridge, the scoped fuzzy pass (≥0.80, per issuer_cik) converted 70% of unmatched rows; the global pass afterward (≥0.90) added 11. Scope by issuer/year/geo and the smaller candidate pool lets you *lower* the threshold safely.
+- TF-IDF on characters is not semantic. `"IBM"` ↔ `"International Business Machines"` will never match at any threshold — that needs a name dictionary or an embedding model.
+- `sp_matmul_topn(A, B, ...)` wants `B` **already transposed** (`R.T`), and `top_n=1` returns an arbitrary hit unless you pass `sort=True`.
+- Duplicate normalized names on the right side with different ids make `top_n=1` return whichever COO entry landed first — non-deterministic id assignment. Deduplicate the right side first.
+
+### Red Flags — STOP If About To:
+
+- Run `sp_matmul_topn` before an exact normalized join has been tried and measured → STOP. You cannot tell false positives from real coverage without the exact-join baseline.
+- Fit a `TfidfVectorizer` inside a per-key loop → STOP. Scores become incomparable across keys; fit once on the full corpus outside the loop.
+- Accept matches below 0.75, or below 0.85 on an unscoped global pass → STOP. See the threshold guide in the reference; that band is noise.
+- Report a hit rate without eyeballing matched pairs near the threshold → STOP. Reporting an unverified hit rate is presenting an unverified claim as fact.
+- Reach for TF-IDF on <5K × 5K, or on strings under ~3 characters → STOP. RapidFuzz edit distance is better there; n-grams collapse on short strings.
+
+## When to Use
+
+Reach for this when linking two datasets whose only shared field is an
+entity name — bridging identifiers (CIK ↔ permno ↔ gvkey ↔ wficn ↔ EIN ↔
+TR personid), deduping filer/fund/insider names, or resolving vendor
+records that share no key at all.
+
+Don't use it for exact joins (pandas `merge`), for semantic equivalence, or
+below ~5K × 5K rows where RapidFuzz is simpler. The reference's
+"Alternatives considered" table covers `rapidfuzz`, `recordlinkage`,
+`dedupe`, and edit-distance metrics and when each wins.
+
+## The Pipeline
+
+```
+normalize both sides
+    ↓
+exact scoped join (issuer/year/geo + norm_name)   ← most of your hits
+    ↓
+exact global join (unambiguous norm_names only)
+    ↓
+fuzzy SCOPED pass   — threshold ≈0.80, per-key candidate pools
+    ↓
+fuzzy GLOBAL pass   — threshold ≥0.90, residuals only, dedup right side first
+    ↓
+residual: synthetic ids / leave unmatched — never force a match
+```
+
+Code for each stage, and the threshold table that governs what to accept at
+each one, is in `references/fuzzy-name-matching.md`.
+
+## Packages
+
+```toml
+# pixi.toml
+[dependencies]
+scikit-learn = "*"
+[pypi-dependencies]
+sparse_dot_topn = ">=1.2"      # ING's fast sparse top-k matmul
+```
+
+`sparse_dot_topn` is pypi-only — not on conda-forge as of 2026-04. Add it
+with `pixi add --pypi sparse_dot_topn`, not `pixi add`.
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/fuzzy-name-matching.md`** — the full recipe: minimal code, threshold guide, normalize-first rule, scoped + global two-pass pattern, seven gotchas, alternatives considered, end-to-end results table
+
+### Example Files
+
+- **`examples/fuzzy_name_match_sample.py`** — runnable template: `normalize()`, `fuzzy_match()`, `fuzzy_match_scoped()`, plus a toy demo linking insider names to reporting-owner CIKs
+
+### Related
+
+- **`skills/wrds/examples/blockholders_pipeline/redo_bridge.py`** — production pipeline this recipe came out of (TR `personid` → SEC `rptOwnerCik`, 97.4% hit rate)
+- **`skills/wrds/references/linkage.md`** — try a real link table *first*; fuzzy matching is for identifiers that genuinely don't cross vendors

--- a/skills/fuzzy-name-matching/examples/fuzzy_name_match_sample.py
+++ b/skills/fuzzy-name-matching/examples/fuzzy_name_match_sample.py
@@ -1,8 +1,8 @@
 """Fuzzy name matching — minimal end-to-end sample.
 
 Copy-paste pattern for entity resolution via char n-gram TF-IDF +
-sparse top-k cosine similarity. See fuzzy-name-matching.md for theory
-and gotchas.
+sparse top-k cosine similarity. See ../references/fuzzy-name-matching.md
+for theory and gotchas.
 
 Dependencies (pixi):
   pixi add scikit-learn

--- a/skills/fuzzy-name-matching/references/fuzzy-name-matching.md
+++ b/skills/fuzzy-name-matching/references/fuzzy-name-matching.md
@@ -174,7 +174,7 @@ char n-grams), no training pairs.
 
 ## End-to-end worked example
 
-See `mirror/scripts/redo_bridge.py` for the full pipeline applied to
+See `skills/wrds/examples/blockholders_pipeline/redo_bridge.py` for the full pipeline applied to
 Thomson Reuters personid → SEC rptOwnerCik bridging. Results on the
 mirror-voting add-on panel (13,663 rows):
 

--- a/skills/wrds/references/linkage.md
+++ b/skills/wrds/references/linkage.md
@@ -75,4 +75,6 @@ PitchBook (`dealid`, `fundid`, `investorid`, `companyid`), Form 4
 `fundid`) are **vendor-internal** — they join only within their own product.
 To leave the vendor, route through `cusip`/`cik`/`ticker` and accept the
 name-match fuzziness those carry (PitchBook private companies have no public id
-at all — `investor.cikcode` exists only for SEC-registered investors).
+at all — `investor.cikcode` exists only for SEC-registered investors). When the
+route bottoms out in a name match, use the `fuzzy-name-matching` skill —
+normalize + exact scoped join first, TF-IDF only on the residual.


### PR DESCRIPTION
## Why

`references/fuzzy-name-matching.md` and `references/fuzzy_name_match_sample.py` documented the ING-banks recipe for fast many-to-many fuzzy entity matching (char n-gram TF-IDF + `sparse_dot_topn` top-k cosine) — but they sat at the repo root with **no callers**:

```
$ rg -l 'fuzzy-name-matching|fuzzy_name_match_sample'
references/fuzzy_name_match_sample.py     # only itself
```

No skill loaded them, so they never surfaced when needed and a session doing entity resolution rebuilt the recipe from memory. This is a packaging fix.

## What

- `git mv` both files into `skills/fuzzy-name-matching/` — `.md` → `references/` (reference material), `.py` → `examples/` (runnable template). Git detects both as renames, so history is preserved.
- New `skills/fuzzy-name-matching/SKILL.md` front door:
  - Description triggers on the real use cases — entity resolution, record linkage, fuzzy match, TF-IDF, `sparse_dot_topn`, deduping entity names, name-based joins, and bridging CIK / permno / gvkey / wficn / EIN / personid.
  - **IRON LAW: no fuzzy match without normalization first** — normalize, exact scoped join, *measure the hit rate*, then TF-IDF on the residual only.
  - Facts + Red Flags target the two mistakes that actually bite: fitting the `TfidfVectorizer` inside the per-key loop (IDF becomes corpus-dependent — the same pair scores 0.69 in a toy fit vs 0.84 in a 600K-row fit), and reporting a hit rate without inspecting pairs near the threshold.
- Cross-links so it's reachable: `skills/wrds/references/linkage.md` (its "identifiers that DON'T cross vendors" section is exactly where a WRDS link bottoms out in a name match), plus `skills/ds-tools/SKILL.md` and `README.md`.
- Version bump 5.72.1 → 5.73.0 (all 3 locations) + CHANGELOG.

## Recipe content is unchanged

The threshold guide, normalize-first rule, scoped/global two-pass pattern, gotchas, alternatives table, and the pixi/PyPI note are preserved verbatim. The single edit inside a moved file is a dangling pointer: the worked example was cited as `mirror/scripts/redo_bridge.py` (out-of-repo); it now points at the in-repo copy `skills/wrds/examples/blockholders_pipeline/redo_bridge.py`, verified to be the same pipeline (its README documents the same 97.4% hit rate).

## One deviation worth a look

I set `user-invocable: true` as the task specified. House convention for technique/data skills (`wrds`, `lseg-data`, `gemini-batch`, `hpc`, `jupytext`) is `false` — auto-load only. `true` keeps auto-loading *and* adds a `/fuzzy-name-matching` command, so it's strictly more discoverable, but flip it to `false` if you'd rather it stay out of the user-command list (it's listed under a new "Data" heading in README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QE2XeFMLgWSkxeFaj91YYz