### PR TITLE
feat(ds): authoritative sample-period + per-source coverage gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.76.0"
+    "version": "5.77.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.76.0",
+      "version": "5.77.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.76.0",
+  "version": "5.77.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/references/constraints/ds-common-constraints.md
+++ b/references/constraints/ds-common-constraints.md
@@ -25,6 +25,7 @@ After reading this index, load the specific constraint files needed for your cur
 | C3 | Deviation Rules | [constraints/ds-deviation-rules.md](constraints/ds-deviation-rules.md) | R1-R3 auto-fix, R4 STOP for user decision — track all deviations in LEARNINGS.md |
 | C4 | External Skill Discovery | [ds-external-skill-discovery.md](ds-external-skill-discovery.md) | Before drafting PLAN.md tasks that reference an external skill (wrds, gemini-batch, etc.), Glob its references/ and examples/, load domain refs, read example READMEs, prefer ADOPT/PATCH over greenfield |
 | C5 | Data Pull Profile | [ds-data-pull-profile.md](ds-data-pull-profile.md) | Before finalizing PLAN.md with any source >= 50M rows, >= 500 MB, or flagged large/bulk/TB/millions — dispatch read-only profiling subagent to quantify raw vs aggregate ship size, record decision table in PLAN.md |
+| C6 | Sample Coverage | [ds-sample-coverage.md](ds-sample-coverage.md) | ONE canonical sample window + sub-windows in SPEC; every windowed source has a Required-vs-Actual coverage row with a disposition per gap; no source used by a task until asserted against its required window (COV gate) |
 
 ## Phase Loading Guide
 
@@ -32,10 +33,10 @@ Not every phase needs every constraint. Load by relevance:
 
 | Phase | Must Load | Why |
 |-------|-----------|-----|
-| **ds (brainstorm)** | — | Brainstorm has no deterministic constraints (see conventions V1-V3) |
-| **ds-fix (midpoint)** | C1-C5 (all) | Midpoint can route to any phase — needs full constraint set |
-| **ds-plan** | C4, C5 | Before drafting external-skill tasks: External Skill Discovery; before finalizing with a large pull: Data Pull Profile |
-| **ds-implement** | C1, C2, C3 | Implementation: data quality, delegation boundary, deviation tracking |
-| **ds-review** | C1, C2 | Review: data quality checks, post-subagent boundary |
-| **ds-verify** | C2 | Verification: delegation boundary |
-| **ds-delegate** | C2, C3 | Delegation: post-subagent boundary, deviation rules |
+| **ds (brainstorm)** | C6 | Brainstorm writes the canonical sample window + sub-windows into SPEC (see also conventions V1-V3) |
+| **ds-fix (midpoint)** | C1-C6 (all) | Midpoint can route to any phase — needs full constraint set |
+| **ds-plan** | C4, C5, C6 | External Skill Discovery; Data Pull Profile; Sample Coverage — fill each source's Actual window from profiling and assert vs Required |
+| **ds-implement** | C1, C2, C3, C6 | Implementation: data quality, delegation boundary, deviation tracking, no windowed source used before COV-asserted |
+| **ds-review** | C1, C2, C6 | Review: data quality checks, post-subagent boundary, sample-coverage gate |
+| **ds-verify** | C2, C6 | Verification: delegation boundary, sample-coverage gate |
+| **ds-delegate** | C2, C3, C6 | Delegation: post-subagent boundary, deviation rules, coverage assertion in task prompts |

--- a/references/constraints/ds-data-quality-checks.md
+++ b/references/constraints/ds-data-quality-checks.md
@@ -1,12 +1,12 @@
 ---
 name: data-quality-checks
-description: Canonical DQ1-DQ6, M1, R1 check definitions — load from ds-checks.md, never inline
+description: Canonical DQ1-DQ6, COV, M1, R1 check definitions — load from ds-checks.md, never inline
 applies-to: [ds-fix, ds-implement, ds-review, ds-verify, ds-delegate]
 ---
 
 ## Rule
 
-All skills that evaluate data quality MUST Read() the canonical checks file at `skills/ds-implement/references/ds-checks.md` to ensure identical DQ1-DQ6, M1, R1 definitions. Do not inline check definitions — they will drift.
+All skills that evaluate data quality MUST Read() the canonical checks file at `skills/ds-implement/references/ds-checks.md` to ensure identical DQ1-DQ6, COV, M1, R1 definitions. Do not inline check definitions — they will drift.
 
 ## Rationale
 

--- a/references/constraints/ds-sample-coverage.md
+++ b/references/constraints/ds-sample-coverage.md
@@ -1,0 +1,90 @@
+---
+name: sample-coverage
+description: Every analysis has ONE authoritative sample period (canonical window + sub-windows); every windowed data source has a Required-vs-Actual coverage row with a disposition for each gap; no windowed source is used by a task until asserted against its required window
+applies-to: [ds, ds-plan, ds-implement, ds-review, ds-verify, ds-delegate, ds-fix]
+---
+
+## Rule
+
+The analysis has **ONE authoritative sample period**, declared once in SPEC.md and inherited by every downstream phase. It is NOT scattered across prose ("2023H2–2025H1 measured", "2009–2024 for source X", "2005–2025 scope") with no single canonical window — that scattering is the failure this rule prevents.
+
+Three things are mandatory:
+
+1. **Canonical window** — the single outer `[start, end]` that bounds the whole study. Every date-bearing source and every task lives inside it (or declares why it legitimately extends beyond, e.g. lags/leads).
+2. **Sub-windows** — named narrower windows a *specific* task or exhibit uses (e.g. `measured = 2023H2–2025H1`, `counterfactual = 2005–2025`, `estimation = 2009–2024`). Each sub-window names the task(s) that consume it. A sub-window that no task names is dead; a task that needs a window not listed is a gap.
+3. **Per-source Required-vs-Actual coverage table** — for EVERY windowed source (raw pull, cache, intermediate, master), the window it is REQUIRED to cover (the union of the sub-windows of every task that reads it) vs the window it ACTUALLY covers (measured `min/max` of its date key), with a **disposition for each gap**.
+
+**The COV gate:** a windowed source MUST NOT be used by a task until its ACTUAL coverage has been asserted against that task's REQUIRED window. Every gap (Actual narrower than Required) is either **closed** (re-pull/extend the source) or **dispositioned** (documented reason it is acceptable — e.g. "task only needs 2018+", "pre-2018 legitimately absent from vendor"). An undispositioned gap is a STOP.
+
+**Reuse is the trap.** A source pulled to satisfy one task's window may be silently reused by a second task with a *wider* required window. The second task's rows outside the pulled window get ZERO data, and a truncated series still produces plausible numbers — so nothing fails loudly. The Required column is the **union across all consuming tasks**, precisely so a wider second consumer forces the coverage question before the reuse, not after an audit.
+
+### Coverage table schema (SPEC.md and PLAN.md)
+
+```markdown
+## Sample Period & Coverage Requirements
+
+**Canonical window:** 2005-01 to 2025-12 (all sources/tasks live inside this unless noted)
+
+**Sub-windows:**
+| Sub-window | Range | Consumed by |
+|------------|-------|-------------|
+| measured | 2023H2–2025H1 | Task 6 (active weight) |
+| counterfactual | 2005–2025 | Task 8 (reassignment) |
+| estimation | 2009–2024 | Task 4 (factor model) |
+
+**Per-source coverage** (Required = union of sub-windows of every task that reads the source):
+| Source | Required window | Actual (min–max) | Gap? | Disposition |
+|--------|-----------------|------------------|------|-------------|
+| mktcap_cache | 2005–2025 (Task 6 ∪ Task 8) | 2018–2026 | pre-2018 missing | **CLOSE** — re-pull from 2005 (Task 8 needs it) |
+| returns | 2009–2024 | 2009–2024 | none | OK |
+| holdings | 2023H2–2025H1 | 2023–2025 | none | OK |
+```
+
+At SPEC time the Actual column is `TBD (profiled in ds-plan)`; ds-plan fills it from profiling; ds-review/ds-verify assert it.
+
+## Rationale
+
+**Live ds project, market-cap cache reuse.** The SPEC scattered the period across three statements ("2023H2–2025H1" measured, "2009–2024" one source, "2005–2025" scope) with NO single canonical window and NO per-source coverage table. A market-cap cache was pulled for **2018–2026** to serve one sub-task (active weight, a `measured`-window task), then silently **reused** by a different task — a **2005–2025** counterfactual reassignment. Pre-2018 items got ZERO market-cap data. Nobody caught it until an independent audit, because a truncated series still produces plausible numbers.
+
+Root cause: there was no sample-period SPEC to review against. The Required-vs-Actual table with `Required = Task6 ∪ Task8 = 2005–2025` would have flagged the 2018-start cache the moment Task 8 was mapped to it — before the reuse silently truncated the counterfactual.
+
+**Why it exists:** period specification folded loosely into "Data Sources" (`[location, format, time period]`) records each source's *own* window in isolation. It never asks "does this source cover every task that reads it?" — the one question the reuse failure turns on. A canonical window + per-source Required-vs-Actual table makes the question mandatory and reviewable.
+
+## Relationship to adjacent rules
+
+- **[[sample-selection]] (V8)** documents *why* each filter (start/end date among them) and the row funnel, at implement time in LEARNINGS.md. It justifies the window; it does NOT assert that each source *covers* the required window, nor catch cross-task reuse. Coverage is the input-side precondition; sample-selection is the output-side accounting. Both are needed.
+- **[[master-datasets]]** enforces *grain/keys* consistency — every exhibit from one master. A master can have the correct grain and still be truncated in time; a cache feeding it is unchecked by the grain rule. Coverage is orthogonal: right grain, wrong span.
+- **[[ds-data-pull-profile]]** measures `min/max` per source but only to decide raw-vs-aggregate *ship size*. This rule reuses that measured `min/max` as the Actual column and gives it something to be asserted against.
+- **[[parameter-transparency]]** centralizes date windows as named config so `START/END` are not inline literals. That prevents drift of the *value*; it does not verify a *source covers* the value. A correctly-centralized `COUNTERFACTUAL_START = 2005` still silently truncates against a 2018 cache — parameter-transparency is satisfied and the analysis is still wrong. Coverage closes that gap.
+
+## COV check (runtime)
+
+`COV` is defined in `skills/ds-implement/references/ds-checks.md` alongside DQ1–DQ6. For every windowed source, ds-review and ds-verify compute measured `min/max` of the date key and assert it covers the Required window of every task that reads it; any uncovered span that is not dispositioned in the coverage table is a high-confidence issue.
+
+## Examples
+
+### Correct
+```markdown
+## Sample Period & Coverage Requirements
+**Canonical window:** 2005 to 2025
+**Sub-windows:** measured 2023H2–2025H1 (Task 6); counterfactual 2005–2025 (Task 8)
+| Source | Required | Actual | Gap? | Disposition |
+| mktcap_cache | 2005–2025 (Task 6 ∪ Task 8) | 2005–2026 | none | OK (re-pulled from 2005) |
+```
+Task 8's wider window is in Required *before* the pull, so the cache is pulled from 2005, not 2018.
+
+### Incorrect
+```markdown
+## Data Sources
+- mktcap_cache: parquet, 2018-2026   # pulled for active weight (Task 6)
+- (Task 8 counterfactual, 2005-2025, silently reuses mktcap_cache)
+```
+No canonical window, no Required column, no gap disposition. Task 8's pre-2018 rows get zero data; a plausible-looking number survives to write-up.
+
+## Facts
+
+- A truncated series produces plausible numbers, so coverage gaps do not fail loudly — they surface at audit, days after the analysis felt done. The Required-vs-Actual table is the only place the gap is visible before the numbers are trusted.
+- The Required window for a source is the UNION of the sub-windows of every task that reads it — not the window of the task it was first pulled for. Recording only the first consumer's window is exactly how reuse truncates the second consumer.
+- Per-source `time period` in the Data Sources list records each source's window in isolation; it never cross-checks source-vs-consuming-task. Isolation is why the loose folding into Data Sources missed the reuse.
+- An undispositioned gap is a STOP, not a warning: "the series looked fine" is not a disposition. A disposition names the reason the missing span is acceptable (task doesn't need it / vendor genuinely lacks it) or triggers a re-pull.
+- Coverage is an input-side precondition checked BEFORE use; sample-selection is output-side accounting checked AFTER filtering. Passing the sample-selection funnel does not imply the source ever covered the window — the funnel starts from whatever rows were pulled.

--- a/skills/ds-implement/references/ds-checks.md
+++ b/skills/ds-implement/references/ds-checks.md
@@ -14,6 +14,7 @@ Shared check definitions for data quality verification. Referenced by ds-validat
 | DQ4 | Row count traceability (vs LEARNINGS.md) | ✅ | ✅ | ✅ | ✅ |
 | DQ5 | Cardinality check on categoricals | ✅ | ✅ | ✅ | ❌ |
 | DQ6 | Output-first verification (shape before/after) | ❌ | ❌ | ✅ | ✅ |
+| COV | Sample-period coverage (each windowed source spans its Required window) | ✅ | ✅ | ✅ | ✅ |
 | R1 | Reproducibility (same inputs → same outputs) | ❌ | ❌ | ❌ | ✅ |
 | M1 | Spec compliance (all SPEC.md objectives addressed) | ✅ | ✅ | ✅ | ✅ |
 
@@ -130,6 +131,23 @@ df.head()
 | Groupby | result shape, sample groups |
 | Model fit | metrics, convergence |
 
+### COV: Sample-Period Coverage
+
+Verify every windowed data source (raw pull, cache, intermediate, master) covers the Required window of every task that reads it. This catches the silent-truncation trap: a source pulled for one task's window and reused by a task with a *wider* window, leaving the uncovered span with zero data — a truncated series still produces plausible numbers, so nothing fails loudly. Definition and gate: constraint C6 (`references/constraints/ds-sample-coverage.md`).
+
+```python
+# required = (start, end) for THIS source = union of the sub-windows of every task that
+# reads it, taken from SPEC.md's "Sample Period & Coverage Requirements" table.
+lo, hi = df[date_col].min(), df[date_col].max()
+req_lo, req_hi = required  # e.g. ("2005-01-01", "2025-12-31")
+if lo > pd.Timestamp(req_lo) or hi < pd.Timestamp(req_hi):
+    print(f"FAIL [COV]: {source} covers {lo:%Y-%m}–{hi:%Y-%m} but is required to cover "
+          f"{req_lo}–{req_hi}. Uncovered span has ZERO data. "
+          f"Must be dispositioned in the coverage table (CLOSE=re-pull, or documented reason).")
+```
+
+**Confidence if triggered:** >= 85 unless the gap has an explicit disposition in SPEC/PLAN's coverage table (task genuinely doesn't need the span, or the vendor legitimately lacks it). An undispositioned gap is a high-confidence issue.
+
 ## Methodology Checks
 
 ### M1: Spec Compliance
@@ -164,7 +182,7 @@ assert hash1 == hash2, "Results not reproducible!"
 When dispatching a review or verification subagent, reference checks by ID:
 
 ```
-"Run checks DQ1-DQ5, M1 from references/ds-checks.md on the final analysis data.
+"Run checks DQ1-DQ5, COV, M1 from references/ds-checks.md on the final analysis data.
 Report any WARNING as confidence >= 80."
 ```
 

--- a/skills/ds-plan/SKILL.md
+++ b/skills/ds-plan/SKILL.md
@@ -227,8 +227,13 @@ df.duplicated(subset=DECLARED_PK).sum()          # MUST be 0, else extraction fa
 df.groupby(BUSINESS_KEY).size().gt(1).sum()      # business-key collisions = restatement/amendment signal
 
 # For time series
-df[date_col].min(), df[date_col].max()  # Date range
+df[date_col].min(), df[date_col].max()  # Date range → Actual coverage (constraint C6)
 df.groupby(date_col).size()              # Records per period
+# COVERAGE ASSERTION (C6): compare the measured min/max against this source's Required
+# window (union of the sub-windows of every task that reads it, from SPEC's Sample Period
+# section). If min > required_start or max < required_end, the source is truncated — record
+# the gap and a disposition in PLAN.md's "Sample Period & Coverage" table. A source pulled
+# for one task's window and reused by a wider-window task is the silent-truncation trap.
 ```
 
 #### Multiple Data Sources (Parallel Profiling)
@@ -271,7 +276,9 @@ Required checks:
    that df.duplicated() misses (e.g. Form 4 4/A re-filings).
 7. Summary statistics: df.describe()
 8. Unique value counts for categorical columns
-9. Date range if time series
+9. Date range if time series: report df[date_col].min() and max(). If SPEC declares a
+   Required window for this source (see its Sample Period & Coverage section), state
+   explicitly whether the measured range COVERS it, and name any uncovered span (gap).
 10. Memory usage: df.info()
 
 Output format:
@@ -832,12 +839,24 @@ tags: [planning, data-profiling]
 ## Spec Reference
 See: .planning/SPEC.md
 
+## Sample Period & Coverage
+<!-- Required (constraint C6, ds-sample-coverage). Carry the canonical window + sub-windows from SPEC.md; fill the Actual column from profiling (the df[date_col].min()/max() measured below) and assert it covers each source's Required window. Required = UNION of the sub-windows of every task that reads the source. -->
+
+**Canonical window:** [from SPEC] — **Sub-windows:** [measured …; counterfactual …]
+
+| Source | Required window | Actual (min–max, profiled) | Gap? | Disposition |
+|--------|-----------------|----------------------------|------|-------------|
+| mktcap_cache | 2005–2025 (Task 6 ∪ Task 8) | 2018–2026 | pre-2018 missing | **CLOSE** — re-pull from 2005 (Task 8 counterfactual needs it) |
+| returns | 2009–2024 | 2009–2024 | none | OK |
+
+Any row with an uncovered Gap and no disposition is a STOP — resolve before finalizing PLAN.md. No task reads a source until its row here shows Gap=none or a disposition.
+
 ## Data Profile
 
 ### Source 1: [name]
 - Location: [path/connection]
 - Shape: [rows] x [columns]
-- Date range: [start] to [end]
+- Date range: [start] to [end]  <!-- feeds the Actual column of Sample Period & Coverage above; assert it covers this source's Required window -->
 - Key columns: [list]
 
 #### Column Summary

--- a/skills/ds-review/SKILL.md
+++ b/skills/ds-review/SKILL.md
@@ -770,6 +770,13 @@ Auto-load all constraints matching `applies-to: ds-review`:
 - [ ] The dataset-construction mermaid diagram matches the code that actually ran — masters, merges, and filters in the diagram exist in the pipeline; the diagram is not stale
 - [ ] Each master dataset is unique at its declared grain (run the keyed dedup; a fan-out here corrupts every downstream exhibit)
 
+### Sample Period Coverage (COV)
+<!-- Per the sample-coverage constraint C6 (loaded above) and check COV in ds-checks.md. Applies to any analysis with a windowed source. -->
+- [ ] SPEC declares ONE canonical sample window plus named sub-windows, each mapped to the task(s) that consume it — the period is NOT scattered across prose with no single authoritative window
+- [ ] Every windowed source (raw pull, cache, intermediate, master) has a Required-vs-Actual coverage row; Required is the UNION of the sub-windows of every task that reads it (not just the task it was first pulled for)
+- [ ] Run COV yourself: for each windowed source, compute `df[date_col].min()/max()` and confirm it covers that source's Required window — a source pulled for one task's window and reused by a wider-window task silently truncates (uncovered span = zero data, still plausible numbers) (a high-confidence issue if uncovered and undispositioned)
+- [ ] Every coverage gap (Actual narrower than Required) is either CLOSED (re-pulled) or has an explicit disposition (task doesn't need the span, or vendor legitimately lacks it) — "the series looked fine" is not a disposition
+
 ### Parameter Transparency
 <!-- Per the parameter-transparency constraint (loaded above). Applies to any analysis with filters/parameters. -->
 - [ ] No magic numbers: filter thresholds, caps, bands, winsorization levels, date windows, and min-obs counts come from a single named config location, not inline literals (grep the pipeline for stray numeric literals in filter/clip/winsorize/date comparisons — any found is a high-confidence issue)

--- a/skills/ds-spec-reviewer/SKILL.md
+++ b/skills/ds-spec-reviewer/SKILL.md
@@ -74,6 +74,7 @@ Read the spec file, then evaluate against ALL categories below.
 |----------|------------------|
 | Completeness | TODOs, placeholders, "TBD", incomplete sections, empty fields |
 | Data Sources | All data sources identified with location, format, and time period |
+| Sample Period & Coverage | ONE canonical window declared (not scattered across prose); named sub-windows each mapped to consuming task(s); every windowed source has a Required-vs-Actual coverage row (Actual may be "TBD — profiled in ds-plan", but Required must be filled = union of consuming tasks' sub-windows) |
 | Analysis Objectives | Clear, specific questions the analysis will answer |
 | Output Format | Expected deliverables specified (report, dashboard, model, tables) |
 | Success Criteria | Measurable, specific, with clear pass/fail (not vague) |
@@ -88,6 +89,7 @@ Read the spec file, then evaluate against ALL categories below.
 - Sections saying "to be defined later" or "will spec when data is explored"
 - Sections noticeably less detailed than others
 - Data sources listed without location or format
+- Sample period scattered across prose (a "measured" range here, a "scope" year there) with NO single canonical window — or a per-source coverage row whose Required window omits a task that will read the source (the reuse-truncation trap)
 - Analysis objectives that are vague ("explore the data", "find patterns")
 - Success criteria that are unmeasurable ("good model", "interesting results")
 - Missing replication/reproducibility strategy when replicating existing work

--- a/skills/ds-verify/SKILL.md
+++ b/skills/ds-verify/SKILL.md
@@ -312,7 +312,7 @@ Verify this analysis produces consistent results from a fresh run.
 Read the shared check definitions:
 Read `${CLAUDE_SKILL_DIR}/../../skills/ds-implement/references/ds-checks.md` and follow its instructions.
 
-Run checks: DQ1-DQ4, DQ6, M1, R1
+Run checks: DQ1-DQ4, DQ6, COV, M1, R1
 
 ## Reproducibility Protocol
 
@@ -342,11 +342,13 @@ papermill notebook.ipynb output.ipynb -p seed 42
 2. CHECK: Verify outputs match SPEC.md success criteria
 3. REPRODUCE: Same inputs → same outputs (run twice, compare hashes)
 4. DATA INTEGRITY: Input data unchanged, row counts traceable
+5. COVERAGE (COV): each windowed source spans the Required window of every task reading it; gaps dispositioned
 
 ## Output
 Report:
 - Reproducibility: PASS/FAIL (with hash comparison)
 - Data quality checks: DQ1-DQ4, DQ6 results
+- Sample-period coverage: COV result (each windowed source spans its Required window; gaps dispositioned)
 - Spec compliance: M1 result
 - Any discrepancies found
 """)

--- a/skills/ds/SKILL.md
+++ b/skills/ds/SKILL.md
@@ -176,8 +176,28 @@ After selecting an approach:
 [What question this analysis answers]
 
 ## Data Sources
-- [Source 1]: [location, format, time period]
-- [Source 2]: [location, format, time period]
+- [Source 1]: [location, format] — coverage asserted in "Sample Period & Coverage Requirements" below
+- [Source 2]: [location, format] — coverage asserted in "Sample Period & Coverage Requirements" below
+
+## Sample Period & Coverage Requirements
+<!-- AUTHORITATIVE. This is the ONE place the sample period lives. Do NOT scatter the period across prose elsewhere (a "measured" range here, a "scope" year there) — every phase reviews data pulls against THIS section. See constraint C6 (ds-sample-coverage). -->
+
+**Canonical window:** [start] to [end]
+<!-- The single outer window that bounds the whole study. Every source and task lives inside it unless a row below declares a legitimate extension (lags/leads). -->
+
+**Sub-windows** (narrower windows a specific task/exhibit uses; each names the task(s) that consume it):
+| Sub-window | Range | Consumed by |
+|------------|-------|-------------|
+| [measured] | [2023H2–2025H1] | [Task/Exhibit] |
+| [counterfactual] | [2005–2025] | [Task/Exhibit] |
+
+**Per-source coverage** (Required = UNION of the sub-windows of EVERY task that reads the source — not just the task it was first pulled for; reuse by a wider-window task is exactly what silently truncates data):
+| Source | Required window | Actual (min–max) | Gap? | Disposition |
+|--------|-----------------|------------------|------|-------------|
+| [source1] | [2005–2025 (Task 6 ∪ Task 8)] | TBD (profiled in ds-plan) | TBD | TBD |
+| [source2] | [2009–2024] | TBD (profiled in ds-plan) | TBD | TBD |
+
+**COV gate:** no windowed source is used by a task until its Actual coverage is asserted against that task's Required window. Every gap (Actual narrower than Required) is CLOSED (re-pull) or dispositioned (documented reason it is acceptable). An undispositioned gap is a STOP.
 
 ## Planned Exhibits
 <!-- The tables and figures the final output will contain. Rough is fine — ds-plan Step 5d maps each to a canonical master dataset so all exhibits share one methodology. Omit only for a genuine single-table one-off. -->
@@ -228,7 +248,7 @@ Before transitioning to ds-plan, execute this gate:
 ```
 1. IDENTIFY → SPEC.md exists at `.planning/SPEC.md`
 2. RUN      → Read(".planning/SPEC.md")
-3. READ     → Verify it contains: Objectives, Data Sources, Requirements (with CATEGORY-NN IDs), Success Criteria sections
+3. READ     → Verify it contains: Objectives, Data Sources, Sample Period & Coverage Requirements (canonical window + sub-windows + per-source table), Requirements (with CATEGORY-NN IDs), Success Criteria sections
 4. VERIFY   → User has confirmed the objectives via AskUserQuestion response (not agent self-assessment).
               Check: was AskUserQuestion called and did user respond affirmatively?
 5. CLAIM    → Only proceed to ds-plan if ALL checks pass
@@ -243,6 +263,7 @@ Before transitioning to ds-plan, execute this gate:
 Declare brainstorm complete when:
 - Analysis objectives clearly understood
 - Data sources identified
+- Sample period declared: one canonical window + named sub-windows, each mapped to the task(s) that consume it (per-source Actual coverage is filled later in ds-plan)
 - Success criteria defined
 - Constraints documented (especially replication requirements)
 - Approach chosen from alternatives


### PR DESCRIPTION
## Problem — a real failure from a live ds project

The ds SPEC.md template never required an **authoritative sample period**. Period was folded loosely into Data Sources (`[location, format, time period]`) — each source's own window in isolation, with no single canonical window and no per-source coverage assertion.

**What this caused (real incident):**
- The SPEC scattered the period across statements ("2023H2–2025H1" measured, "2009–2024" for one source, "2005–2025" scope) — no canonical window, no per-source coverage table.
- A market-cap cache was pulled for **2018–2026** to serve one sub-task (active weight), then silently **reused** by a different task — a **2005–2025** counterfactual reassignment. Pre-2018 items got **zero** market-cap data.
- Nobody caught it until an independent audit, because a truncated series still produces plausible numbers.
- Root cause: there was no sample-period SPEC to review against.

## Why existing mechanisms didn't cover it

Confirmed the gap is genuine, not a duplicate:
- **`sample-selection` (V8)** documents *why* each filter (start/end among them) and the row funnel — at implement time in LEARNINGS.md. Output-side accounting; it never asserts a source *covers* the required window, nor catches cross-task reuse.
- **`master-datasets`** enforces *grain/keys* consistency — a master can have the correct grain and still be truncated in time; a cache feeding it is unchecked (right grain, wrong span).
- **`ds-data-pull-profile`** measures `min/max` per source, but only to decide raw-vs-aggregate *ship size* — nothing to assert coverage against.
- **`parameter-transparency`** centralizes date windows as named config (prevents value drift) but does not verify a source *covers* the value.
- **DQ1–DQ6** has no date-coverage check.

## The fix

New constraint **C6 `ds-sample-coverage`** — the canonical gate, auto-loaded for ds/ds-plan/ds-implement/ds-review/ds-verify/ds-delegate/ds-fix:
- **ONE canonical window** + named **sub-windows**, each mapped to the task(s) that consume it.
- **Per-source Required-vs-Actual coverage table**, where **Required = union of the sub-windows of every task that reads the source** — so a wider second consumer forces the coverage question *before* the reuse, not after an audit.
- **COV gate:** no windowed source is used by a task until asserted; every gap is CLOSED (re-pull) or dispositioned. Undispositioned gap = STOP.

Wired end-to-end so the gate is enforced, not just documented:
- **ds SPEC.md template** — new authoritative "Sample Period & Coverage Requirements" section; exit-brainstorm gate + output checklist updated.
- **ds-plan** — PLAN.md "Sample Period & Coverage" table; profiling now asserts measured `min/max` against each source's Required window (fills the Actual column).
- **ds-checks.md** — new runtime **COV** check + matrix row (validate/review/fix/verify).
- **ds-review** — "Sample Period Coverage" checklist block (run COV yourself).
- **ds-verify** — COV added to run-checks and the report.
- **ds-spec-reviewer** — coverage-completeness check (catches scattered period / a Required window that omits a consuming task).
- Indexes updated (ds-common-constraints C6; data-quality-checks canonical set → adds COV).

Verified the constraint auto-loads for ds, ds-plan, ds-review, ds-verify via `load-constraints.py`. No `.py` check added — consistent with `sample-selection`/`master-datasets` (prose gate + runtime COV check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)