### PR TITLE
feat(skills): add bmll skill for BMLL Data Lab

### DIFF
--- a/skills/bmll/SKILL.md
+++ b/skills/bmll/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: bmll
+version: 1.0
+description: Use when "query BMLL", "BMLL Data Lab", "Trades Plus", "markouts / mark-out analysis", "spread capture / PricePoint", "block trades", "classified trades", "lit vs dark volume", "venue market share", "liquidity fragmentation", "Level 3 / L3 order book", "rebuild the limit order book", "order book snapshot", "MBO / MBP data", "CBBO / EBBO / NBBO", "auction dislocation", "closing auction", "tick data by MIC", "ListingId / listing_id", "bmll2", or "bmll" Python package.
+user-invocable: false
+---
+
+## Contents
+
+- [Query Enforcement](#query-enforcement)
+- [The Two Packages](#the-two-packages)
+- [Core Data Model](#core-data-model)
+- [Choosing an Access Path](#choosing-an-access-path)
+- [Quick Start](#quick-start)
+- [Scripts](#scripts)
+- [Reference Files](#reference-files)
+
+# BMLL Data Lab
+
+BMLL provides full-depth historical **Level 3** (order-by-order) market data across global
+equities, ETFs, futures and US options, plus derived analytics. Work happens inside the **BMLL
+Data Lab** — a hosted JupyterLab environment where `bmll2` and `bmll` are pre-installed and
+pre-authenticated.
+
+Docs: `https://lab.bmlltech.com/docs/` (requires a logged-in BMLL session).
+
+## Query Enforcement
+
+<EXTREMELY-IMPORTANT>
+## The Iron Law of BMLL Results
+
+**NO DATA CLAIM WITHOUT INSPECTING THE ROWS. This is not negotiable.**
+
+BMLL returns an empty frame — not an error — for a valid-but-wrong MIC, a non-trading date, a
+listing that was not alive, or a missing entitlement. Handing back an unexamined frame is not
+faster help; it silently converts "I asked the wrong question" into "this venue had zero volume,"
+and the user builds an analysis on a hole they cannot see.
+</EXTREMELY-IMPORTANT>
+
+Before claiming any query succeeded:
+
+1. **VALIDATE** the MIC, `ListingId` and date (`reference.query`, `reference.availability`)
+2. **VALIDATE** the table name against `get_market_tables()` for that asset class
+3. **EXECUTE** the query
+4. **INSPECT** `.head()` — and row counts *per date*, not just overall
+5. **VERIFY** the currency, enum and sentinel columns mean what you assume
+6. **CLAIM** success only after 1–5 pass
+
+### BMLL API Facts
+
+Non-derivable behaviour of this API. Each is a real property of BMLL, not a restatement of the
+rule above.
+
+- **`get_market_data_range` returns a Spark DataFrame, and its
+  `TradeTimestampNanoseconds` / `PublicationTimestampNanoseconds` columns are integer nanoseconds
+  — not `datetime64` like the `get_market_data` equivalents.** Reusing single-date pandas code
+  against a range pull produces timestamps interpreted as epoch-1970 nanos and time-of-day
+  bucketing that is silently wrong for every row. Shipping that is the exact incompetence
+  inspection exists to catch.
+- **`Size` is negative for cancellations and `Printable` is the flag that decides inclusion in
+  cumulative volume.** Summing `Size` without `Printable == True` both double-counts amended
+  prints and nets out cancellations — a volume number that is wrong in two directions at once,
+  and wrong quietly.
+- **`Price` is denominated in `CurrencyCode` while `InstrumentCurrencyPrice` is denominated in
+  `InstrumentCurrencyCode`, and minor-currency listings (GBp, ZAc) carry `MinorCurrencyFactor`.**
+  Mixing the two yields notionals off by 100× on UK and South African names. Prefer the
+  pre-computed `TradeNotionalEUR` / `TradeNotionalUSD` where they exist.
+- **`ExecutionVenue` is not `MIC`.** A Liquidnet trade reported via CBOE BXTR carries
+  `MIC='BOTC'` but `ExecutionVenue='LIQU'`. Venue market-share computed on `MIC` attributes every
+  reported trade to the reporting facility — the headline result of the analysis is then an
+  artefact of the plumbing.
+- **`IsBlock` is a string enum (`'TRUE'`/`'FALSE'`/`'UNKNOWN'`), not a boolean.** `df[df.IsBlock]`
+  raises; `df[df.IsBlock == True]` silently returns nothing. Reporting "no block trades" from that
+  is an unverified claim presented as a finding.
+- **`AggressorSide == 0` means unknown, and it is common on off-book and auction prints.** Trades
+  Plus provides no side inference. Treating `0` as a third side, or dropping it silently, changes
+  signed-markout results without any error surfacing.
+- **`PricePoint` carries `±99999` sentinels** when best bid equals best ask (and `0.5` when price
+  equals both). An unfiltered mean is dominated by sentinels and is not a spread-capture number.
+- **The Data Lab local filesystem is ephemeral** — `df.to_csv(...)` output is destroyed when the
+  workspace stops. Only `bmll2.put_file(...)` persists. Telling the user their results are saved
+  when they are on a disk that will be wiped is worse than not saving them.
+- **`reference.query` with no date returns the latest snapshot, not history**; passing a date range
+  is correct but markedly slower. Use `IsAlive` to test liveness on a date.
+- **Classified trades and analytics are computed T+1.** Today's data is not there today; a
+  today-inclusive range returns a short series, not an error.
+- **`time_series` analytics need an entitlement separate from market data.** A missing subscription
+  returns empty results, not a permission error.
+
+### Red Flags — STOP If You Catch Yourself:
+
+| Action | Why Wrong | Do Instead |
+|---|---|---|
+| About to sum `Size` or notional without a `Printable` filter | Counts cancellations and non-printable prints | Filter `Printable == True` first |
+| About to call `.toPandas()` on a full `get_market_data_range` result | Multi-venue multi-month pulls exceed driver memory and kill the session | Aggregate in Spark/Polars, then collect |
+| About to write `df[df.IsBlock == True]` | `IsBlock` is a string enum; this returns an empty frame | Compare to `'TRUE'` |
+| About to average `PricePoint` across all rows | `±99999` sentinels dominate the mean | Filter to the plausible band (e.g. `-2..2`) first |
+| About to group venue market share by `MIC` | Attributes trades to the reporting venue, not the executing one | Group by `ExecutionVenue` |
+| About to report "zero volume on venue X" from an empty frame | Empty means "not asked correctly" as often as "no trades" | Check `reference.availability` before concluding |
+| About to reuse single-date pandas code on a `_range` result | Timestamps are integer nanos there | Convert timestamps explicitly |
+| About to hand-roll a markout loop | Deterministic, easy to get sign-wrong | Use `scripts/bmll_markouts.py` |
+
+### Data Validation Checklist
+
+**For `get_market_data` / `get_market_data_range`:**
+- [ ] Table valid for the asset class (`get_market_tables()`)
+- [ ] `schema='Future'` set for futures; options only via `get_market_data*`
+- [ ] Non-empty result asserted per date
+- [ ] `Printable` filter applied before any volume/notional sum
+- [ ] Currency column chosen deliberately
+- [ ] For `_range`: timestamps converted from integer nanos
+
+**For `Security` / `NormalisedSecurity`:**
+- [ ] `listing_id` resolved via `reference.query`, not guessed
+- [ ] Feed chosen deliberately (`L2` aggregated vs `L3` order-by-order)
+- [ ] `all_trades()` vs `trades()` chosen deliberately
+- [ ] Market-state filter applied where continuous trading is assumed
+
+**For `bmll.time_series`:**
+- [ ] Metric + suffix confirmed against `available()`
+- [ ] `frequency` matches the metric's published frequency
+- [ ] Universe chunked by MIC / date range for large pulls
+
+## The Two Packages
+
+Both import in the Data Lab; they are **not** interchangeable.
+
+| Package | What it is | Main surface |
+|---|---|---|
+| **`bmll2`** | Data Lab API — raw + normalised market data, reference, files, clusters | `reference`, `get_market_data`, `get_market_data_range`, `Security`, `NormalisedSecurity`, `SparkHelper`, `put_file`, `get_fx`, `corporate_actions`, `rebuilder` |
+| **`bmll`** | Data Feed API — pre-computed analytics over the wire | `time_series.available/query/classified_trades`, `market_data.instrument_cbbo`, `compute` (jobs), `reference`, `data` |
+
+`bmll.reference` and `bmll2.reference` are the same service.
+
+## Core Data Model
+
+- **Market** — a venue, a trade-reporting facility (TRF/APA), or a consolidated feed. Keyed by
+  **MIC** (`XLON`, `BATE`, `@SIP`). BMLL maps a venue's lit book to one MIC, so segments collapse
+  (Euronext Growth `ALXP` → `XPAR`).
+- **Instrument** — a fungible set of listings across venues (equities) or one traded product
+  (futures). Keyed by `InstrumentId`. The cross-venue unit.
+- **Listing** — orders and trades for one instrument on one market. Keyed by `ListingId`. The unit
+  nearly every call takes.
+
+`OPOL` (Original Place Of Listing) is the most reliable way to scope "all UK-primary names".
+`ISIN`, `MIC`, `CurrencyCode`, `OPOL` are the most consistently populated identifiers; `FIGI`,
+`SegmentCode`, `Ticker` are best-effort.
+
+## Choosing an Access Path
+
+| You want | Use | See |
+|---|---|---|
+| Trades + prevailing quotes + markouts, ready to analyse | `get_market_data(mic, date, 'trades-plus')` | [trades-plus.md](references/trades-plus.md) |
+| A whole market's trades/quotes for one date | `get_market_data(mic, date, table)` | [market-data.md](references/market-data.md) |
+| Many markets × many dates | `get_market_data_range(mics, start, end, table)` | [market-data.md](references/market-data.md) |
+| One listing's order book, replayed | `NormalisedSecurity.from_listing_id(...).market_data(feed='L3')` | [security-api.md](references/security-api.md) |
+| Custom order-book metrics over the day | `md.rebuilt_history_L2/L3(apply(...))` | [order-book-rebuilding.md](references/order-book-rebuilding.md) |
+| Daily analytics (spread, volume, auction dislocation) | `bmll.time_series.query(...)` | [analytics-timeseries.md](references/analytics-timeseries.md) |
+| Daily lit/dark/SI/OTC split | `bmll.time_series.classified_trades(...)` | [analytics-timeseries.md](references/analytics-timeseries.md) |
+| Cross-venue consolidated book | `bmll.market_data.instrument_cbbo(...)` | [order-book-rebuilding.md](references/order-book-rebuilding.md) |
+| Market cap / free float / FX / calendar | `bmll2.corporate_actions`, `get_fx`, `Calendar` | [other-datasets.md](references/other-datasets.md) |
+
+Asset-class support differs by method:
+
+| Asset class | `get_market_data*` | `Security` / `NormalisedSecurity` |
+|---|---|---|
+| Equities | yes | yes |
+| Futures | yes (`schema='Future'`) | yes |
+| Options (OPRA) | yes | **no** |
+
+## Quick Start
+
+```python
+from bmll2 import reference, get_market_data, NormalisedSecurity
+
+ref = reference.query(ISIN='GB00BH4HKS39', MIC='XLON')
+listing_id = int(ref.ListingId.iloc[0])          # 121317 — Vodafone on the LSE
+
+tp = get_market_data('XLON', '2025-08-22', 'trades-plus')
+
+md = NormalisedSecurity.from_listing_id(listing_id=listing_id, date='2022-04-21').market_data()
+book = md.l2_snapshot(depth=5)
+trades = md.all_trades()
+```
+
+Dates are ISO strings (`'YYYY-MM-DD'`) or `datetime.date` throughout.
+
+## Scripts
+
+Deterministic multi-step computations live in `scripts/` — invoke them rather than re-deriving the
+logic inline. Hand-rolled versions get the markout sign convention or the sentinel filtering wrong
+and the error is invisible in the output.
+
+| Script | Purpose |
+|---|---|
+| `scripts/bmll_markouts.py` | Pre/post-trade markouts from a Trades Plus frame: side inference (Lee-Ready), bps conversion, aggressor-normalised sign, notional-weighted aggregation by any grouping |
+| `scripts/bmll_checks.py` | Validation helpers: per-date non-emptiness, `Printable`/currency sanity, `PricePoint` sentinel filtering, `IsBlock` normalisation |
+
+Run with `python scripts/bmll_markouts.py --help` inside the Data Lab, or import the functions.
+
+## Reference Files
+
+Load the file that matches the task — do not read them all.
+
+| File | Covers |
+|---|---|
+| [references/trades-plus.md](references/trades-plus.md) | **Trades Plus**: full ~99-field schema, markouts, `PricePoint` spread capture, block analysis, participant type, intraday classification |
+| [references/reference-data.md](references/reference-data.md) | `reference.query`, markets/instruments/listings, indices and constituents, futures, OPRA options |
+| [references/market-data.md](references/market-data.md) | `get_market_data` / `_range`, tables, dataframe engines, Spark SQL, futures and options access |
+| [references/security-api.md](references/security-api.md) | `Security` vs `NormalisedSecurity`, `MarketData` tables, normalised enums, market states |
+| [references/order-book-rebuilding.md](references/order-book-rebuilding.md) | `l2_snapshot`, `rebuilt_book_*`, snapshot generators, `rebuilder` operations, custom metrics, order tracing, consolidated books |
+| [references/analytics-timeseries.md](references/analytics-timeseries.md) | `bmll.time_series` metrics and tags, Mongo-style metric queries, classified-trades taxonomy, CBBO |
+| [references/compute-and-storage.md](references/compute-and-storage.md) | File management API, storage areas, Spark dataframes, `SparkHelper`, clusters, scheduled jobs |
+| [references/other-datasets.md](references/other-datasets.md) | FX, shares outstanding / free float / market cap, trading calendar, ETF reference data |
+| [references/troubleshooting.md](references/troubleshooting.md) | Empty results, memory errors, Spark result-size limits, permissions, timestamp types |

--- a/skills/bmll/SKILL.md
+++ b/skills/bmll/SKILL.md
@@ -86,6 +86,24 @@ rule above.
   today-inclusive range returns a short series, not an error.
 - **`time_series` analytics need an entitlement separate from market data.** A missing subscription
   returns empty results, not a permission error.
+- **Venue schemas change at feed migrations, and every field carries an Available-From date.** The
+  LSE splits into Pre-GTP and GTP generations with different field sets (11 trade fields vs 56) and
+  different normalisation mappings. A multi-year study that does not check the venue page reports a
+  feed migration as a regime change — a confident finding about the market that is an artefact of
+  the plumbing.
+- **Retail flags start mid-history and some mechanisms are excluded entirely.** Xetra's retail flag
+  exists only from 2024-05-20, CBOE EU's from 2025-09-08; Turquoise Retail Max and the German
+  single-market-maker venues are not in the `RetailTrades` metric at all; US SIP retail is inferred
+  from odd-lot + inside-NBBO + sub-penny pricing and misses internalised PFOF. Retail "growth"
+  starting exactly on a flag's go-live date is the instrument, not the market.
+- **Three MMT versions coexist (v3.04, v4.1, v5.0) and the level semantics differ between them** —
+  v4.1 splits several v3.04 levels into pairs, v5.0 adds 3.14 and renames 3.3. Decoding a long
+  history with one version's table silently mislabels the other periods.
+- **`event_no` repeats across rows; only `end_of_event == True` marks a book state that could
+  actually be traded against.** Analysing every row treats intermediate states as real ones.
+- **`market_state` auction values span order entry *and* uncrossing.** Filtering
+  `CLOSING_AUCTION` returns the whole call phase; isolate the uncross with
+  `bmll_trade_type == UNCROSSING`.
 
 ### Red Flags — STOP If You Catch Yourself:
 
@@ -158,6 +176,9 @@ Both import in the Data Lab; they are **not** interchangeable.
 | Daily analytics (spread, volume, auction dislocation) | `bmll.time_series.query(...)` | [analytics-timeseries.md](references/analytics-timeseries.md) |
 | Daily lit/dark/SI/OTC split | `bmll.time_series.classified_trades(...)` | [analytics-timeseries.md](references/analytics-timeseries.md) |
 | Cross-venue consolidated book | `bmll.market_data.instrument_cbbo(...)` | [order-book-rebuilding.md](references/order-book-rebuilding.md) |
+| Impact around non-trade events, sub-ms horizons, or cross-product | `scripts/bmll_impact.py` over an L3 book | [market-impact.md](references/market-impact.md) |
+| Retail flow | `BMLLParticipantType` (Trades Plus), `RetailTrades` metric, or `all_trades(columns=[...,'retail'])` | [retail.md](references/retail.md) |
+| What a venue publishes / how it is normalised | Venue dataset page | [venues.md](references/venues.md) |
 | Market cap / free float / FX / calendar | `bmll2.corporate_actions`, `get_fx`, `Calendar` | [other-datasets.md](references/other-datasets.md) |
 
 Asset-class support differs by method:
@@ -194,9 +215,12 @@ and the error is invisible in the output.
 | Script | Purpose |
 |---|---|
 | `scripts/bmll_markouts.py` | Pre/post-trade markouts from a Trades Plus frame: side inference (Lee-Ready), bps conversion, aggressor-normalised sign, notional-weighted aggregation by any grouping |
+| `scripts/bmll_impact.py` | Event-time market impact from an L3 book: arbitrary events, arbitrary horizons, cross-product (events in one book vs another book's midpoint) |
 | `scripts/bmll_checks.py` | Validation helpers: per-date non-emptiness, `Printable`/currency sanity, `PricePoint` sentinel filtering, `IsBlock` normalisation |
 
 Run with `python scripts/bmll_markouts.py --help` inside the Data Lab, or import the functions.
+`scripts/test_bmll_scripts.py` and `scripts/test_bmll_impact.py` cover them against synthetic
+frames built to the documented schema — they do not exercise the live API.
 
 ## Reference Files
 
@@ -205,11 +229,16 @@ Load the file that matches the task — do not read them all.
 | File | Covers |
 |---|---|
 | [references/trades-plus.md](references/trades-plus.md) | **Trades Plus**: full ~99-field schema, markouts, `PricePoint` spread capture, block analysis, participant type, intraday classification |
+| [references/schemas.md](references/schemas.md) | Raw vs harmonised vs normalised layers, LOB event model, the normalised value vocabularies (market state, trade type, LOB actions), normalisation process (icebergs, auctions, regional trade conditions, LIS), MMT |
+| [references/venues.md](references/venues.md) | Per-venue datasets: MIC index for all 88 venues, feed generations and Available-From dates, member attribution |
 | [references/reference-data.md](references/reference-data.md) | `reference.query`, markets/instruments/listings, indices and constituents, futures, OPRA options |
 | [references/market-data.md](references/market-data.md) | `get_market_data` / `_range`, tables, dataframe engines, Spark SQL, futures and options access |
 | [references/security-api.md](references/security-api.md) | `Security` vs `NormalisedSecurity`, `MarketData` tables, normalised enums, market states |
 | [references/order-book-rebuilding.md](references/order-book-rebuilding.md) | `l2_snapshot`, `rebuilt_book_*`, snapshot generators, `rebuilder` operations, custom metrics, order tracing, consolidated books |
+| [references/market-impact.md](references/market-impact.md) | Event-time impact from the L3 book, sign convention, window choice, cross-product (futures → ETF) impact |
+| [references/retail.md](references/retail.md) | Retail mechanisms and per-venue indicators, the three access routes, coverage caveats that bound the metric |
 | [references/analytics-timeseries.md](references/analytics-timeseries.md) | `bmll.time_series` metrics and tags, Mongo-style metric queries, classified-trades taxonomy, CBBO |
 | [references/compute-and-storage.md](references/compute-and-storage.md) | File management API, storage areas, Spark dataframes, `SparkHelper`, clusters, scheduled jobs |
 | [references/other-datasets.md](references/other-datasets.md) | FX, shares outstanding / free float / market cap, trading calendar, ETF reference data |
+| [references/advanced-tutorials.md](references/advanced-tutorials.md) | Index of BMLL's advanced notebooks; thread safety and `Session`, code sharing, external data, R, simulation |
 | [references/troubleshooting.md](references/troubleshooting.md) | Empty results, memory errors, Spark result-size limits, permissions, timestamp types |

--- a/skills/bmll/examples/trades_plus_execution_quality.py
+++ b/skills/bmll/examples/trades_plus_execution_quality.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""End-to-end execution-quality analysis on BMLL Trades Plus.
+
+Run inside the BMLL Data Lab. Produces, for one date across the UK venue set:
+
+  1. intraday traded notional by trade Classification
+  2. intraday block-sized notional by execution venue
+  3. distribution of notional by level of CBBO spread capture (PricePoint)
+  4. pre/post-trade markout curves by Classification
+
+Each step applies the validation the dataset requires rather than assuming clean
+input — see ../references/trades-plus.md for why each filter is present.
+"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import plotly.express as px
+
+from bmll2 import get_market_data
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from bmll_markouts import run as markout_run          # noqa: E402
+from bmll_checks import (                              # noqa: E402
+    assert_non_empty, printable_only, drop_price_point_sentinels,
+    normalise_enum_flags, describe_coverage,
+)
+
+DATE = "2025-08-22"
+MICS = ["XLON", "BATE", "CHIX", "TRQX", "AQXE", "SGMX", "BOTC"]
+
+pd.options.display.max_columns = None
+
+
+def load(date: str, mics: list[str]) -> pd.DataFrame:
+    """Load Trades Plus + reference for each venue and attach InstrumentType."""
+    tp_parts, ref_parts = [], []
+    for mic in mics:
+        tp_mic = get_market_data(mic, date, "trades-plus")
+        ref_mic = get_market_data(mic, date, "reference")
+        # A venue with no rows here is a coverage question, not zero activity.
+        assert_non_empty(tp_mic, what=f"trades-plus {mic} {date}")
+        tp_parts.append(tp_mic)
+        ref_parts.append(ref_mic)
+
+    tp = pd.concat(tp_parts, ignore_index=True, copy=False)
+    ref = pd.concat(ref_parts, ignore_index=True, copy=False)
+
+    # Trades Plus carries no InstrumentType; the reference table does.
+    tp = tp.merge(ref[["ListingId", "InstrumentType"]], on="ListingId", how="left")
+    return normalise_enum_flags(tp)
+
+
+def prepare(tp: pd.DataFrame, date: str) -> pd.DataFrame:
+    """UK equities only, printable prints only, with a TradingDate column."""
+    eq = tp[(tp.InstrumentType == "Equity") & (tp.Jurisdiction == "UK")].copy()
+    eq = printable_only(eq)                       # Size < 0 are cancellations
+    eq["TradingDate"] = pd.to_datetime(eq["TradeTimestamp"].dt.date)
+    eq = eq[eq.TradingDate == date]
+    assert_non_empty(eq, what=f"UK equity prints on {date}")
+    print(describe_coverage(eq).to_string(index=False))
+    return eq
+
+
+def intraday_by_classification(eq: pd.DataFrame):
+    """5-minute bars of traded notional, split by BMLL trade classification."""
+    bars = eq.groupby(
+        ["Classification",
+         pd.Grouper(key="TradeTimestamp", freq="5min", label="right")],
+        as_index=False,
+    )[["TradeNotionalEUR"]].sum()
+
+    return px.bar(bars, x="TradeTimestamp", y="TradeNotionalEUR", color="Classification",
+                  template="plotly_white",
+                  title="UK trades by Classification (5-minute bars)")
+
+
+def intraday_blocks_by_venue(eq: pd.DataFrame):
+    """When during the day is block-sized liquidity actually available, and where."""
+    blocks = eq[eq.IsBlock == "TRUE"]             # string enum, not a bool
+    bars = blocks.groupby(
+        ["ExecutionVenue",                        # where it executed, not where reported
+         pd.Grouper(key="TradeTimestamp", freq="5min", label="right")],
+        as_index=False,
+    )[["TradeNotionalEUR"]].sum()
+
+    return px.bar(bars, x="TradeTimestamp", y="TradeNotionalEUR", color="ExecutionVenue",
+                  template="plotly_white",
+                  title="Block-sized UK trades by Execution Venue (5-minute bars)")
+
+
+def spread_capture(eq: pd.DataFrame):
+    """Notional by level of CBBO spread capture: 0 = at bid, 0.5 = mid, 1 = at ask."""
+    d = drop_price_point_sentinels(eq)            # removes the +/-99999 rows
+    d = d.assign(PricePointRounded=d.PricePoint.round(1))
+    dist = d.groupby(["PricePointRounded", "ExecutionVenue"],
+                     as_index=False)[["TradeNotionalEUR"]].sum()
+
+    return px.bar(dist, x="PricePointRounded", y="TradeNotionalEUR", color="ExecutionVenue",
+                  template="plotly_white",
+                  title="UK trades by level of CBBO spread capture")
+
+
+def markouts(eq: pd.DataFrame, group_by=("Classification",)):
+    """Notional-weighted markout curves, normalised to an aggressive buyer."""
+    tidy = markout_run(eq, group_by=list(group_by), benchmark="primary")
+
+    fig = px.line(tidy, x="interval_ms", y="markout_bps", color="group",
+                  template="plotly_white",
+                  title="Pre/post-trade markouts vs the primary midpoint")
+    fig.update_xaxes(title="Interval (ms, negative = pre-trade)")
+    fig.update_yaxes(title="Markout (bps)")
+    return tidy, fig
+
+
+def main() -> None:
+    tp = load(DATE, MICS)
+    eq = prepare(tp, DATE)
+
+    intraday_by_classification(eq).show()
+    intraday_blocks_by_venue(eq).show()
+    spread_capture(eq).show()
+
+    tidy, fig = markouts(eq, group_by=("Classification",))
+    fig.show()
+    print(tidy.head(20).to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bmll/references/advanced-tutorials.md
+++ b/skills/bmll/references/advanced-tutorials.md
@@ -1,0 +1,74 @@
+# Advanced Tutorials
+
+`https://lab.bmlltech.com/docs/contents/tutorials/advanced.html`
+
+Index of BMLL's advanced notebooks and where each is covered in this skill.
+
+| Tutorial | Covered in |
+|---|---|
+| Advanced data access: `Security` class | [order-book-rebuilding.md](order-book-rebuilding.md) — snapshots, generators, `apply`, custom operations, order tracing |
+| Advanced data access: `get_market_data` | [market-data.md](market-data.md) |
+| Retail Trades | [retail.md](retail.md) |
+| Market Impact with BMLL | [market-impact.md](market-impact.md) + `scripts/bmll_impact.py` |
+| Advanced analytics usage | Below — threading and `Session` |
+| Parallelising Data Access | [compute-and-storage.md](compute-and-storage.md) |
+| Cluster management API | [compute-and-storage.md](compute-and-storage.md) |
+| Sharing and Importing Code | Below |
+| External Data Management | Below |
+| R in the Data Lab | Below |
+
+## Thread safety and `Session`
+
+`bmll.reference.query` and `bmll.time_series.query` are **not threadsafe by default**. In a
+multithreaded application, create an explicit `Session` per thread rather than relying on the
+module-level default:
+
+```python
+from bmll import Session
+
+session = Session()                                    # uses BMLL env vars
+session = Session(username=..., key_path=..., key_passphrase=...)
+```
+
+The `Session` class handles authentication and low-level communication with the BMLL REST APIs.
+Sharing the implicit default session across threads is the failure this guidance exists to prevent
+— and it surfaces as corrupted or interleaved responses rather than as an exception, so it is not
+obvious from a traceback.
+
+This matters when combining `bmll` Data Feed calls with `SparkHelper.map` or any thread pool. Note
+`SparkHelper` parallelises across *processes*, which sidesteps the issue; a `ThreadPoolExecutor`
+does not.
+
+## Sharing and importing code
+
+`tutorials/notebooks/sharing_and_importing_code_on_the_BMLL_platform.html`
+
+How to make modules written in one workspace importable in another, and share them across an
+organisation. Relevant because the Data Lab's local filesystem is ephemeral — code, like data,
+needs to live in a persistent area to survive a workspace stop. See
+[compute-and-storage.md](compute-and-storage.md).
+
+## External data management
+
+`tutorials/notebooks/external_data_management.html`
+
+Connecting the Data Lab to external sources via SFTP and cloud connections, for bringing your own
+data alongside BMLL's. Storage-area mechanics are in
+[compute-and-storage.md](compute-and-storage.md); admin-side configuration is under
+`contents/admin/external_storage.html` and `contents/admin/sftp.html`.
+
+## R in the Data Lab
+
+`tutorials/notebooks/getting_started_with_R.html`
+
+The Data Lab supports R alongside Python. The BMLL APIs are Python-first — the usual pattern is to
+pull with Python, persist, then analyse in R.
+
+## Simulation
+
+Not part of the advanced tutorials index, but adjacent and worth knowing exists:
+`contents/knowledge_centre/simulation.html` plus notebooks for a first strategy, passive execution,
+portfolio and agent examples, cluster-scale simulation, auctions, and market response. BMLL
+provides a backtesting simulator that replays the historical order book and models the market's
+response to your orders — a different tool from the impact measurement in
+[market-impact.md](market-impact.md), which measures impact that already happened.

--- a/skills/bmll/references/analytics-timeseries.md
+++ b/skills/bmll/references/analytics-timeseries.md
@@ -1,0 +1,251 @@
+# Analytics: `bmll.time_series` and the Data Feed
+
+Pre-computed analytics built from Level 3 data, served over the wire by the **`bmll`** package
+(not `bmll2`). Every Lab user can connect; the analytics themselves need a **separate
+subscription** — without it queries return empty results rather than a permission error.
+
+Computed **T+1**. Currently equity venues only.
+
+```python
+import bmll
+```
+
+## Discovering metrics
+
+Never guess a metric name — `available()` is the catalogue:
+
+```python
+bmll.time_series.available()
+# metric | suffix | group | type | frequency | tags | description | unit
+```
+
+A metric is identified by `metric` **plus `suffix`**; the suffix encodes the variant. `tags` holds
+the semantics behind the suffix, and `explode_tags=True` turns them into columns for filtering:
+
+```python
+bmll.time_series.available(explode_tags=True).query(
+    'metric == "AuctionDislocation" and frequency == "D"'
+).dropna(axis=1)
+# -> Phase=C, Horizon=1m/5m/Last
+```
+
+Example groups: `Liquidation cost` (`TradeImbalance` by side and level), `Auction analysis`
+(`AuctionDislocation`), `Liquidity classification` (`TradeVolume`/`TradeCount` by classification).
+Frequencies include `D` and `30M` — a metric published at `30M` will not answer a daily query.
+
+## Querying
+
+```python
+bmll.time_series.query(Ticker='AAL', MIC='XLON',
+                       metric='TradeVolume',
+                       start_date='2020-01-02', end_date='2020-01-10')
+# ListingId Ticker MIC Date TradeVolume|Dark TradeVolume|Lit TradeVolume|Bi TradeVolume|Non
+```
+
+Result columns are `metric|suffix`. A bare `metric='TradeVolume'` returns **every** suffix — often
+what you want, but it makes the frame wide and the column names are the only place the variant is
+recorded.
+
+Multiple metrics:
+
+```python
+bmll.time_series.query(Ticker='AAL', MIC='XLON',
+                       metric=['TradeCount', 'TradeVolume'],
+                       start_date='2020-01-01', end_date='2020-03-31')
+```
+
+### Narrowing with a Mongo-style filter
+
+`metric` accepts a MongoDB-style query document, matched against the catalogue:
+
+```python
+bmll.time_series.query(Ticker='AALl', MIC='BOTC',
+                       metric={'metric': {'$in': ['TradeVolume', 'TradeCount']},
+                               'tags.Classification': 'DarkAddressable'},
+                       start_date='2020-01-02', end_date='2020-01-10')
+```
+
+Tags are addressed as `tags.<Name>`. Reference: MongoDB `db.collection.find` operators.
+
+### Passing the catalogue frame directly
+
+Often clearest — filter `available()` with pandas, hand the result to `query`:
+
+```python
+metrics = bmll.time_series.available(explode_tags=True).query(
+    'metric in ["TradeVolume","TradeCount"] and Classification == "DarkAddressable" '
+    'and frequency == "D"').dropna(axis=1)
+
+bmll.time_series.query(Ticker='AALl', MIC='BOTC', metric=metrics,
+                       start_date='2020-01-01', end_date='2020-01-10')
+```
+
+The metric selection is then visible and checkable as a frame before any data is pulled.
+
+### Querying a universe
+
+`object_ids` takes listing IDs, so reference data defines the universe:
+
+```python
+ref = bmll.reference.query(MIC='XHEL', start_date='2019-12-01', end_date='2019-12-02')
+
+ts = bmll.time_series.query(object_ids=ref.ListingId,
+                            metric={'metric': 'TradeVolume', 'suffix': 'Lit'},
+                            start_date='2018-01-01', end_date='2020-01-01')
+# -> ObjectId | Date | TradeVolume|Lit
+```
+
+When queried by `object_ids` the key column is **`ObjectId`**, not `ListingId` — join on it:
+
+```python
+df = pd.merge(ref[['ListingId', 'Ticker']], ts, left_on='ListingId', right_on='ObjectId')
+df.pivot_table(index='Date', columns='Ticker', values='TradeVolume|Lit').fillna(0)
+```
+
+### Large universes
+
+Split by MIC, and for ranges beyond a year by date too:
+
+```python
+ref = bmll.reference.query(OPOL=['XLON'])
+out = []
+for mic in ref.MIC.unique():
+    lids = ref.loc[ref.MIC == mic, 'ListingId'].unique().tolist()
+    out.append(bmll.time_series.query(object_ids=lids,
+                                      metric=['Spread', 'TradeNotional'],
+                                      frequency='D',
+                                      start_date='2022-01-01', end_date='2022-12-31'))
+ts = pd.concat(out, ignore_index=True)
+```
+
+(BMLL's published version of this loop appends outside the loop and keeps only the last MIC —
+append inside, as above.)
+
+## Classified trades
+
+Daily traded volume, count and notional broken down by a 22-bucket taxonomy and execution venue —
+the standard tool for liquidity-fragmentation questions: where liquidity is, how venue mix evolves,
+which mechanisms are growing.
+
+```python
+ref = bmll.reference.query(ISIN='GB00BH4HKS39',
+                           MIC=['XLON','TRQX','BOTC','AQXE','XEQT','XPAR','XAMS'])
+
+trades = bmll.time_series.classified_trades(object_ids=ref['ListingId'],
+                                            start_date='2022-02-02',
+                                            end_date='2022-02-07')
+# Date | PublicationDate | ListingId | ExecutionVenue | Notional | Shares | Count | Classification
+```
+
+Currency is normalised to **EUR for Europe/UK and USD elsewhere**. (Via the `bmll2` route you can
+choose the currency.)
+
+### The taxonomy
+
+Three levels. Bracketed names are groupings, not values in the data.
+
+```
+(ON_EXCHANGE)                        execution_venue not XOFF/SINT
+    LIT_CONTINUOUS                   on-book continuous, pre-trade transparent (incl. visible iceberg parts)
+    (AUCTIONS)
+        LIT_OPENING_AUCTION
+        LIT_INTRADAY_AUCTION
+        LIT_CLOSING_AUCTION
+        AUCTION_ON_DEMAND            periodic auction
+    (CLOSING_PRICE)
+        CLOSING_PRICE                mechanism guaranteeing the closing price
+        POST_TRADE_UNCROSSING        post-close auction (CBOE 3C)
+    (DARK)
+        DARK_BELOW_LIS
+        DARK_ABOVE_LIS
+        DARK_CONDITIONAL_BELOW_LIS   hybrid mechanisms (Turquoise UNCROSS + Block Discovery)
+        DARK_CONDITIONAL_ABOVE_LIS
+    (REQUEST_FOR_QUOTE)
+        REQUEST_FOR_QUOTE_BELOW_LIS
+        REQUEST_FOR_QUOTE_ABOVE_LIS
+    OFF_BOOK_ON_EXCHANGE
+(OFF_EXCHANGE)                       execution_venue is XOFF or SINT
+    (SI)                             systematic internaliser
+        SI_ADDRESSABLE_BELOW_LIS
+        SI_ADDRESSABLE_ABOVE_LIS
+        SI_NON_ADDRESSABLE_BELOW_LIS
+        SI_NON_ADDRESSABLE_ABOVE_LIS
+    (OTC)
+        BENCHMARK_PRICE              MMT BENC flag
+        SPECIAL_PRICE                non-price-forming (dividends, physical delivery, ...)
+        OTC                          vanilla OTC
+```
+
+**Addressable** means: not `SPECIAL_PRICE`, executed during the primary market's regular hours, and
+in the primary market's currency.
+
+Larger buckets are reconstructed by summing, using these maps:
+
+```python
+LEVEL3_TO_LEVEL2 = {
+  "POST_CLOSE_UNCROSSING": "CLOSING_PRICE",
+  "REQUEST_FOR_QUOTES_BELOW_LIS": "REQUEST_FOR_QUOTES",
+  "REQUEST_FOR_QUOTES_ABOVE_LIS": "REQUEST_FOR_QUOTES",
+  "DARK_BELOW_LIS": "DARK", "DARK_ABOVE_LIS": "DARK", "DARK_CONDITIONAL": "DARK",
+  "SI_ADDRESSABLE_BELOW_LIS": "SI", "SI_ADDRESSABLE_ABOVE_LIS": "SI",
+  "SI_NON_ADDRESSABLE_BELOW_LIS": "SI", "SI_NON_ADDRESSABLE_ABOVE_LIS": "SI",
+  "BENCHMARK_PRICE": "OTC", "SPECIAL_PRICE": "OTC",
+  "LIT_OPENING_AUCTION": "AUCTION", "LIT_CLOSING_AUCTION": "AUCTION",
+  "LIT_INTRADAY_AUCTION": "AUCTION", "LIT_UNSCHEDULED_AUCTION": "AUCTION",
+  "AUCTION_ON_DEMAND": "AUCTION",
+}
+
+LEVEL2_TO_LEVEL1 = {
+  "LIT_CONTINUOUS": "ON_EXCHANGE", "CLOSING_PRICE": "ON_EXCHANGE", "DARK": "ON_EXCHANGE",
+  "AUCTION": "ON_EXCHANGE", "REQUEST_FOR_QUOTE": "ON_EXCHANGE",
+  "OFF_BOOK_ON_EXCHANGE": "ON_EXCHANGE",
+  "OTC": "OFF_EXCHANGE", "SI": "OFF_EXCHANGE",
+}
+
+trades['L2'] = trades['Classification'].replace(LEVEL3_TO_LEVEL2)
+trades['L1'] = trades['L2'].replace(LEVEL2_TO_LEVEL1)
+```
+
+Note the maps carry BMLL's own key spellings (`POST_CLOSE_UNCROSSING`, `REQUEST_FOR_QUOTES_*`,
+`DARK_CONDITIONAL`) which differ from the documented bucket names (`POST_TRADE_UNCROSSING`,
+`REQUEST_FOR_QUOTE_*`, `DARK_CONDITIONAL_{BELOW,ABOVE}_LIS`). Unmapped values pass through
+`replace` unchanged and land in the L1 layer as themselves — check for leftovers after mapping
+rather than assuming a clean two-level rollup:
+
+```python
+assert set(trades.L1) <= {"ON_EXCHANGE", "OFF_EXCHANGE"}, set(trades.L1)
+```
+
+Hierarchy view:
+
+```python
+cols = ['ExecutionVenue', 'L1', 'L2', 'Classification']
+px.treemap(trades[cols + ['Notional']].dropna(), path=cols, values='Notional',
+           color='ExecutionVenue')
+```
+
+### Versus Trades Plus
+
+| | `classified_trades` | Trades Plus `Classification` |
+|---|---|---|
+| Grain | Daily aggregate | Per trade |
+| Intraday | no | yes |
+| Currency | EUR/USD by region | plus `TradeNotional` in native currency |
+| `OFF_BOOK_ON_EXCHANGE` | includes `BENCHMARK_PRICE`/`SPECIAL_PRICE` | `OTC` type only, non-`SINT`/`XOFF` venue |
+
+The two will not reconcile exactly. Use Trades Plus when intraday or per-trade context matters,
+`classified_trades` for long daily histories.
+
+## Consolidated BBO
+
+`bmll.market_data.instrument_cbbo` — see
+[order-book-rebuilding.md](order-book-rebuilding.md#consolidated-books).
+
+## Data SDK
+
+`bmll.data` works inside and outside the Data Lab, for dataset discovery and generic queries:
+
+```python
+bmll.data.datasets(describe=..., dataset=...)
+bmll.data.query(dataset, startDate=..., endDate=...)
+```

--- a/skills/bmll/references/compute-and-storage.md
+++ b/skills/bmll/references/compute-and-storage.md
@@ -1,0 +1,179 @@
+# Compute and Storage
+
+## Storage areas
+
+The Data Lab has a **`local`** area (the notebook instance's disk) and persistent remote areas
+(`user`, `organisation`, `sftp`, `support`).
+
+**Everything written locally is destroyed when the workspace stops.** Notebooks in every area save
+into `local`, so `df.to_csv('results.csv')` produces a file that disappears — a result the user
+believes is saved and is not.
+
+Small files can be dragged out of the JupyterLab UI. Anything larger, or anything programmatic,
+goes through the file management API.
+
+```python
+import bmll2 as b2
+```
+
+| Call | Purpose |
+|---|---|
+| `b2.create_folder(name, area=, ensure_exists=)` | Create a folder in a storage area |
+| `b2.list_files(area=, path=, local=)` | List files |
+| `b2.put_file(local_filename, remote_dir=, ...)` | **Persist** a local file |
+| `b2.get_file(filename, area=, local_dir=, ...)` | Download to the instance |
+| `b2.copy_file(old, new, ...)` | Copy within an area |
+| `b2.copy_file_to_support(filepath, path=, area=)` | Share with BMLL support |
+| `b2.rename_file(old, new, area=)` | Rename |
+| `b2.delete_file(path, area=)` | Delete |
+| `b2.delete_folder(path, area=, recursive=)` | Delete a folder |
+| `b2.file_exists(path, area=, is_folder=)` | Existence check |
+| `b2.list_deleted_files(path=, area=)` | Recently deleted files |
+| `b2.get_file_history(path, area=)` | All versions of a file |
+| `b2.recover_file_version(path, recovery_file_name, version_id=)` | Restore |
+
+```python
+b2.create_folder('analysis')
+b2.put_file('analysis/results.csv')
+b2.list_files(path='analysis')
+b2.get_file('analysis/results.csv', local_dir='analysis')
+```
+
+### Versioning and recovery
+
+Storage is versioned. Deleted files are recoverable for **7 days**:
+
+```python
+b2.list_deleted_files('analysis')
+b2.get_file_history(path='analysis/results.csv')
+# {'analysis/results.csv': [VersionInfo(version_id='t3ih...', latest=False, size=12,
+#                                       last_modified=..., delete_marker=False),
+#                           VersionInfo(version_id='ZFNw...', latest=True,
+#                                       delete_marker=True, ...)]}
+b2.recover_file_version('analysis/results.csv', recovery_file_name='recovered.csv')
+```
+
+A `delete_marker=True` entry is the deletion event, not a version of the content — recover the
+`version_id` of the last real version below it. `get_file_history` accepts a filename prefix, so
+partial paths return every matching file.
+
+Recovered files land in the **same directory** as the deleted original.
+
+## Spark dataframes
+
+```python
+from bmll2 import save_spark_dataframe, load_spark_dataframe
+
+save_spark_dataframe(spark_df, path='/analysis/book', format='parquet', mode='overwrite')
+sdf = load_spark_dataframe(path='/analysis/book', format='parquet')
+```
+
+Saves to the user, organisation or support area — persistent, unlike a local write.
+
+## Parallelising without a cluster
+
+A workspace has up to **192 cores**. Exhaust single-machine parallelism before reaching for a
+cluster — the cluster's startup cost frequently exceeds the job.
+
+**Dataframe engines** parallelise for free:
+
+```python
+df = get_market_data('XLON', '2025-06-23', 'trades', df_engine='polars')
+df.group_by('Ticker').agg(pl.col('Size').sum())     # CPU time >> wall time
+```
+
+CPU time being a multiple of wall time is the confirmation it went parallel.
+
+**`SparkHelper`** parallelises per-listing `Security` work, which is otherwise serial:
+
+```python
+from bmll2 import SparkHelper, Security
+
+def get_lob_size(lid, date):
+    sec = Security.from_listing_id(listing_id=lid, date=date)
+    return len(sec.market_data('L3').incremental_book_L3())
+
+args = [(lid, date) for lid in listing_ids]
+
+with SparkHelper.track_progress():
+    results = SparkHelper.map(get_lob_size, args).collect()
+```
+
+Roughly 4× on 20 large UK order books versus the serial loop; the speedup depends on the function
+and the data size.
+
+`SparkHelper` methods: `map`, `flatMap`, `foreach`, `parallelize`, `get_context`,
+`track_progress`.
+
+**`SparkHelper.map` returns results in completion order, not argument order.** Zip the inputs into
+the return value rather than pairing the result list against `args` positionally — BMLL's own
+tutorial demonstrates the mispairing (`pd.DataFrame(lids, results)` transposes the two).
+
+```python
+def get_lob_size(lid, date):
+    sec = Security.from_listing_id(listing_id=lid, date=date)
+    return (lid, len(sec.market_data('L3').incremental_book_L3()))   # carry the key
+```
+
+## Clusters
+
+For genuinely multi-machine work:
+
+```python
+from bmll2 import create_cluster, get_clusters, ClusterConfig
+```
+
+`create_cluster` takes a configurable node count and node type, and a log path (in a user area). If
+the log path is omitted, **no logging happens** — and a failed cluster job with no logs is
+undiagnosable after the fact.
+
+`get_clusters()` lists clusters with `Name`, `Status`, total running time, `Started`/`Ready`/
+`Stopped`, node type and count, user, and job count.
+
+Cluster objects: `.submit()`, `.execute()`, `.wait()`, `.describe()`, `.logs()`, `.distcp()`,
+`.terminate()`. Collections: `ClusterCollection.get/describe/terminate`.
+
+Logging helpers for code running on a cluster: `bmll2.cluster.get_logger`,
+`initialise_logging`, `put_cluster_log`, `parameters`.
+
+`stop_workspace()` stops the current workspace immediately — the programmatic equivalent of the
+Stop Workspace button.
+
+## Scheduled jobs
+
+Jobs run notebooks or scripts on a schedule or a data-availability trigger. Manage them in the Data
+Lab UI under *Jobs*, or via the API:
+
+```python
+from bmll import compute
+
+compute.create_job(compute_type='cluster', ...)   # or 'instance'
+compute.get_jobs()
+compute.get_tasks()
+compute.terminate_job_run(...)
+```
+
+Jobs are built from `JobTask` objects and triggers:
+
+| Trigger | Fires on |
+|---|---|
+| `CronTrigger` | A cron schedule |
+| `L3Availability` | Level 3 data becoming available for a market/date |
+
+`L3Availability` is the one that matters for daily pipelines — cron fires at a wall-clock time
+whether or not the data has landed, and BMLL data is T+1 with variable arrival.
+
+Job objects (`ClusterJob`, `InstanceJob`) support `add_task`, `add_trigger`, `delete_task`,
+`delete_trigger`, `execute`, `clone`, `update`, `reload`, `previous_runs`, `to_dict`, `delete`.
+
+Jobs are **public** or **private**; public jobs are visible to the whole organisation.
+
+`bmll2.scheduling` offers the cluster-side equivalents: `schedule_cluster`, `ClusterTask`
+(`submit`, `trigger`, `delete`, `get_history`, `get_triggers_history`, `display`),
+`get_cluster_tasks`, `L3Availability`.
+
+## Credentials
+
+`bmll2.key_management` — `store_key`, `get_keys`, `delete_key` — for third-party credentials needed
+inside the Lab. Do not hard-code secrets in notebooks; they persist in the notebook file and in
+version history.

--- a/skills/bmll/references/market-data.md
+++ b/skills/bmll/references/market-data.md
@@ -1,0 +1,162 @@
+# Market Data: `get_market_data` and `get_market_data_range`
+
+Whole-market access, indexed by MIC and date. For per-listing order-book work use
+[security-api.md](security-api.md) instead.
+
+```python
+import pandas as pd, polars as pl
+from bmll2 import get_market_data, get_market_data_range, get_market_tables, get_df_engines
+pd.options.display.max_columns = None
+```
+
+## Picking a table
+
+`get_market_tables()` is the authority — table availability varies by asset class:
+
+| asset-class | reference | cbbo | trades-plus | l1 | l2 | l3 | trades | nbbo | market-state | imbalance | statistics |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Equity | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Future | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| Option | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
+
+Call it rather than trusting this table — it reflects entitlements as well as coverage.
+
+## Single date
+
+```python
+df = get_market_data('AQXE', '2024-03-18', 'trades')
+
+get_market_data('XLON', '2024-01-12', 'trades',
+                ticker=['BP.', 'VOD'],
+                columns=['Ticker', 'MIC', 'ListingId', 'Price', 'Size',
+                         'TradeTimestampNanoseconds'])
+```
+
+Optional filters: `ticker`, `listing_id`, `columns`. Pushing `columns` down is the single cheapest
+optimisation — these tables are wide.
+
+Returns **pandas** by default.
+
+## Dataframe engines
+
+```python
+get_df_engines()          # ['pandas', 'polars', 'spark']
+
+df = get_market_data('XLON', '2024-04-25', 'trades', df_engine='polars')
+lf = get_market_data('XLON', '2025-06-23', 'trades', df_engine='polars', lazy_load=True)
+```
+
+Polars and Spark natively use every core on the workspace (up to 192). `lazy_load=True` returns a
+Polars `LazyFrame` for out-of-memory work on a single machine — usually the right answer before
+reaching for a cluster.
+
+## Date ranges
+
+```python
+df = get_market_data_range(['XLON', 'XPAR', 'XTRA'], '2024-01-01', '2024-01-30', 'trades')
+```
+
+Two differences from `get_market_data` that break naive code reuse:
+
+1. Returns a **PySpark** DataFrame, not pandas.
+2. `TradeTimestampNanoseconds` and `PublicationTimestampNanoseconds` are **integer nanoseconds**,
+   not `numpy.datetime64`.
+
+Use `scripts/bmll_checks.py::coerce_range_timestamps` to normalise (2) — it is idempotent, so it is
+safe on either result type.
+
+**Aggregate in Spark before collecting.** `.toPandas()` on a full multi-venue, multi-month result
+loads everything into driver memory and takes the session with it:
+
+```python
+import pyspark.sql.functions as F
+
+sdf = get_market_data_range(['XLON','BATE','CHIX','TRQX','AQXE','SGMX','BOTC'],
+                            '2024-01-01', '2024-10-30', 'trades')
+res = (sdf[sdf['InstrumentId'].isin([121429])]
+       .groupBy(['TradeDate', 'ExecutionVenue'])
+       .agg(F.sum('Size').alias('Size'))
+       .toPandas())          # collect only the aggregate
+```
+
+That aggregation over 7 venues year-to-date runs in well under a minute.
+
+### Spark SQL
+
+```python
+from pyspark.sql import SparkSession
+spark = SparkSession.builder.getOrCreate()
+
+sdf = get_market_data_range(['XLON'], '2024-01-01', '2024-10-28', 'trades')
+sdf.createOrReplaceTempView('sdf')
+
+spark.sql("""
+    SELECT TradeDate, ExecutionVenue, sum(Size) AS TotalSize
+    FROM sdf WHERE InstrumentId = 121429
+    GROUP BY TradeDate, ExecutionVenue
+""").toPandas()
+```
+
+### Raising the driver result limit
+
+When a legitimately large collect is unavoidable:
+
+```python
+from pyspark.sql import SparkSession
+conf = spark.sparkContext.getConf()
+conf.set('spark.driver.maxResultSize', '10g')
+spark.stop()
+spark = SparkSession.Builder().master('local[*]').config(conf=conf).getOrCreate()
+```
+
+Do this at the top of the cell, before any query — it restarts the session.
+
+## Futures
+
+Set `schema='Future'`, and narrow with `product_code` / `maturity_month_year` so only the relevant
+slice is read:
+
+```python
+tr = get_market_data_range('XCME', '2025-06-01', '2025-09-30', 'trades',
+                           schema='Future',
+                           product_code=['ES'], maturity_month_year=['202509'],
+                           df_engine='polars', lazy_load=True)
+
+daily = (tr.group_by(['TradeDate', 'ContractType'])
+           .agg(pl.col('Size').sum().alias('DailyVolume'))
+           .collect().to_pandas())
+```
+
+Group by or filter on `ContractType` — `Outright` vs `Spread` — or spread legs inflate volume.
+
+## Options (OPRA)
+
+Options are only reachable through these methods (`Security` does not support them). Prefer
+`get_market_data_range` even for one day; the conflated feed is still large.
+
+```python
+ref = get_market_data_range('OPRA', '2024-11-04', '2024-11-04', 'reference')
+ref = ref[ref['UnderlyingTicker'] == 'TSLA']
+
+grouped = (ref.groupby(['ExpiryDate', 'OptionType', 'StrikePrice']).sum()
+              .withColumnRenamed('sum(DailyVolume)', 'DailyVolume'))
+grouped = grouped[grouped.DailyVolume > 0].sort(['ExpiryDate', 'OptionType', 'StrikePrice'])
+```
+
+Tables available: `trades`, `nbbo`, `reference`, `statistics`.
+
+## Consolidated tapes
+
+Where a consolidated tape exists, query it by its MIC — `@SIP` for the US. The `cbbo` and `nbbo`
+tables give consolidated touch data; see [order-book-rebuilding.md](order-book-rebuilding.md) for
+the deeper `instrument_cbbo` API.
+
+## Before aggregating anything
+
+```python
+from bmll_checks import printable_only, assert_non_empty_per_date, describe_coverage
+
+df = printable_only(df)                                   # Size < 0 are cancellations
+assert_non_empty_per_date(df, expected_trading_days)      # a blank date hides in a total
+describe_coverage(df)                                     # rows per date × venue
+```

--- a/skills/bmll/references/market-impact.md
+++ b/skills/bmll/references/market-impact.md
@@ -1,0 +1,129 @@
+# Market Impact
+
+Tutorial: `tutorials/notebooks/market_impact.html`
+
+Price impact is the correlation between an incoming order and the subsequent price change. It is a
+cost: a trader's second trade is on average more expensive than the first because of their own
+impact. A **markout** — the price change measured at offsets around an event — is how it is
+quantified.
+
+BMLL gives two routes, and they answer different questions.
+
+| | Trades Plus markouts | Event-time impact (this page) |
+|---|---|---|
+| Source | Pre-computed midpoint columns on each trade row | Rebuilt from the L3 book |
+| Events | Executed trades only | Any query on the incremental book |
+| Horizons | 15 fixed intervals, 1ms–5m | Arbitrary, including sub-millisecond |
+| Universe | A whole market in one call | Per listing (parallelise for more) |
+| Cross-product | No | **Yes** — events from one book vs another book's midpoint |
+| Cost | Cheap | Rebuilds the book |
+
+Use Trades Plus ([trades-plus.md](trades-plus.md)) for breadth — impact across a market by
+classification or venue. Use event-time impact when the event is not a trade, the horizon is not on
+the published grid, or the response is in a *different* instrument.
+
+## The script
+
+The computation is deterministic and easy to get subtly wrong — the sign convention especially.
+Use `scripts/bmll_impact.py`:
+
+```python
+from bmll2 import NormalisedSecurity
+from bmll_impact import (MarketImpactComputer, liquidity_removal_events,
+                         mid_from_book, geometric_window)
+
+book = (NormalisedSecurity.from_listing_id(121317, "2021-05-05")   # VOD on XLON
+        .market_data().incremental_book_L3()
+        .set_index("event_timestamp"))
+
+im = MarketImpactComputer(
+    events=liquidity_removal_events(book),
+    books={"VOD:XLON": book},
+    impact_metric=mid_from_book,
+    window=geometric_window(seconds=10, n=20),
+)
+
+curve = im.mean_curve()      # offset_seconds | ID | impact_bps
+raw = im.raw_impact          # per-event, per-offset
+```
+
+`mean_curve()` returns a tidy frame ready to plot: `offset_seconds` runs negative (pre-event)
+through zero to positive (post-event).
+
+```python
+import plotly.express as px
+px.line(curve, x="offset_seconds", y="impact_bps", color="ID",
+        labels={"impact_bps": "Midpoint impact (bps)", "offset_seconds": "Markout time (s)"})
+```
+
+## How it works, and what to get right
+
+**The reference is taken 1ns before the event.** At the event timestamp the book is already
+impacted, so measuring deviation from the event-time midpoint understates impact by exactly the
+part you are trying to measure.
+
+**Sign is normalised to the aggressor.** `events['side']` is the side of the *resting* order that
+was executed, so an executed ASK means an aggressive **buyer** and an executed BID an aggressive
+**seller**. `impact_bps` flips the sign for seller-initiated events so both add.
+
+Without that normalisation the mean curve collapses toward zero — buy and sell impact cancel — and
+reads as "no impact" rather than "two opposite signs were averaged". The test in
+`scripts/test_bmll_impact.py` asserts exactly this: on a fixture where each event moves the mid 1%
+in its own direction, the normalised mean is ~99.5 bps while the unnormalised mean is ~0.5.
+
+(BMLL's tutorial reaches the same place by a double negation — the measure multiplies by `-1` for
+ASK and the plotting code multiplies by `-1` again "to look at the aggressive side". The script
+does it once, explicitly.)
+
+**Windows are geometric by default.** Impact decays fast and nearly all the structure is in the
+first milliseconds; evenly spaced offsets spend their resolution on the flat tail.
+`geometric_window(seconds=10, n=20)` covers 10s densest near zero. Use
+`linear_window(seconds=1e-4, n=80)` for sub-millisecond work.
+
+**Events are user-defined.** `liquidity_removal_events` selects
+`lob_action == 'REMOVE' & execution_size > 0`, largest first — but any query works. Passive
+inserts, cancellations, iceberg reveals, or events filtered to a size band are all valid; supply a
+frame with `event_timestamp` and `side`.
+
+`num_events` bounds the set to the N largest, which is usually the question and also bounds cost —
+the reindexing is per event per offset.
+
+## Cross-product impact
+
+The distinctive capability: measure events in one book against the midpoint of another. Pass a
+different book in `books` than the one the events came from.
+
+```python
+from bmll2 import Security, NormalisedSecurity
+
+SPY = (NormalisedSecurity.from_listing_id(366216, "2021-05-05")      # SPY on XNYS
+       .market_data().incremental_book_L3().set_index("event_timestamp"))
+ES = (Security.from_listing_id(415907260, date="2021-05-05")         # ES future
+      .market_data(feed="L3").incremental_book_L3().set_index("event_timestamp"))
+
+im = MarketImpactComputer(
+    events=liquidity_removal_events(ES, num_events=10_000),   # events from the future
+    books={"SPY:XNYS": SPY},                                  # impact measured on the ETF
+    window=linear_window(seconds=1e-4, n=80),
+)
+curve = im.mean_curve()
+```
+
+In BMLL's run the SPY response appears about **4ms** after the ES event — the New York/Chicago
+round-trip time. That is the shape of the result to expect: a flat pre-event line, then a step at
+the propagation delay rather than at zero.
+
+Two things follow. The window must be fine enough to resolve the delay — a geometric 10s window
+puts the whole effect in one bucket. And the futures book comes from `Security` rather than
+`NormalisedSecurity`, so its columns are venue-native: the tutorial's futures event query uses
+`lob_action == 3` and `executed_size` where the normalised equity book uses `'REMOVE'` and
+`execution_size`. Check the column names on a raw book before assuming the normalised ones.
+
+Expect this to be slow — BMLL's 10,000-event cross-product example takes ~45s after the books are
+loaded.
+
+## Related
+
+- Trades Plus markouts across a whole market: [trades-plus.md](trades-plus.md)
+- Rebuilding books and custom metrics: [order-book-rebuilding.md](order-book-rebuilding.md)
+- Parallelising per-listing work: [compute-and-storage.md](compute-and-storage.md)

--- a/skills/bmll/references/order-book-rebuilding.md
+++ b/skills/bmll/references/order-book-rebuilding.md
@@ -1,0 +1,205 @@
+# Order Book Rebuilding
+
+Replaying the limit order book from L2/L3 events. All methods hang off a `MarketData` object
+(see [security-api.md](security-api.md)).
+
+```python
+import datetime, itertools
+import numpy as np, pandas as pd
+from bmll2 import NormalisedSecurity
+
+sec = NormalisedSecurity.from_listing_id(listing_id=121317, date='2022-04-21')
+md = sec.market_data()
+
+ct = md.market_info().query('market_state == "CONTINUOUS_TRADING"')
+open_dt, close_dt = ct.start_timestamp.min(), ct.end_timestamp.max()
+```
+
+## Choosing a method
+
+| Method | Returns | Use when |
+|---|---|---|
+| `l2_snapshot(depth=N)` | DataFrame, one row per event, `bid/ask_price_i`, `_size_i`, `_num_orders_i` | Fastest path to a book; default depth 5 |
+| `rebuilt_book_L2(...)` / `rebuilt_book_L3(...)` | DataFrame over a window at a frequency | A bounded window as a frame |
+| `snapshot_generator_L2/L3(...)` | Generator of `(bid, ask)` arrays | Full-day replay without materialising it |
+| `rebuilt_history_L2/L3(apply(...))` | DataFrame of *your* metrics | Custom metrics over the day — the workhorse |
+
+Materialising a full-day book at event granularity is large. If the output is a handful of metrics
+rather than the book itself, use `rebuilt_history_*` — it computes as it replays instead of
+building the frame and then reducing it.
+
+## Snapshots
+
+```python
+md.l2_snapshot(depth=3)
+
+df_l2 = md.rebuilt_book_L2(start_timestamp=open_dt,
+                           end_timestamp=open_dt + datetime.timedelta(hours=1),
+                           frequency=pd.Timedelta('600s'))
+
+df_l3 = md.rebuilt_book_L3(start_timestamp=open_dt,
+                           end_timestamp=open_dt + datetime.timedelta(seconds=60))
+```
+
+## Generators
+
+```python
+gen = md.snapshot_generator_L2(start_timestamp=open_dt, end_timestamp=close_dt,
+                               frequency=pd.Timedelta('1s'))
+
+for bid, ask in itertools.islice(gen, 2):
+    print(bid[:10], ask[:10])
+```
+
+Each yield is a pair of structured arrays with fields `level`, `price`, `size`, `num_orders`, plus
+a `.meta_data` mapping (`event_no`, `quote_no`, `timestamp`, `side`). Timestamps in `meta_data` are
+**integer nanoseconds**.
+
+Called with no frequency, the generator yields on every event, which lets you walk quotes and book
+state together:
+
+```python
+gen = md.snapshot_generator_L2()
+quotes = md.incremental_book_L3().itertuples()
+
+for quote, (bid, ask) in zip(quotes, gen):
+    ...
+```
+
+This zip is the general pattern for event-time features — trade-conditioned imbalance, queue
+position, lookback windows — where the metric needs both the event and the resulting book.
+
+Sub-sampling helpers from `bmll2.rebuilder` wrap a generator:
+
+```python
+from bmll2.rebuilder import (every_n_events, timestamp_sampler, date_range_sampler,
+                             date_range_sampler_on_the_fly, event_number_window,
+                             timestamp_window)
+
+df_every_5 = every_n_events(5)(md.snapshot_generator_L2())
+```
+
+`date_range_sampler_on_the_fly` is the minimal-memory variant — prefer it for full-day work.
+
+## `apply` and `rebuilt_history_*`
+
+The efficient route to custom metrics: `apply` bundles named operations, `rebuilt_history_*`
+replays the book once and evaluates all of them.
+
+```python
+from bmll2.rebuilder import apply, volume_imbalance, sma
+
+fn = apply(vol_imb=volume_imbalance(5),
+           moving_vol_imb=sma(volume_imbalance(5), 15))
+
+hist = md.rebuilt_history_L2(fn,
+                             start_timestamp=open_dt, end_timestamp=close_dt,
+                             frequency=pd.Timedelta('600s'))
+```
+
+Each keyword becomes a column.
+
+### Built-in operations
+
+| Function | Returns |
+|---|---|
+| `volume_imbalance(levels)` | Volume imbalance to depth `levels` |
+| `order_imbalance(levels)` | Order-count imbalance to depth `levels` |
+| `size_up_to_nth_level(size_type, levels)` | Cumulative volume / order count to level `n` for a side |
+| `liquidity_around_bbo(levels=, bps=)` | Liquidity within a band of the touch |
+| `sweep_to_fill(volume_to_fill, ...)` | Price or level required to fill a given volume |
+| `sma(func, window)` / `ema(func, window)` | Moving averages of another operation |
+| `returns(dtype)` | Decorator marking a custom function's return type |
+| `get_dataframe(events, *args, sort_by_price=)` | Snapshots as a DataFrame |
+| `nested_adapter(depth, display_implied_prices=)` | Changes the dtype of generated L2 snapshots |
+
+### Custom operations
+
+Any `(bid, ask) -> scalar` function works, decorated with `@returns` so `apply` knows the dtype:
+
+```python
+from bmll2.rebuilder import returns
+
+@returns(np.float64)
+def avg_bid_size(bid, ask):
+    return bid['size'].mean()
+
+@returns(np.int64)
+def bid_size(bid, ask):
+    return bid['size'].sum()
+
+fn = apply(avg_bid_size=avg_bid_size, bid_size=bid_size)
+df = md.rebuilt_history_L3(fn, start_timestamp=open_dt, end_timestamp=close_dt,
+                           frequency=pd.Timedelta('60s'))
+```
+
+The `@returns` dtype is not decoration — it is how the output column is allocated. Omitting it, or
+declaring `np.int64` for a function that returns a mean, silently truncates.
+
+`bid`/`ask` are the structured arrays described above; index by field name (`bid['size']`), not
+position.
+
+## Order tracing
+
+L3 exposes the full life of an order. **`original_order_id`** is the tracing key — `order_id`
+changes on modification, so grouping on it fragments the life of a single order:
+
+```python
+sec = Security.from_listing_id(listing_id, date)
+book = sec.market_data('L3').incremental_book_L3()
+
+freq = book.groupby('original_order_id').count()['event_no'].sort_values()
+oid = freq[freq >= 35].index[0]
+
+orders = book[book.original_order_id == oid].reset_index(drop=True)
+lifetime = orders.event_timestamp.max() - orders.event_timestamp.min()
+executed = orders.executed_size.sum()
+```
+
+Useful per-order fields: `event_timestamp`, `lob_action` (INSERT / AMEND / DELETE / EXECUTE),
+`size`, `old_size`, `price`, `price_level`, `executed_size`, `side`.
+
+`old_size - size` on an execution event gives the executed quantity for that event, which is how
+the event-time trade reconstruction above recovers trade sizes from the book.
+
+## Consolidated books
+
+Cross-venue books, two routes.
+
+**Data Feed (pre-computed, 10 levels).** Requires an entitlement and specific venue coverage:
+
+```python
+import pandas as pd
+from bmll import market_data
+
+df = market_data.instrument_cbbo(324347, '2022-05-23', level=1)
+# timestamp, ask_1_price, ask_1_size, ask_1_cum_size, bid_1_price, bid_1_size, bid_1_cum_size
+
+full = pd.concat(
+    (market_data.instrument_cbbo(324347, '2022-05-23', level).set_index('timestamp')
+     for level in range(1, 11)),
+    axis=1).reset_index()
+```
+
+One call per level — loop to assemble the book. Keyed by **`InstrumentId`**, not `ListingId`.
+`_cum_size` is cumulative size through that level.
+
+**This consolidation ignores market state.** Venues open and close at different times, so a naive
+consolidated book includes venues that are closed or in auction. Fetch per-venue states and filter:
+
+```python
+market_data.instrument_market_state(324347, '2022-05-23')
+# timestamp, market_state, market  — one row per venue state change
+```
+
+**Data Lab (build it yourself):**
+
+```python
+from bmll2 import (consolidate_book, consolidated_snapshot_generator_L2,
+                   consolidated_rebuilt_history_L2)
+
+consolidate_book(order_books, timestamp=...)
+```
+
+`consolidated_rebuilt_history_L2` takes the same `apply(...)` functions as the single-venue
+version, so custom cross-venue metrics reuse the operations above.

--- a/skills/bmll/references/other-datasets.md
+++ b/skills/bmll/references/other-datasets.md
@@ -1,0 +1,148 @@
+# Other Datasets
+
+FX, corporate actions, trading calendar, ETF reference data.
+
+## FX
+
+Daily ECB spot rates:
+
+```python
+from bmll2 import get_fx
+
+fx = get_fx('AUDGBP', from_date='2015-06-01', to_date='2026-03-26')
+```
+
+Returns a daily series indexed by `date`. One ticker per call — loop and `pd.concat(axis=1)` for a
+panel:
+
+```python
+rates = pd.concat([get_fx(t, from_date=f, to_date=t2) for t in ['AUDGBP','AUDEUR','GBPEUR']],
+                  axis=1)
+rates['GBPEUR_implied'] = rates['AUDEUR'] / rates['AUDGBP']
+```
+
+These are ECB reference rates — daily, not intraday. Converting an intraday notional with them
+introduces a same-day timing error. Trades Plus already carries `TradeNotionalEUR` /
+`TradeNotionalUSD` converted at publication date; prefer those when they exist.
+
+## Shares outstanding and free float
+
+```python
+from bmll2.corporate_actions import get_shares_outstanding, get_free_float
+
+get_free_float(['US0378331005', 'GB00BH4HKS39', 'KYG875721634'])
+get_shares_outstanding(['US0378331005', 'GB00BH4HKS39', 'KYG875721634'], date='2024-04-10')
+```
+
+Keyed by **ISIN**, not `ListingId`.
+
+`get_shares_outstanding` returns `effective_date`, `ISIN`, `issuer_name`, `security_description`,
+`event_type`, `late_flag`, `new_sos`, `old_sos`.
+`get_free_float` returns `old_free_float`, `new_free_float` (percentages) and
+`old_free_float_shares`, `new_free_float_shares`.
+
+Field meanings that matter:
+
+- `effective_date` — the day the value is valid **from**. Rows are events, not a daily panel; a
+  point-in-time join needs an as-of merge, not an equality join on date.
+- `late_flag` — the value was amended or updated *after* its effective date. A backtest that treats
+  `late_flag=True` rows as known on `effective_date` has lookahead.
+- `event_type` — what triggered the change; `SHOCH` (shares outstanding change) is the common one.
+
+Shares outstanding values are **corporate-action adjusted**.
+
+**Chunk ISIN lists to ~5000** — that is the current per-request ceiling:
+
+```python
+sos = pd.concat([get_shares_outstanding(isins[5000*i:5000*(i+1)], date='2024-04-12')
+                 for i in range(len(isins)//5000 + 1)])
+```
+
+### Market cap
+
+Combine with a price from the Data Feed:
+
+```python
+ref = bmll.reference.query(Index='buk100p')
+sos = get_shares_outstanding(ref.ISIN.tolist(), date='2024-04-10')
+
+ts = bmll.time_series.query(object_ids=ref.ListingId.tolist(),
+                            start_date='2024-04-10', end_date='2024-04-10',
+                            metric=['Close', 'ClosingAuctionPrice'])
+
+df = (ref[['ISIN','ListingId','CurrencyCode','DisplayName']]
+      .merge(ts, left_on='ListingId', right_on='ObjectId')
+      .merge(sos, on='ISIN'))
+
+df['MarketCap'] = df['new_sos'] * df['ClosingAuctionPrice|Executed'] / 1e11   # GBp -> £bn
+```
+
+The `1e11` divisor is `1e9` (billions) × `100` (GBp→GBP). Currency scaling is per-listing — a
+mixed-currency universe needs `MinorCurrencyFactor` or an explicit per-currency factor, not one
+constant.
+
+### Free-float market cap and index construction
+
+Free float is the better proxy for tradeable market cap:
+
+```python
+ff = pd.concat([get_free_float(isins[5000*i:5000*(i+1)], date='2024-04-12')
+                for i in range(n//5000 + 1)])
+
+ffdf = sos.merge(ff[['ISIN','new_free_float']], on='ISIN', how='left')
+ffdf['new_free_float'] = ffdf['new_free_float'].fillna(100)     # no data -> assume full float
+
+df['FreeFloatCap'] = df['new_free_float'] / 100 * df['new_sos'] * df['Close|Midpoint'] / 1e9
+index = (df[df.InstrumentType == 'Equity'].drop_duplicates()
+           .sort_values('FreeFloatCap', ascending=False).head(1000))
+```
+
+Use `new_sos` from `get_shares_outstanding` for the share count, **not** the
+`new_free_float_shares` field — only the former is corporate-action adjusted.
+
+## Trading calendar
+
+```python
+from bmll2 import Calendar
+
+cal = Calendar(mic, cen_code, date)
+cal.trading_days(...)
+cal.utc_to_local(...)
+
+sec.calendar          # also available on a Security
+```
+
+Covers all equities and *some* futures contracts. `cen_code` is the calendar code — a
+market/segment key (`SYSA` = ASX cash equities, `PASA` = Euronext Paris continuous, `FRSA` = Xetra
+DAX, `HKSA` = HKEX cash equities). One MIC can map to several codes (Aquis Exchange Europe `AQEU`
+carries a separate code per national segment), and one code can serve several MICs — so the
+MIC↔code relationship is many-to-many. The tutorial ships the full mapping table.
+
+For intraday session boundaries on a specific day, deriving them from `market_info()` is usually
+more reliable than the calendar, because it reflects what actually happened including auction
+extensions — see [security-api.md](security-api.md#deriving-the-trading-window).
+
+## ETF reference data
+
+Ultumus fund data, joined on ISIN. See [reference-data.md](reference-data.md#etf-reference-data)
+for the query surface.
+
+Issuer market share, combining ETF reference data with classified trades:
+
+```python
+ref = pd.concat([
+    bmll.reference.query(OPOL=['XSWX'], InstrumentType='Funds', IsAlive=True),
+    bmll.reference.query(MIC=['TREU','TWEM','BMTF','BTFE'], InstrumentType='Funds', IsAlive=True),
+])
+ref_etf = bmll.reference.etf_data(ISIN=ref['ISIN'].unique().tolist())
+
+ts = bmll.time_series.classified_trades(object_ids=ref['ListingId'].tolist(),
+                                        start_date='2025-09-01', end_date='2025-09-30')
+
+merged = ts.merge(ref[['ListingId','ISIN']], on='ListingId').merge(ref_etf, on='ISIN')
+share = merged.groupby('UmbrellaName')['Notional'].sum().reset_index()
+share['percent'] = share['Notional'] / share['Notional'].sum()
+```
+
+`UmbrellaName` is the issuer — the grouping key for market share. ETFs listed on multiple venues
+appear once per listing, so aggregate to ISIN before counting funds (as opposed to notional).

--- a/skills/bmll/references/reference-data.md
+++ b/skills/bmll/references/reference-data.md
@@ -1,0 +1,185 @@
+# Reference Data
+
+Finding markets, instruments and listings. Every market-data call needs an identifier that comes
+from here, so this is almost always the first query.
+
+```python
+from bmll2 import reference, get_market_data, get_market_data_range
+```
+
+`bmll.reference` and `bmll2.reference` are the same service.
+
+## Markets
+
+```python
+reference.available_markets()
+```
+
+Returns every market in the Data Lab with `MarketId`, `CountryCode`, `Description`, `DisplayName`,
+`IsAlive`, `MIC`, `OperatingMIC`, `Schema` (`Equity`/`Future`/`Option`) and `StartDate` — the last
+being the practical answer to "how far back does this venue go".
+
+Use **`MIC`**, not `MarketId`, everywhere else. BMLL maps a venue's lit-book trading mechanism to
+one MIC rather than splitting by segment, so Euronext Growth (`ALXP`) reports under the main market
+`XPAR`. This is deliberate — it makes total-venue comparison possible — but it means a segment-level
+question cannot be answered by MIC alone; use `SegmentCode`.
+
+Consolidated feeds have their own MICs (`@SIP` for the US).
+
+## Listings and instruments
+
+Two routes, with different performance profiles:
+
+| Route | Best for |
+|---|---|
+| `reference.query(...)` | Granular search on identifier fields |
+| `get_market_data(mic, date, 'reference')` | An entire market on one date — markedly faster |
+
+```python
+cols = ['Date', 'InstrumentId', 'ListingId', 'Ticker', 'Description', 'ISIN']
+reference.query(MIC='AQXE')[cols]
+
+reference.query(ISIN='GB0007980591')[cols + ['MIC', 'OPOL', 'CurrencyCode']]
+
+get_market_data('XNAS', '2025-10-13', 'reference')
+```
+
+### Identifier reliability
+
+Most consistently populated: **`MIC`, `CurrencyCode`, `ISIN`, `OPOL`**. Some venues genuinely lack
+ISINs (the STAR segment of Shanghai) — use other identifiers there rather than assuming a data gap.
+
+`Ticker` is the exchange-provided ticker: repeated across venues, reused over time, and absent
+entirely on some venues (Tradeweb). `FIGI` and `SegmentCode` are populated for liquid instruments
+but not guaranteed. Resolving a universe on `Ticker` alone will silently mismatch.
+
+### Dates
+
+With no date, `reference.query` returns the **most recent** snapshot — not history. That is the
+fast path. Passing `start_date`/`end_date` returns point-in-time rows and is slower.
+
+```python
+reference.query(Ticker='PPB', MIC='XLON', start_date='2019-05-26', end_date='2019-05-29')
+# 2019-05-28: PPB -> FLTR, same ISIN — a ticker change mid-window
+```
+
+`IsAlive` tests whether a listing was available on the queried date.
+
+### `object_type`
+
+`reference.query(object_type=...)` changes what a row represents:
+
+| `object_type` | Returns |
+|---|---|
+| `'Listing'` (default) | One row per listing |
+| `'Instrument'` | All sibling listings sharing the `InstrumentId` |
+| `'Index'` | Index definitions |
+| `'IndexMarket'` | An index's projection onto a specific venue |
+
+```python
+# Vodafone's LSE listing
+reference.query(Ticker='VOD', MIC='XLON', object_type='Listing')
+
+# ...and everywhere it trades (BATE, CHIX, TRQX, AQXE, BOTC, SGMX, XEQT, @ALP)
+reference.query(Ticker='VOD', MIC='XLON', object_type='Instrument')
+```
+
+`object_type='Instrument'` with a `MIC` constraint reads as "find the instrument *via* this
+listing, then give me all its listings" — the `MIC` selects the anchor, it does not filter the
+result.
+
+## Indices
+
+Constituent data needs an entitlement separate from market data. BMLL carries CBOE indices plus
+synthetic "market-index" constituents that split a market by asset class.
+
+```python
+reference.query(object_type='Index')                      # available indices
+
+# Constituents (primary listings only, by default)
+reference.query(object_type='Listing', Index='buk100p', start_date='2022-12-01')
+
+# Constituents plus all their sibling listings across venues
+reference.query(object_type='Instrument', Index='buk100p', start_date='2022-12-01')
+```
+
+With no date the query defaults to **yesterday**. Index membership is point-in-time, so historical
+composition needs an explicit `start_date`/`end_date` range — reconstructing history from a single
+recent snapshot bakes in survivorship bias.
+
+Projecting an index onto one venue:
+
+```python
+df = reference.query(object_type='Instrument', Index='buk100p', start_date='2022-12-01')
+df.loc[df['MIC'] == 'TRQX'].query('IsAlive')
+```
+
+`IndexMarket` objects are the identifiers used by cross-venue analytics (e.g. TimeAtEBBO for the
+UK 100 across markets):
+
+```python
+reference.query(object_type='IndexMarket', Index='bde30p')
+reference.query(object_type='IndexMarket', MIC='TRQX')
+```
+
+## Futures
+
+Futures use a different reference schema — pass `schema='Future'` or the fields below do not exist:
+
+```python
+reference.query(MIC='IFLL', ProductCode='Z', IsAlive=True, schema='Future')[
+    ['ListingId', 'InstrumentId', 'Ticker', 'ContractType', 'ProductCode',
+     'MaturityMonthYear', 'DisplayName']
+]
+```
+
+`ContractType` distinguishes `Outright` from `Spread` (and TIC) contracts. Volume analysis that
+does not filter on it double-counts, since a spread's legs also print.
+
+For futures, `InstrumentId` groups the whole product (all maturities); `ListingId` is the
+individual contract.
+
+## US equity options (OPRA)
+
+Options are **not** supported by `Security`/`NormalisedSecurity` — use `get_market_data*` only.
+A day of raw OPRA is ~4TB unconflated; BMLL serves a 1-second conflated feed with `trades`,
+`nbbo`, `reference` and `statistics` tables.
+
+```python
+get_market_data('OPRA', '2024-10-11', 'reference', line_number=1)
+```
+
+Reference rows carry `UnderlyingTicker`, `ExpiryDate`, `OptionType`, `StrikePrice`,
+`RegularTradingHours`, `LineNumber`, `UnderlyingPrice`, `OpenInterest`, `DailyVolume`. Filtering by
+`line_number` (the OPRA multicast line) is the cheap way to cut the universe when you know it.
+
+Because a large number of contracts is created daily, prefer `get_market_data_range` with Spark for
+anything beyond a single day.
+
+## ETF reference data
+
+Ultumus fund reference data, joined on ISIN:
+
+```python
+reference.etf_data()                                              # full dataset
+reference.etf_data(UCITS='True')
+reference.etf_data(UnderlyingAssetClass='Fixed Income', ISIN='HK0000921830')
+reference.etf_data(ISIN=ref['ISIN'].unique().tolist())
+```
+
+Note `UCITS='True'` is a **string**. Fields include `FullName`, `UmbrellaName`
+(the issuer — the natural grouping for market-share work), `UmbrellaFullName`,
+`UnderlyingAssetClass`.
+
+See [other-datasets.md](other-datasets.md) for a worked issuer market-share example.
+
+## Availability
+
+```python
+reference.availability(mics, date=...)          # is there data for these MICs on this date
+```
+
+Check this before concluding that an empty market-data frame means no activity.
+
+`available_listings(listing_ids, start_date, ...)` gives the dates with market data for specific
+listings and feeds — the right tool when a per-listing backfill has gaps.

--- a/skills/bmll/references/retail.md
+++ b/skills/bmll/references/retail.md
@@ -1,0 +1,138 @@
+# Retail Trades
+
+Tutorial: `tutorials/notebooks/retail.html` · Schema: `data_ref/retail.html`
+
+Retail flow is executed through many different mechanisms, on- and off-exchange, and few of them
+are labelled as retail by the venue. BMLL identifies retail trades from L3 data — using explicit
+flags where exchanges provide them and **inference where they do not** — and exposes the result as
+a `RetailTrades` metric plus per-trade fields.
+
+The inference/flag split is the thing to keep in view: retail volume is measured with different
+confidence in different places, so cross-venue and cross-region retail comparisons are partly
+comparing measurement methods.
+
+## Mechanisms
+
+| Region | Mechanism | Shape |
+|---|---|---|
+| EU | SIX EBBO | Competing market makers incentivised to improve on EBBO, multiple venues |
+| EU | Euronext Best of Book | Competing market makers improving on primary BBO, single venue |
+| EU | Retail Service Providers (LSEG) | Market makers on an RFQ basis, off-book |
+| EU | Equiduct Apex | Reflects a consolidated BBO, multiple venues |
+| EU | Turquoise Retail Max | Reflects primary midpoint via an auction mechanism, single venue |
+| EU | Tradegate, Lang & Schwarz, Gettex, Quotrix | Single market maker; XETR as reference (Tradegate uses a dynamic reference market) |
+| US | Wholesaler / PFOF | Competing market makers offering price improvement on NBBO, multiple venues |
+
+## Indicators
+
+How each mechanism is identified in the data:
+
+| Mechanism | Indicator | Notes |
+|---|---|---|
+| Euronext Best of Book | `original_trade_type` is `20` | |
+| SIX EBBO | `execution_venue` is `XSEB` | Excludes retail that executes on Swiss-At-Mid (`XSWM`) or the SIX CLOB (`XSWX`) before resulting in an `XSEB` execution venue |
+| Equiduct Apex | `trade_type` in `B`,`S` (VBBO) or `b`,`s` (ALP order) | |
+| Retail Service Providers (LSEG) | Off Book On Exchange, during continuous trading, below Standard Market Size (€10,000) | **Inferred** |
+| Xetra | `trade_condition` is `743` | Retail Execution Service went live **2024-05-20** — the flag does not exist before |
+| CBOE EU | `bats_trade_timing_indicator` is `G` (UK entity) or `K` (EU entity) | Available from **2025-09-08** |
+| BME | L2 feed: `buy_trade_type`/`sell_trade_type` is `8` or `9`; L3 feed: `retail_flag` is `True` | |
+| Turquoise Retail Max | `execution_venue` is `TRQA`/`TQEA` | **Not currently in the `RetailTrades` metric** — not a sufficient indicator |
+| Tradegate, Lang & Schwarz, Gettex, Quotrix | Entirely retail; no indicator needed | **Not available currently**, to be added |
+| US SIP | Odd lot (`original_trade_type` contains `I`) **and** price inside the NBBO but not at the midpoint **and** sub-decimal pricing (>2 dp) | **Inferred.** Excludes PFOF trades where wholesalers internally cross aggregated retail against a counterparty. Daily TRF data on the SIP gives no transparency on the underlying off-exchange venue |
+
+Three of these materially bound what the metric can tell you, and none is visible in the output:
+
+- **Turquoise Retail Max and the German single-market-maker venues are excluded**, so European
+  retail totals are an undercount of known size but unknown magnitude.
+- **The Xetra and CBOE EU flags start mid-history** (2024-05-20, 2025-09-08). A retail time series
+  crossing those dates has a level shift that is pure instrumentation.
+- **US SIP retail is inferred from odd-lot + inside-NBBO + sub-penny pricing** and misses
+  internalised PFOF. It is a proxy, not a measurement.
+
+State the relevant one when reporting retail figures — a reader who assumes a clean measurement
+will over-read a trend that is really a flag going live.
+
+## Accessing retail
+
+Three routes, at different grains.
+
+### Trades Plus — per trade
+
+Two fields:
+
+- `ParticipantType` — exchange-specific values
+- `BMLLParticipantType` — normalised: `RETAIL`, `INSTITUTIONAL`, `MARKET_MAKER`, `BROKER_DEALER`,
+  `UNKNOWN`
+
+```python
+from bmll2 import get_market_data
+
+(get_market_data("XPAR", "2025-10-16", "trades-plus")
+ .query("BMLLParticipantType == 'RETAIL'")
+ [['Ticker', 'TradeTimestamp', 'Price', 'Size', 'ParticipantType', 'BMLLParticipantType']])
+```
+
+Use `BMLLParticipantType` for cross-venue work. Report the `UNKNOWN` share rather than dropping it
+— it is large, and dropping it silently converts "unclassified" into "not retail".
+
+See [trades-plus.md](trades-plus.md).
+
+### Time series — daily aggregate
+
+The `RetailTrades` metric, keyed on the linked `ListingId` for the mechanism's venue:
+
+```python
+from bmll import reference, time_series
+
+# Europe: query the venue where the mechanism runs (XPAR for Euronext Best of Book)
+ref_eu = reference.query(Ticker='MC', OPOL='XPAR', object_type='Instrument')
+ts_eu = time_series.query(
+    object_ids=ref_eu[ref_eu.MIC.isin(['XPAR', 'XEQT'])].ListingId.unique(),
+    metric=['RetailTrades'], frequency='D',
+    start_date='2024-01-01', end_date='2024-05-15')
+
+# US: retail is measured on the consolidated tape, so use the @SIP listing
+ref_us = reference.query(Ticker='TSLA', OPOL='XNAS', object_type='Instrument')
+ts_us = time_series.query(
+    object_ids=ref_us[ref_us.MIC == '@SIP'].ListingId.unique(),
+    metric=['RetailTrades'], frequency='D',
+    start_date='2024-01-01', end_date='2024-05-15')
+```
+
+Returns `RetailTrades|Count`, `|Shares`, `|NotionalLocal`, `|NotionalEUR`, `|NotionalUSD`.
+
+**US retail resolves against the `@SIP` listing, not the primary exchange listing.** Querying the
+`XNAS` listing for US retail returns nothing — the mechanism is measured on the consolidated tape.
+
+`object_type='Instrument'` then filtering by MIC is the idiom: it finds every sibling listing, from
+which you select the venue where the mechanism actually runs.
+
+### Security object — per trade, raw
+
+`all_trades()` exposes a `retail` boolean, but **only if `retail` is in the requested columns**:
+
+```python
+from bmll2 import NormalisedSecurity
+
+sec = NormalisedSecurity.from_listing_id(121317, "2025-10-16")
+COLS = ['trade_id', 'trade_timestamp', 'publication_timestamp', 'aggressor_side',
+        'price', 'execution_size', 'market_state', 'sequence_no', 'currency',
+        'printable', 'bmll_trade_type', 'trade_action', 'execution_venue', 'retail']
+
+sec.market_data().all_trades(columns=COLS).query("retail")
+```
+
+Note what the LSE result shows: retail prints come back as `bmll_trade_type == 'OTC'` with
+`market_state == 'NOT_APPLICABLE'` and `aggressor_side == 'UNKNOWN'` — they are RSP off-book
+prints. Retail flow is not a subset of lit continuous trading, so a filter on `LIT` excludes most
+of it.
+
+## Participant type sources
+
+`data_ref/retail.html` documents, per MIC, the source column and value behind each
+`ParticipantType`, plus the contra-type name. Venue-native values include `THIRD_PARTIES`,
+`OWN_ACCOUNT`, `SPECIALIST` (XMAD) and `CUSTODIAN_PARTICIPANT`, `PROPRIETARY`,
+`NON_CP_NON_PROPRIETARY` (XNSE) — see [trades-plus.md](trades-plus.md).
+
+Member attribution (broker IDs) is documented there too, by region — see
+[venues.md](venues.md#member-attribution).

--- a/skills/bmll/references/schemas.md
+++ b/skills/bmll/references/schemas.md
@@ -1,0 +1,256 @@
+# Data Schemas
+
+`https://lab.bmlltech.com/docs/contents/data_ref/start.html`
+
+BMLL publishes market data at three levels of processing. Choosing the wrong one is the source of
+most "why doesn't this field exist" and "why don't these venues agree" confusion.
+
+| Layer | What it is | Access |
+|---|---|---|
+| **Raw / per-venue** | The exchange's own fields, as published, per feed generation | `Security` |
+| **Harmonised** | Common column names and types across venues; venue semantics preserved | `Security` |
+| **Normalised** | Common *values* too — market states, trade types, sides, LOB actions mapped to one vocabulary | `NormalisedSecurity` |
+
+Normalised is the default for cross-venue work. Raw is for auditing BMLL's mapping or reading a
+venue-specific flag that normalisation deliberately discards.
+
+## Normalised tables
+
+| Table | Access function | Contents |
+|---|---|---|
+| Limit Order Updates | `incremental_book_L2()`, `incremental_book_L3()` | Instructions changing the book. Sufficient to reconstruct L2/L3 |
+| Market State | `market_info()` | Market phases, where the exchange provides them |
+| Snapshots | `best_bid_offer()`, `rebuilt_book_L2()`, `rebuilt_book_L3()` | Book state for every event that changed it |
+| Trades | `trades()`, `all_trades()` | Trades and executions |
+| Auction | `auction_data()` | Auction imbalance / indicative price and quantity |
+| Exchange Metrics | `exchange_metrics()` | Exchange-supplied metrics with a fixed schema across every venue |
+
+Tables not listed here have the same shape as the Harmonised data.
+
+### Limit Order Updates — the event model
+
+A row is one **instruction** to change the book: add, remove or modify an order (L3) or a level
+(L2). `quote_no` numbers rows sequentially from 1 and uniquely identifies one.
+
+`event_no` is different and it is the one that matters for analysis. An *event* is a valid book
+state that could in principle be traded against. Many instructions can belong to one event, so
+`event_no` repeats. **`end_of_event` is `True` only on the last row of an event** — filter on it
+when you need genuine book states rather than intermediate ones, or you will analyse states that
+never existed for anyone to trade against.
+
+Key L3 fields:
+
+| Field | Notes |
+|---|---|
+| `event_no`, `quote_no`, `end_of_event` | Event model above |
+| `side`, `price`, `size`, `order_id` | State **after** the instruction. For `REMOVE`/`UNKNOWN`: price `NaN`, size `0`, order_id `''` |
+| `old_price`, `old_size`, `old_order_id` | State **before** the instruction |
+| `lob_action` | `INSERT` / `UPDATE` / `REMOVE` / `SKIP` / `UNKNOWN` |
+| `order_executed` | `True` when the instruction was an execution |
+| `execution_price`, `execution_size` | Populated on executions; `execution_size == old_size - size` |
+| `price_level`, `old_price_level` | Level after/before (1 = best) |
+| `original_order_id` | ID originally assigned — **the key for tracing an order's life** |
+| `trade_id` | Exchange trade ID, else a synthetic ID prefixed `BMLL-` |
+| `size_ahead`, `orders_ahead` | Queue position ahead of this order on INSERT/UPDATE |
+| `modify_count` | Times the order has been modified |
+| `best_{bid,ask}_{price,size,num_orders}` | Touch at the time of the event |
+| `total_{bid,ask}_{size,orders}` | Whole-book totals after this row |
+| `level_size_total`, `level_num_orders_total` | At this price level after this row |
+| `is_new_best_price`, `is_new_best_size` | Whether this instruction moved the touch |
+| `market_state`, `printable` | Normalised state; printability |
+| `is_implied`, `level_size_implied`, `level_num_orders_implied` | Implied book (futures). `False`/absent where no implied book exists |
+
+L2 updates carry the level-oriented equivalents (`num_orders`, `old_num_orders`, `size_implied`,
+`truncate_excess_levels`, `msg_original_type`, `price_lvl_num_orders`).
+
+`truncate_excess_levels` distinguishes a real cancellation from bookkeeping when a level falls out
+of the feed's depth window — counting those as cancellations overstates cancel rates on depth-
+limited L2 feeds.
+
+## Normalised value vocabularies
+
+These are the values `NormalisedSecurity` guarantees across every venue. Access them as objects
+from `bmll2.normalised` (`MARKET_STATES`, `SIDES`, `BMLL_TRADE_TYPES`, `TRADE_ACTIONS`,
+`L2_LOB_ACTIONS`, `L3_LOB_ACTIONS`) rather than as string literals.
+
+### Market state
+
+| Value | Meaning |
+|---|---|
+| `PRE_OPEN` | Before continuous trading, generally before the opening auction |
+| `OPENING_AUCTION` | Includes order entry **and** uncrossing |
+| `CONTINUOUS_TRADING` | Main continuous session |
+| `CONTINUOUS_TRADING_PRIMARY_CLOSED` | Secondary venue trading while the primary is closed (MTF/ATS) |
+| `INTRADAY_AUCTION` | Scheduled auction interrupting continuous trading |
+| `UNSCHEDULED_AUCTION` | Unscheduled auction interrupting continuous trading |
+| `AUCTION_ON_DEMAND` | Auction running *alongside* continuous trading |
+| `CLOSING_AUCTION` | Includes order entry and uncrossing |
+| `POST_TRADE` | After continuous trading, generally after the primary closing auction. Includes trade-at-last — distinguish those via the `CLOSING_PRICE` trade type |
+| `CONDITIONAL` | Uncrossing for specific mechanisms (e.g. Turquoise Plato Uncross) |
+| `HALTED` | Unscheduled halt, e.g. circuit breaker |
+| `CLOSED` | No trading activity possible |
+| `NOT_APPLICABLE` | Venues without market phases — trade reporting facilities |
+| `UNKNOWN` | Could not be resolved |
+
+Auction states **span order entry and uncrossing**, so filtering `market_state == CLOSING_AUCTION`
+gives the whole call phase, not just the uncross. Isolate the uncross with
+`bmll_trade_type == UNCROSSING`.
+
+`NOT_APPLICABLE` is not missing data — it is the correct state for a TRF/APA.
+
+### Side
+
+`ASK`, `BID`, `UNKNOWN` (not provided and not inferable).
+
+### BMLL trade type
+
+| Value | Meaning |
+|---|---|
+| `LIT` | Match on a lit book with full pre-trade transparency. **Includes hidden-order executions that cannot be distinguished from lit ones**, such as icebergs |
+| `DARK` | Match on a book with limited or waived pre-trade transparency (e.g. mid-price book) |
+| `UNCROSSING` | Paired quantity matched at the end of an auction phase |
+| `CLOSING_PRICE` | Executed at the closing price from a Market-on-Close order |
+| `BENCHMARK_PRICE` | Executed at a public reference price — VWAP, TWAP, EBBO, PBBO, auction reference; MiFID II `BENC` |
+| `REQUEST_FOR_QUOTE` | Resulting from an RFQ |
+| `OTC` | Bilateral, reported to a trade reporting facility |
+| `SPECIAL_PRICE` | Negotiated, `TNCP`, dividends, technical trades |
+| `EXCHANGE_FOR_RELATED_POSITION` | Futures position exchanged for related positions |
+| `UNKNOWN` | Unresolved |
+
+That `LIT` absorbs indistinguishable iceberg executions is a real limit on "visible liquidity"
+analysis — the lit bucket is an upper bound, not a clean measure.
+
+### Trade action
+
+`NEW` (the majority), `AMEND`, `CANCEL`, `UNKNOWN`. Amendments and cancellations are why `Size`
+can be negative and why `Printable` exists.
+
+### LOB actions
+
+**L3:** `INSERT`, `UPDATE`, `REMOVE` (cancellation *or* execution — check `order_executed` to tell
+them apart), `SKIP`, `UNKNOWN`.
+
+**L2:** `NEW`, `UPDATE`, `DELETE`, `SKIP`.
+
+`SKIP` is reserved for instructions derived from exchange data that do **not** change book state
+but may still carry relevant data. In L3, `quote_no` increments on a SKIP but `event_no` does not.
+Counting `quote_no` as an activity measure therefore counts non-events.
+
+## Normalisation process
+
+`https://lab.bmlltech.com/docs/contents/data_ref/normalisation_process.html`
+
+### Icebergs
+
+Exchanges represent icebergs in three ways: a distinct non-displayed trade message; an *over-fill*
+(execution larger than the visible order, sometimes with a size-remaining field); or nothing at all.
+
+BMLL matches the exchange's representation rather than imposing one:
+
+- On over-fills, `execution_size` is the **full** execution even when larger than the visible
+  order; `revealed_qty` shows the liquidity that became visible.
+- Orders are synthetically re-added when further hidden liquidity remains.
+- Where no order information exists, the execution appears in the Trades table only — it cannot be
+  attached to a visible quantity.
+
+Consequently iceberg detectability varies by venue, and each venue's dataset page documents its
+representation. Cross-venue hidden-liquidity comparisons are comparing different observability, not
+different behaviour.
+
+### Auctions
+
+Venues differ in what they publish — full call-phase order book, indicative price/quantity, or
+both. These are not mutually exclusive, and the venue page states which apply.
+
+### Region-specific trade condition mapping
+
+**US** (`original_trade_type` contains):
+
+| Code | Description | BMLL trade type |
+|---|---|---|
+| `7` | Qualified Contingent Trade | `SPECIAL_PRICE` |
+| `4` | Derivatively Priced | `SPECIAL_PRICE` |
+| `R` | Seller's Option | `SPECIAL_PRICE` |
+| `C` | Cash | `SPECIAL_PRICE` |
+| `Z` | Sold, Out of Sequence | `SPECIAL_PRICE` |
+| `N` | Next Day Trade | `SPECIAL_PRICE` |
+| `B` | Bunched Trades | `SPECIAL_PRICE` |
+| `W` | Average Price | `BENCHMARK_PRICE` |
+| `P` | Prior Reference Price | `BENCHMARK_PRICE` |
+
+**Canada** maps by cross type, with columns for whether the cross updates the BBO, is subject to
+interference, and sets the last trade.
+
+**Europe** maps from MMT fields. The docs carry the full MMT→BMLL trade-type table plus a
+`market_mechanism`/`trading_mode`/`execution_venue` combination rule.
+
+### LIS thresholds
+
+Above/below Large-In-Scale splits in the classified-trade taxonomy depend on a LIS value. BMLL
+documents, per venue operator, the primary and secondary LIS source (a 25-row table keyed by
+reporting venue MICs). LIS is also available per security as
+`exchange_metadata.lis_local`.
+
+Because LIS is sourced per venue operator, above/below-LIS splits are only comparable across venues
+to the extent their LIS sources agree — a caveat worth stating when reporting the split.
+
+## MMT
+
+`https://lab.bmlltech.com/docs/contents/data_ref/mmt.html`
+
+Market Model Typology flags, carried on European trades. BMLL uses the **efficient encoding**
+(single characters), not the raw exchange strings.
+
+**Three versions coexist: v3.04, v4.1 and v5.0**, and the level semantics change between them.
+v4.1 splits several v3.04 levels into pairs (3.1 gains 3.13 RFMD Give-up; 3.2 gains 3.10 waiver
+size/scale; 3.5 gains 3.11 PORT and 3.12 CONT; 4.1 gains 4.3 ILQD and 4.4 SIZE; 5 becomes 5.1/5.2/
+5.3), and v5.0 adds 3.14 CLSE and renames level 3.3 to Agency Cross Trade Indicator. Decoding a
+long history with one version's table mislabels the other periods.
+
+Level 1 — Market Mechanism (v3.04):
+
+| Value | Meaning |
+|---|---|
+| `1` | Central Limit Order Book |
+| `2` | Quote Driven Market |
+| `3` | Dark Order Book |
+| `4` | Off Book |
+| `5` | Periodic Auction |
+| `6` | Request For Quotes |
+| `7` | Any Other, Including Hybrid |
+
+Level 2 — Trading Mode (v3.04):
+
+| Value | Meaning |
+|---|---|
+| `1` | Undefined Auction |
+| `2` | Continuous Trading |
+| `3` | At Market Close Trading |
+| `4` | Out Of Main Session |
+| `5` | Trade Reporting (On Exchange) |
+| `6` | Trade Reporting (Off Exchange) |
+| `7` | Trade Reporting (Systematic Internaliser) |
+| `O` | Scheduled Opening Auction |
+| `K` | Scheduled Closing Auction |
+| `I` | Scheduled Intraday Auction |
+| `U` | Unscheduled Auction |
+
+Remaining levels (3.1–3.9, 4.1–4.2, 5) are in the docs and on `https://www.fixtrading.org/mmt/`.
+In Trades Plus these are the `MarketMechanism`, `TradingMode`, `TransactionCategory`,
+`NegotiatedTrade`, `CrossingTrade`, `ModificationIndicator`, `BenchmarkIndicator`,
+`SpecialDividendIndicator`, `OffBookAutomatedIndicator`, `PriceFormation`, `AlgorithmicTrade`,
+`PublicationMode`, `DeferralType` and `DuplicativeIndicator` columns.
+
+## Other schema pages
+
+| Page | Contents |
+|---|---|
+| `data_ref/reference_data.html` | Reference-data schema — the identifier model behind `reference.query` |
+| `data_ref/l2_schema.html` | Equity, OPRA and futures market-data schemas |
+| `data_ref/harmonised_schema.html` | Harmonised tables, trade source / BMLL trade type / modification indicator vocabularies, SI quote, manual orders, exchange-metrics enum reference (~100 labels) |
+| `data_ref/analytics.html` | Trades Plus, daily classified trades, daily analytics — see [trades-plus.md](trades-plus.md) |
+| `data_ref/metadata.html` | Exchange and third-party metadata |
+| `data_ref/calendar.html` | Financial calendar schema |
+| `data_ref/shares_outstanding.html` | Shares outstanding / free float schema |
+| `data_ref/retail.html` | Retail mechanisms and indicators — see [retail.md](retail.md) |
+| `data_ref/datasets/<Venue>.html` | Per-venue detail — see [venues.md](venues.md) |

--- a/skills/bmll/references/security-api.md
+++ b/skills/bmll/references/security-api.md
@@ -1,0 +1,186 @@
+# `Security` and `NormalisedSecurity`
+
+Per-listing access: raw venue data, normalised data, and order-book replay. Equities and futures
+only — **options are not supported** (use `get_market_data*`).
+
+```python
+from bmll2 import Security, NormalisedSecurity, reference
+from bmll2.normalised import (MARKET_STATES, L2_LOB_ACTIONS, L3_LOB_ACTIONS,
+                              BMLL_TRADE_TYPES, SIDES, TRADE_ACTIONS)
+```
+
+## Which class
+
+| | `Security` | `NormalisedSecurity` |
+|---|---|---|
+| Fields | Venue-native flags, exactly as the exchange publishes them | Normalised across all venues |
+| Use when | You need a venue-specific flag, or are auditing BMLL's normalisation | Comparing behaviour across venues or securities — the default |
+| Class hierarchy | base | inherits `Security`; same interface, normalised `market_data` tables |
+
+`NormalisedSecurity` is the right default. Cross-venue analysis on raw venue flags means writing
+per-venue conditionals, which is the work the normalisation already did.
+
+```python
+sec = NormalisedSecurity.from_listing_id(listing_id=121317, date='2022-04-21')
+# -> LSEEquity(listing_id=121317, date='2022-04-21')
+```
+
+The concrete class depends on venue and asset type. Dates are ISO strings or `datetime.date`.
+
+## Metadata
+
+Attributes are tab-completable and return `None` when unavailable:
+
+```python
+sec.currency            # 'GBp'
+sec.tick_size_rule      # [[0.0001, 0.0001], [0.1, 0.0001], ..., [50000, 10]]
+sec.calendar            # see other-datasets.md
+sec.exchange_metadata   # named tuple of exchange-provided metadata
+```
+
+`exchange_metadata` carries venue-specific fields — for the LSE: `lis_threshold`, `segment_mic`,
+`lot_size`, `allowed_book_types`, `first_trading_date`, `average_daily_turnover`, circuit-breaker
+tolerances. Attributes appear only when meaningful (no ISIN attribute if no ISIN exists), so use
+`getattr` rather than assuming presence.
+
+`lis_local` from `exchange_metadata` is the Large-In-Scale threshold needed for trade
+classification.
+
+## Market data
+
+```python
+md = sec.market_data(feed='L3')      # 'L2' = aggregated per price level, 'L3' = order-by-order
+```
+
+Most methods accept `start_timestamp`, `end_timestamp` and `columns`; passing them pushes the
+filter down and is materially faster than slicing afterwards.
+
+### Tables
+
+| Method | Contents |
+|---|---|
+| `all_trades()` | **All printable trades** from every source (book executions + trades table) |
+| `trades()` | Trades *not* covered by book executions — off-book, reported |
+| `incremental_book_L3()` | Order-by-order LOB updates |
+| `incremental_book_L2()` | Per-price-level LOB updates (MBP venues) |
+| `best_bid_offer()` | L1 touch with `market_state` |
+| `best_bid_offer_ct()` | `best_bid_offer` filtered to continuous trading |
+| `midpoint()` | L1 midpoint with `market_state` |
+| `l2_snapshot(depth=...)` | Rebuilt book, default 5 levels |
+| `auction_data()` | Auction imbalance / indicative price and quantity |
+| `market_info()` | Market phases (state intervals) for the day |
+| `exchange_metrics()` | Exchange-published statistics — settlement/closing/reference prices, price limits, open interest, auction results; one row per metric |
+| `trade_summary()` | Trade-summary messages (CME, Eurex) — aggressor's perspective |
+| `open_interest()` | Open-interest messages (derivatives) |
+| `manual_orders()` | Manual orders |
+| `si_quotes()` | Systematic internaliser quotes |
+| `sip_quotes()` | SIP quotes |
+
+**`all_trades()` vs `trades()` is the most common mistake here.** On `Security`, `trades()` returns
+only off-book prints — order-book executions live in `incremental_book_L3()`. Summing `trades()`
+and calling it the day's volume misses every lit continuous execution. `all_trades()` aggregates
+across sources and returns only *printable* trades, which is what a volume figure wants.
+
+In the normalised data, auction uncrossings appear in the trades table for consistency.
+
+## Market states and normalised enums
+
+`NormalisedSecurity` gives every table a consistent `market_state`, so filtering works uniformly:
+
+```python
+mkt = md.market_info()
+# CLOSED -> OPENING_AUCTION -> CONTINUOUS_TRADING -> CLOSING_AUCTION -> POST_TRADE -> CLOSED
+```
+
+Normalised categorical fields: `market_state`, `side` / `aggressor_side`, `bmll_trade_type`,
+`lob_action`. Values are text (readable, still performant). Enumerate them:
+
+```python
+SIDES.categories          # Index(['ASK', 'BID', 'UNKNOWN'])
+MARKET_STATES.categories
+BMLL_TRADE_TYPES.categories
+```
+
+Use the enum objects in `query()` rather than string literals — a typo in a literal silently
+matches nothing:
+
+```python
+book = md.incremental_book_L3()
+
+opening = book.query('market_state == @MARKET_STATES.OPENING_AUCTION')
+bid_inserts = opening.query('(side == @SIDES.BID) & (lob_action == @L3_LOB_ACTIONS.INSERT)')
+
+trades = md.trades()
+otc = trades.query('bmll_trade_type == @BMLL_TRADE_TYPES.OTC')
+uncross = trades.query('(bmll_trade_type == @BMLL_TRADE_TYPES.UNCROSSING) & '
+                       '(market_state == @MARKET_STATES.OPENING_AUCTION)')
+```
+
+## Key columns
+
+`incremental_book_L3()`: `event_no`, `quote_no`, `side`, `price`, `size`, `order_id`,
+`original_order_id`, `event_timestamp`, `lob_action`, `order_executed`, `execution_price`,
+`execution_size`, `price_level`, `end_of_event`, `market_state`, `printable`, `old_size`.
+(The full frame is ~110 columns.)
+
+Trades tables: `trade_id`, `trade_timestamp`, `publication_timestamp`, `aggressor_side`, `price`,
+`execution_size`, `market_state`, `sequence_no`, `currency`, `printable`, `bmll_trade_type`,
+`trade_action`, `execution_venue`.
+
+`best_bid_offer()`: `event_timestamp`, `best_bid_size`, `best_bid_price`, `best_ask_price`,
+`best_ask_size`, `market_state`.
+
+`auction_data()`: `imbalance_qty`, `paired_qty`, `ref_price`, `sequence_no`, `side`,
+`event_timestamp`, `market_state`.
+
+Note `aggressor_side` is frequently `UNKNOWN` on off-book and auction prints — the same limitation
+as Trades Plus. Continuous lit executions carry `BID`/`ASK`.
+
+## Deriving the trading window
+
+Almost every intraday analysis wants the continuous session, not the whole file:
+
+```python
+ct = md.market_info().query('market_state == "CONTINUOUS_TRADING"')
+open_dt, close_dt = ct.start_timestamp.min(), ct.end_timestamp.max()
+```
+
+Hard-coding session times instead breaks on half-days, auction extensions and venue-specific
+schedules — and does so silently, by returning fewer rows rather than an error.
+
+## Trade classification
+
+The daily classified-trades taxonomy can be recomputed per security. It needs a Large-In-Scale
+value plus the primary venue's `market_info` (addressable liquidity is defined relative to the
+primary market's hours and currency):
+
+```python
+import bmll
+from bmll2.beta import NormalisedSecurity
+from bmll2.analytics.security_metrics import trades_classification
+
+ref = bmll.reference.query(ISIN=['GB00BH4HKS39'])
+instrument_ref = ref[ref.InstrumentId == ref[ref.ListingId == 121317].InstrumentId.iloc[0]]
+
+security = NormalisedSecurity.from_listing_id(121317, '2022-01-24')
+primary_listing_id = instrument_ref.query('IsPrimary').ListingId.iloc[0]
+primary_market_info = (NormalisedSecurity.from_listing_id(primary_listing_id, '2022-01-24')
+                       .market_data().market_info())
+
+botc = NormalisedSecurity.from_listing_id(
+    instrument_ref.query("MIC=='BOTC'").ListingId.iloc[0], '2022-01-24')
+
+ct = trades_classification.get_granular_trades_classification(
+    security, primary_listing_id, primary_market_info,
+    'EUR', float(botc.exchange_metadata.lis_local), botc.currency)
+```
+
+For most purposes the pre-computed daily feed
+(`bmll.time_series.classified_trades`, [analytics-timeseries.md](analytics-timeseries.md)) or the
+`Classification` column in Trades Plus is the better route — recompute only when you need a
+different LIS or a custom taxonomy.
+
+## Parallelising across listings
+
+`Security` calls are per-listing and serial by default. `SparkHelper` parallelises them across the
+workspace's cores — see [compute-and-storage.md](compute-and-storage.md).

--- a/skills/bmll/references/trades-plus.md
+++ b/skills/bmll/references/trades-plus.md
@@ -1,0 +1,303 @@
+# Trades Plus
+
+`get_market_data(mic, date, 'trades-plus')` — Equities only.
+
+The single most useful BMLL dataset for execution quality. Trades are rarely analysable in
+isolation: judging a fill requires the prevailing quote, the consolidated touch, and the
+subsequent price path. Trades Plus ships all of that **pre-joined onto every trade row** —
+venue/primary/consolidated BBO as of the trade, 30 pre- and post-trade midpoint columns, the
+BMLL trade classification, block thresholds, lot type and participant type.
+
+That means the questions below need no merge against a quotes table:
+
+- intraday volume by lit/dark/SI/OTC classification
+- block liquidity by venue and time of day
+- spread capture / price improvement against the consolidated touch
+- pre- and post-trade markouts (market impact)
+- retail vs institutional participation
+
+## Loading
+
+```python
+import pandas as pd
+from bmll2 import get_market_data
+
+pd.options.display.max_columns = None
+
+tp, ref = [], []
+for mic in ['XLON', 'BATE', 'CHIX', 'TRQX', 'AQXE', 'SGMX', 'BOTC']:
+    tp.append(get_market_data(mic, '2025-08-22', 'trades-plus'))
+    ref.append(get_market_data(mic, '2025-08-22', 'reference'))
+
+tp = pd.concat(tp, ignore_index=True, copy=False)
+ref = pd.concat(ref, ignore_index=True, copy=False)
+```
+
+Trades Plus has no `InstrumentType`; join the `reference` table for it:
+
+```python
+tp = tp.merge(ref[['ListingId', 'InstrumentType']], on='ListingId', how='left')
+equity = tp[(tp.InstrumentType == 'Equity') & (tp.Jurisdiction == 'UK')].copy()
+```
+
+For multi-day or multi-region pulls use `get_market_data_range` (Spark; see
+[market-data.md](market-data.md)) and aggregate before collecting.
+
+## Traps specific to this dataset
+
+- `IsBlock` / `LotType` / `ParticipantType` / `BMLLParticipantType` are **string enums**, including
+  a literal `'UNKNOWN'` level. `IsBlock == True` matches nothing.
+- `PricePoint*` uses `±99999` when best bid equals best ask, and `0.5` when the trade price equals
+  both. Filter before aggregating.
+- `AggressorSide` is `0` (unknown) on most off-book and auction prints. No side inference is
+  supplied — see [Markouts](#markouts).
+- `Size` may be negative (cancellation); `Printable` decides inclusion in cumulative volume.
+- `MIC` is the *reporting* venue; `ExecutionVenue` is where it actually executed.
+- `BestBidPriceAtVenue` / `BestAskPriceAtVenue` are **only populated for lit exchanges** — null on
+  dark and off-book rows, which quietly drops those rows from any venue-relative calculation.
+- `Classification`'s `OFF_BOOK_ON_EXCHANGE` bucket is scoped **differently** from the daily
+  `classified_trades` product: here it holds only `BMLLTradeType == 'OTC'` with a non-`SINT`/`XOFF`
+  `ExecutionVenue`, whereas the daily product also folds in `BENCHMARK_PRICE`/`SPECIAL_PRICE`.
+  The two will not reconcile to the share; do not present them as cross-checks of each other.
+- MMT flags use BMLL's **efficient encoding** (single chars), not the raw exchange strings.
+- BMLL's published notebooks use `pd.Grouper(freq='5T')`; `'T'` was removed in pandas 2.2 — use
+  `'5min'`.
+
+## Recipes
+
+### Intraday volume by classification
+
+`Classification` carries the same taxonomy as the daily classified-trades product, so intraday
+bars need no extra work:
+
+```python
+equity['TradingDate'] = pd.to_datetime(equity['TradeTimestamp'].dt.date)
+
+intr = (equity[equity.TradingDate == '2025-08-22']
+        .groupby(['Classification',
+                  pd.Grouper(key='TradeTimestamp', freq='5min', label='right')],
+                 as_index=False)[['TradeNotionalEUR']].sum())
+
+px.bar(intr, x='TradeTimestamp', y='TradeNotionalEUR', color='Classification',
+       template='plotly_white')
+```
+
+### Block liquidity by venue and time of day
+
+Shows when in the day large size is actually available:
+
+```python
+blocks = equity[equity.IsBlock == 'TRUE']          # string enum
+intr_blocks = (blocks[blocks.TradingDate == '2025-08-22']
+               .groupby(['ExecutionVenue',
+                         pd.Grouper(key='TradeTimestamp', freq='5min', label='right')],
+                        as_index=False)[['TradeNotionalEUR']].sum())
+```
+
+`TradeNotionalBlockBps` (10,000 × trade notional / block threshold) gives a continuous measure of
+size relative to the jurisdiction's block threshold, and is `NaN` where the threshold is unknown.
+`BlockSize` and `BlockNotional` are independent thresholds — the notional threshold is *not*
+derived from the size threshold.
+
+### Spread capture against the consolidated touch
+
+`PricePoint = (TradePrice − BidPrice) / (AskPrice − BidPrice)` against the consolidated/national
+book (or primary, per region). `0` = traded at bid, `1` = at ask, `0.5` = at mid, outside `[0,1]`
+= outside the touch.
+
+```python
+d = equity[equity.TradingDate == '2025-08-22'].copy()
+d['PricePointRounded'] = d.PricePoint.round(1)
+
+pp = d.groupby(['PricePointRounded', 'ExecutionVenue'],
+               as_index=False)[['TradeNotionalEUR']].sum()
+
+px.bar(pp[pp.PricePointRounded.between(-2, 2)],      # excludes ±99999 sentinels
+       x='PricePointRounded', y='TradeNotionalEUR', color='ExecutionVenue')
+```
+
+The `between(-2, 2)` filter is doing real work — without it the sentinel rows swamp the chart and
+any mean.
+
+Variants: `PricePointAtVenue` (vs the reporting venue's own book, lit only),
+`PricePointAtPrimary` (vs the primary exchange).
+
+### Markouts
+
+The dataset supplies midpoints at 15 pre- and 15 post-trade intervals — 1ms, 2, 5, 10, 25, 50,
+100, 200, 500ms, 1s, 5s, 15s, 30s, 60s, 300s — in two families:
+
+- `PreTradeMid{X}ms` / `PostTradeMid{X}ms` — consolidated/national (or primary, per region)
+- `PreTradeMid{X}msAtPrimary` / `PostTradeMid{X}msAtPrimary` — primary exchange
+
+Plus `PostTradeMid`, `PostTradeMidAtPrimary`, and volume-clock marks
+`PostTradeBestBid/Ask{1,3,10}V` (the touch after 1×/3×/10× the trade's volume has printed across
+venues, counting lit continuous trades only).
+
+**Sign convention is the whole game.** A markout must be normalised to one perspective —
+conventionally an aggressive buyer — or buys and sells cancel and the series flattens toward zero,
+which reads as "no impact" rather than "you averaged two opposite signs."
+
+Because `AggressorSide == 0` is common, the side must be inferred. BMLL's own notebook uses
+Lee-Ready: price above mid → buyer-initiated; below → seller-initiated; at mid → use the next
+tick.
+
+**Do not hand-roll this.** Use the script:
+
+```bash
+python scripts/bmll_markouts.py --help
+```
+
+```python
+from scripts.bmll_markouts import infer_aggressor_side, compute_markouts, aggregate_markouts
+
+d = infer_aggressor_side(d, benchmark='primary')         # fills AggressorSide == 0
+d, markout_cols = compute_markouts(d, benchmark='primary')   # bps, sign-normalised
+agg = aggregate_markouts(d, markout_cols, group_by=['Classification'])  # notional-weighted
+```
+
+`aggregate_markouts` weights by `TradeNotionalEUR` rather than taking a simple mean — an unweighted
+average lets a cloud of tiny odd-lot prints outvote the institutional flow the analysis is about.
+
+Group by `Classification` to compare impact of lit continuous vs dark vs SI; by `ExecutionVenue`
+for venue comparison; by `BMLLParticipantType` for retail vs institutional.
+
+### Retail participation
+
+`ParticipantType` holds venue-specific values (`RETAIL`, `THIRD_PARTIES` (XMAD),
+`OWN_ACCOUNT` (XMAD), `SPECIALIST` (XMAD), `CUSTODIAN_PARTICIPANT` (XNSE), `PROPRIETARY` (XNSE),
+`NON_CP_NON_PROPRIETARY` (XNSE), `UNKNOWN`), derived from exchange flags where available and
+heuristics otherwise. `BMLLParticipantType` normalises these globally to `RETAIL`,
+`INSTITUTIONAL`, `MARKET_MAKER`, `BROKER_DEALER`, `UNKNOWN`.
+
+Use `BMLLParticipantType` for cross-venue work; `ParticipantType` only when you need the
+venue-native distinction. Both carry a large `UNKNOWN` share — report it rather than dropping it.
+
+## Schema
+
+~99 fields. Grouped by purpose.
+
+### Identifiers and timestamps
+
+| Field | Type | Notes |
+|---|---|---|
+| `ExchangeTicker` | varchar | Ticker as provided by the reporting venue |
+| `Ticker` | varchar | FactSet ticker |
+| `MIC` | char(4) | Exchange the trade is **reported** for |
+| `OPOL` | char(4) | MIC of the Original Place Of Listing |
+| `ISOCountryCode` | char(3) | ISO country of the primary listing exchange |
+| `SegmentCode` | varchar | Exchange segment of execution |
+| `InstrumentCurrencyCode` | varchar(3) | Currency the instrument quotes in |
+| `ListingId` | bigint | BMLL listing identifier |
+| `InstrumentId` | bigint | BMLL instrument identifier (0 if absent) |
+| `TradeDate` | datetime | Date the trade was published |
+| `TradeTimestamp` | timestamp | Execution time, UTC, µs precision |
+| `PublicationTimestamp` | timestamp | Report time, UTC, µs precision |
+| `LocalTradeTimestamp` | timestamp | Execution time, reporting venue's local zone |
+| `LocalPublicationTimestamp` | timestamp | Report time, local zone |
+| `TradeTimestampNanoseconds` | timestamp | Execution time, UTC, ns precision |
+| `PublicationTimestampNanoseconds` | timestamp | Report time, UTC, ns precision |
+| `TZOffset` | integer | Local−UTC offset in seconds, DST-adjusted; based on the primary listing's location |
+| `TradeId` | varchar | Exchange-provided trade ID |
+| `ExchangeSequenceNo` | bigint | Exchange sequence number, where provided |
+| `BMLLSequenceNo` | bigint | Synthetic sequence allowing message reordering within security/date |
+| `BMLLSequenceSource` | bigint | Feed source, where on/off-book arrive on different feeds |
+
+### Price, size, currency
+
+| Field | Type | Notes |
+|---|---|---|
+| `AggressorSide` | integer | `1` ask aggressed by buy, `2` bid aggressed by sell, `0` unknown |
+| `Price` | double | In `CurrencyCode` |
+| `Size` | double | Negative if the execution is a cancellation |
+| `CurrencyCode` | char(3) | Currency the trade executed in |
+| `InstrumentCurrencyPrice` | double | Price in `InstrumentCurrencyCode` |
+| `MinorCurrencyFactor` | double | Minor→major scale where the instrument currency is a minor (GBp, ZAc) |
+| `Printable` | bool | Whether to include in cumulative volume |
+| `ExecutionVenue` | char(4) | MIC where execution occurred; differs from `MIC` for reported trades |
+| `TradeNotional` | double | In `CurrencyCode` |
+| `TradeNotionalUSD` | double | FX as of publication date |
+| `TradeNotionalEUR` | double | FX as of publication date |
+
+### Trade type, MMT flags, classification
+
+| Field | Type | Notes |
+|---|---|---|
+| `OriginalTradeType` | varchar | Concatenated exchange-reported flags; exchange-dependent |
+| `MarketMechanism` | char(1) | MMT Level 1 |
+| `TradingMode` | char(1) | MMT Level 2 |
+| `TransactionCategory` | char(1) | MMT Level 3.1 |
+| `NegotiatedTrade` | char(1) | MMT 3.2 |
+| `CrossingTrade` | char(1) | MMT 3.3 |
+| `ModificationIndicator` | char(1) | MMT 3.4 |
+| `BenchmarkIndicator` | char(1) | MMT 3.5 |
+| `SpecialDividendIndicator` | char(1) | MMT 3.6 |
+| `OffBookAutomatedIndicator` | char(1) | MMT 3.7 |
+| `PriceFormation` | char(1) | MMT 3.8 |
+| `AlgorithmicTrade` | char(1) | MMT 3.9 |
+| `PublicationMode` | char(1) | MMT 4.1 |
+| `DeferralType` | char(1) | MMT 4.2 |
+| `DuplicativeIndicator` | char(1) | MMT 5 |
+| `Jurisdiction` | char(2) | ISO country of execution/publication venue; `EU` for Europe |
+| `MarketState` | varchar | BMLL-standardised market state |
+| `MarketStateAtPrimary` | varchar | BMLL-standardised state of the primary exchange |
+| `BMLLTradeType` | varchar | BMLL-standardised trade type |
+| `Classification` | varchar | One of the 22 classified-trade buckets (see caveat above) |
+| `BrokerIdBuyer` | varchar | Passive buy-side broker, where the exchange provides it |
+| `BrokerIdSeller` | varchar | Passive sell-side broker, where provided |
+
+MMT reference: `https://www.fixtrading.org/mmt/`
+
+### Block, lot and participant
+
+| Field | Type | Notes |
+|---|---|---|
+| `BlockSize` | double | Jurisdictional block threshold in shares; `None` if N/A |
+| `BlockNotional` | double | Block notional threshold; independent of `BlockSize` |
+| `BlockNotionalCurrency` | char(3) | EUR for Europe/UK, USD elsewhere |
+| `TradeNotionalBlockBps` | double | 10,000 × notional / block threshold; `NaN` if threshold unknown |
+| `IsBlock` | varchar | `TRUE` / `FALSE` / `UNKNOWN` (string) |
+| `LotType` | varchar | `ODD` / `ROUND` / `MIXED` / `UNKNOWN`; odd-lot threshold is region-specific |
+| `ParticipantType` | varchar | Venue-specific participant enum (see above) |
+| `BMLLParticipantType` | varchar | `RETAIL` / `INSTITUTIONAL` / `MARKET_MAKER` / `BROKER_DEALER` / `UNKNOWN` |
+
+### Prevailing quotes
+
+All are as of the trade timestamp, **before** the trade.
+
+| Field | Notes |
+|---|---|
+| `BestBidPrice` / `BestBidSize` / `BestBidVenue` | Consolidated/national or primary, per region. US NBBO size is round lots converted to shares. Venue = largest size at the touch, ties broken by first quote at that size |
+| `BestAskPrice` / `BestAskSize` / `BestAskVenue` | As above |
+| `BestBidPriceAtVenue` / `BestBidSizeAtVenue` | The `MIC` venue's own book — **lit exchanges only** |
+| `BestAskPriceAtVenue` / `BestAskSizeAtVenue` | As above |
+| `BestBidPriceAtPrimary` / `BestBidSizeAtPrimary` | Primary exchange |
+| `BestAskPriceAtPrimary` / `BestAskSizeAtPrimary` | Primary exchange |
+| `PriorQuoteSizeRank` | Rank of the execution venue by prevailing quote size across cross-listed venues; `0` = venue was not at BB/BO. Lit trades only, else null |
+
+### Timing, spread capture, impact
+
+| Field | Notes |
+|---|---|
+| `PreTradeElapsedTimeChg` | Nanoseconds since the last price change on the consolidated/primary book before this trade |
+| `PostTradeElapsedTimeChg` | Nanoseconds since the last price change after this trade |
+| `PreTradeElapsedTimeChgAtPrimary` / `PostTradeElapsedTimeChgAtPrimary` | Same, primary BBO |
+| `PricePoint` | `(Price − Bid) / (Ask − Bid)` vs consolidated/primary. Sentinels: `+99999` if Price > Bid when Bid == Ask, `−99999` if Price < Bid, `0.5` if equal |
+| `PricePointAtVenue` | Same vs the `MIC` venue's book — lit only |
+| `PricePointAtPrimary` | Same vs the primary book |
+| `OrderRemainingQty` | Remaining qty of the passively executed order. Lit on-book only, else null |
+| `BBORemainingQtyAtVenue` | Remaining qty at the trade price on the execution venue's touch after the trade; computed from the side opposite the aggressor. On-book only |
+| `PreTradeMid{X}ms` / `PostTradeMid{X}ms` | 15 intervals each, consolidated/primary |
+| `PreTradeMid{X}msAtPrimary` / `PostTradeMid{X}msAtPrimary` | 15 intervals each, primary |
+| `PostTradeMid` / `PostTradeMidAtPrimary` | Midpoint immediately after the trade |
+| `PostTradeBestBid{1,3,10}V` / `PostTradeBestAsk{1,3,10}V` | Touch after 1×/3×/10× the trade's volume prints across venues; lit continuous only |
+
+Interval set for the `{X}ms` families: `1, 2, 5, 10, 25, 50, 100, 200, 500, 1000, 5000, 15000,
+30000, 60000, 300000`.
+
+## Related
+
+- Daily aggregated equivalent: `bmll.time_series.classified_trades` —
+  [analytics-timeseries.md](analytics-timeseries.md)
+- Order-book context beyond the touch: [order-book-rebuilding.md](order-book-rebuilding.md)
+- Full-market pulls across dates: [market-data.md](market-data.md)

--- a/skills/bmll/references/troubleshooting.md
+++ b/skills/bmll/references/troubleshooting.md
@@ -1,0 +1,105 @@
+# Troubleshooting
+
+## Empty result
+
+The most common BMLL failure, and the one that does not raise. Work through these in order:
+
+| Check | How |
+|---|---|
+| Does the venue have data on that date? | `reference.availability(mics, date=...)` |
+| Was it a trading day for that venue? | `Calendar`, or `market_info()` for a known-good listing |
+| Was the listing alive? | `reference.query(..., start_date=, end_date=)` → `IsAlive` |
+| Is the table valid for the asset class? | `get_market_tables()` |
+| Is `schema='Future'` needed? | Futures reference/market data need it |
+| Is the MIC right? | `reference.available_markets()`; note segment MICs collapse to the main MIC |
+| Does the venue's history start later? | `available_markets()` → `StartDate` |
+| Is this an entitlement gap? | Analytics (`time_series`), index constituents and CBBO need separate subscriptions and return empty, not 403 |
+| Did the date range end today? | Derived data is T+1 |
+
+For per-listing coverage gaps, `available_listings(listing_ids, start_date, ...)` gives the dates
+with data per listing and feed.
+
+Do not conclude "no activity" until availability has been checked. An empty frame means "the query
+found nothing", which is a statement about the query at least as often as about the market.
+
+## Wrong-looking numbers
+
+| Symptom | Likely cause |
+|---|---|
+| Volume ~2× too high, or oddly netted | Missing `Printable == True` filter; `Size` is negative on cancellations |
+| Notionals off by exactly 100× | Mixed `Price` (in `CurrencyCode`) with `InstrumentCurrencyPrice`; minor currency (GBp, ZAc) needs `MinorCurrencyFactor` |
+| Venue market share attributes everything to a reporting venue | Grouped by `MIC` instead of `ExecutionVenue` |
+| Block filter returns nothing | `IsBlock` is the string `'TRUE'`, not a bool |
+| Mean `PricePoint` is enormous | `±99999` sentinels (bid == ask) not filtered |
+| Markout curve is flat near zero | Sign not normalised for `AggressorSide == 2`; buys and sells cancelled |
+| Markouts drop most rows | `AggressorSide == 0` not inferred |
+| Futures volume too high | `ContractType == 'Spread'` legs counted alongside outrights |
+| Timestamps in 1970 | Integer-nanosecond columns from `get_market_data_range` treated as datetimes |
+| `pd.Grouper(freq='5T')` raises | `'T'` removed in pandas 2.2; use `'5min'` |
+| Daily volume missing lit executions | Used `trades()` instead of `all_trades()`; on `Security`, `trades()` is off-book only |
+| Two classification products disagree | `OFF_BOOK_ON_EXCHANGE` is scoped differently in Trades Plus vs `classified_trades` — they are not reconcilable |
+| Market-cap panel has lookahead | `late_flag=True` rows were amended after `effective_date` |
+
+`scripts/bmll_checks.py` covers the mechanical ones — `printable_only`,
+`drop_price_point_sentinels`, `normalise_enum_flags`, `coerce_range_timestamps`.
+
+## Memory and Spark
+
+**Driver OOM / session death** — almost always `.toPandas()` on a full `get_market_data_range`
+result. Aggregate in Spark first, collect the aggregate.
+
+**`spark.driver.maxResultSize` exceeded** — raise it *before* running any query, at the top of the
+cell (this restarts the session):
+
+```python
+from pyspark.sql import SparkSession
+conf = spark.sparkContext.getConf()
+conf.set('spark.driver.maxResultSize', '10g')
+spark.stop()
+spark = SparkSession.Builder().master('local[*]').config(conf=conf).getOrCreate()
+```
+
+**Out-of-memory on a single machine** — use Polars lazy frames:
+
+```python
+df = get_market_data(mic, date, table, df_engine='polars', lazy_load=True)
+```
+
+**Full-day L3 book too large to materialise** — use `rebuilt_history_L2/L3` with `apply(...)` so
+metrics are computed during the replay, or `date_range_sampler_on_the_fly` for the
+minimal-memory generator. See [order-book-rebuilding.md](order-book-rebuilding.md).
+
+**Slow per-listing loops** — parallelise with `SparkHelper.map` before considering a cluster; a
+workspace has up to 192 cores. See [compute-and-storage.md](compute-and-storage.md).
+
+## Lost files
+
+Local writes are destroyed when the workspace stops. If the workspace is still running, persist
+now with `b2.put_file(...)`. If it stopped, the local copy is gone — but files that were in a
+persistent area and then deleted are recoverable for **7 days**:
+
+```python
+b2.list_deleted_files('path')
+b2.get_file_history(path='path/file.csv')
+b2.recover_file_version('path/file.csv', recovery_file_name='recovered.csv')
+```
+
+## Slow reference queries
+
+`reference.query` without a date returns the latest snapshot and is the fast path. Adding
+`start_date`/`end_date` makes it point-in-time and markedly slower.
+
+For a whole market on one date, `get_market_data(mic, date, 'reference')` is faster than
+`reference.query`.
+
+For large `time_series` universes, split the query by MIC, and by date for ranges beyond a year.
+
+## Cluster jobs with no diagnostics
+
+`create_cluster` only logs if a log path is supplied. Without one, a failed job leaves nothing to
+read. Always pass the log path.
+
+## Scheduled job fired before the data landed
+
+`CronTrigger` fires on wall-clock time regardless of data availability, and BMLL data is T+1 with
+variable arrival. Use `L3Availability` as the trigger for data-dependent pipelines.

--- a/skills/bmll/references/venues.md
+++ b/skills/bmll/references/venues.md
@@ -1,0 +1,169 @@
+# Per-Venue Datasets
+
+`https://lab.bmlltech.com/docs/contents/data_ref/datasets/`
+
+88 venue pages. Each documents what is special about that dataset: which MICs it serves, the raw
+fields the exchange publishes, how BMLL maps them onto the normalised vocabulary, and behaviour
+that differs from other venues (iceberg representation, auction transparency, member attribution).
+
+**Consult the venue page whenever an analysis depends on venue-specific behaviour** — hidden
+liquidity, auction mechanics, retail flags, member/broker IDs, or any comparison that assumes two
+venues publish the same thing. They frequently do not, and the difference is documented there
+rather than being visible in the data.
+
+## What a venue page contains
+
+Using LSE as the template:
+
+| Section | Contents |
+|---|---|
+| Introduction → Key Features | Available MIC codes, venue background |
+| Data Schema | Raw fields per table (Market State, Trades, Limit Order Updates, Exchange Metadata), each with an **Available From** date |
+| Normalised Data Schema | The mapping: BMLL Market State ← venue fields; BMLL Trade Type ← venue trade types, again dated |
+| Reference | Venue documentation links |
+
+### Feed generations
+
+Venue schemas change when the exchange migrates feeds, and BMLL documents the generations
+separately — the LSE page splits every table into **Pre-GTP** and **GTP**, with different field
+sets (the GTP trades table has 56 fields against Pre-GTP's 11) and different normalisation
+mappings.
+
+Every field carries an **Available From** date. A backtest spanning a migration sees fields appear
+mid-sample, and normalisation mappings that differ either side of the boundary. Checking the venue
+page before running a multi-year study is the difference between a real regime change and an
+artefact of the feed.
+
+The same applies to flags added later — Xetra's retail flag (`trade_condition` 743) only exists
+from 2024-05-20, and CBOE EU's from 2025-09-08. Volume "growth" that begins exactly on a flag's
+start date is the flag, not the market.
+
+## Venue index
+
+MICs as documented on each page. Multi-MIC venues cover their whole operator family.
+
+### Europe / UK
+
+| Venue | MICs |
+|---|---|
+| LSE | `XLON` |
+| Cboe Europe | `BATE`, `CHIX`, `CEUX` |
+| Cboe BXTR | `BOTC` |
+| Turquoise | `TRQX`, `TQEX` |
+| Aquis | `AQXE`, `AQEU` |
+| Sigma X MTF | `SGMX`, `SGMU` |
+| Equiduct | `XEQT`, `EQTA`, `EQTB`, `EQTC` |
+| Equiduct Apex | `@ALP` |
+| Euronext | `XPAR`, `XAMS`, `XBRU`, `XLIS`, `XDUB` |
+| Deutsche Boerse Xetra | `XETR`, `XEUB` |
+| German Regionals | `XBER`, `XDUS`, `XFRA`, `XHAM`, `XHAN`, `XMUN`, `XSTU` |
+| Tradegate | `XGAT` |
+| Borsa Italiana | `XMIL`, `MTAA`, `MTAH`, `ETFP`, `MOTX`, `SEDX`, `XAIM`, `ATFX` |
+| BME | `XMAD` |
+| SIX | `XSWX`, `XSWM`, `XSEB`, `XICB`, `EBBO`, `SIX` |
+| Nasdaq Nordic | `XSTO`, `XCSE`, `XHEL`, `XICE`, `XTAL`, `XRIS`, `XLIT`, `ESTO`, `FNSE`, `FNDK`, `FNFI`, `FNIS`, `FNEE`, `FNLT`, `FNLV`, `ONSE` |
+| Oslo Børs | `XOSL` |
+| Vienna | `XWBO` |
+| Warsaw | `XWAR` |
+| Prague | `XPRA` |
+| Budapest | `XBUD` |
+| Athens | `XATH` |
+| Istanbul | `XIST` |
+| AQSE | `AQSE` |
+| ARTEX | `ARTX` |
+| Bloomberg MTF | `BMTF`, `BTFE` |
+| Tradeweb | `TREU`, `TWEM` |
+| Cinnober Boat | `BOAT` |
+| Lynx Periodic Match | `LYNX` |
+| Eurex | `XEUR`, `XERT`, `XERE`, `XEUB`, `XEUP` |
+| ICE | `IFEU`, `IFLL`, `IFLO`, `IFLX`, `IFUS`, `IFED`, `NDEX` |
+
+### Americas
+
+| Venue | MICs |
+|---|---|
+| The U.S. Consolidated Tape | `@SIP` |
+| NYSE | `XNYS`, `ARCX`, `XASE`, `XCHI`, `XCIS` |
+| Nasdaq | `XNAS`, `XBOS`, `XPSX` |
+| Cboe US | `BATS`, `BATY`, `EDGA`, `EDGX` |
+| IEX | `IEXG` |
+| MEMX | `MEMX` |
+| MIAX Pearl Equities | `EPRL` |
+| LTSE | `LTSE` |
+| Blue Ocean | `OCEA` |
+| OTC Markets | `OTCM` |
+| OPRA (US equity options) | `OPRA` |
+| CME Group | `XCME`, `XCBT`, `XNYM`, `XCEC`, `CME`, `CBOT`, `NYMEX`, `COMEX` |
+| Toronto Stock Exchange & TSX Venture | `XTSE`, `XTSX`, `TSX` |
+| TSX Alpha | `XATS` |
+| Canadian Consolidated Book | `@CCB` |
+| Aequitas NEO Exchange | `NEOE`, `NEON`, `NEO` |
+| Nasdaq Canada | `CHIC` |
+| Nasdaq CX2 | `XCX2` |
+| Omega ATS | `OMGA` |
+| CSE | `XCNQ` |
+| B3 (Brasil) | `BVMF` |
+| Mexico | `XMEX` |
+| Colombia | `XBOG` |
+| Lima | `XLIM` |
+| Santiago | `XSGO` |
+
+### APAC
+
+| Venue | MICs |
+|---|---|
+| ASX | `XASX` |
+| ASX24 | `XSFE` |
+| Cboe Australia | `CHIA` |
+| Tokyo | `XTKS` |
+| Cboe Japan | `CHIJ` |
+| Japannext | `XSBI`, `SBIJ`, `SBIU` |
+| Hong Kong | `XHKG` |
+| Shanghai | `XSHG` |
+| Shenzhen | `XSHE` |
+| Korea | `XKRX` |
+| Singapore | `XSES` |
+| Taiwan | `XTAI` |
+| Taipei | `ROCO` |
+| Malaysia | `XKLS` |
+| Thailand | `XBKK` |
+| Philippines | `XPHS` |
+| New Zealand | `XNZE` |
+| NSE (India) | `XNSE` |
+| BSE (India) | `XBOM` |
+| Hanoi | `HSTC` |
+| Ho Chi Minh | `XSTC` |
+
+### EMEA (non-European)
+
+| Venue | MICs |
+|---|---|
+| JSE | `XJSE` |
+| JSE Derivatives | `XSAF`, `ZFXM` |
+| A2X | `A2XX` |
+| Tadawul | `XSAU` |
+| Abu Dhabi | `XADS` |
+| Dubai | `XDFM` |
+| Qatar | `DSMD` |
+| Kuwait | `XKUW` |
+| Bahrain | `XBAH` |
+| Egypt | `XCAI` |
+| Tel Aviv | `XTAE` |
+
+Confirm coverage and start dates at runtime with `reference.available_markets()` — it returns
+`StartDate` and `IsAlive` per market, which this static table cannot.
+
+## Consolidated and synthetic MICs
+
+`@SIP` (US), `@CCB` (Canada) and `@ALP` (Equiduct Apex) are consolidated or venue-family feeds
+rather than single order books. Treating `@SIP` as one more venue in a venue-share breakdown
+double-counts, since its prints are also attributed to the executing venues.
+
+## Member attribution
+
+The retail page documents which venues expose member/broker identifiers, by region, with the exact
+table and field names — Americas (11 markets), APAC (3), EMEA (2). Broker attribution exists on far
+fewer venues than people assume; `BrokerIdBuyer`/`BrokerIdSeller` in Trades Plus are populated only
+where the exchange provides them, and only for the **passive** side.
+
+See [retail.md](retail.md).

--- a/skills/bmll/scripts/bmll_checks.py
+++ b/skills/bmll/scripts/bmll_checks.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validation helpers for BMLL frames.
+
+BMLL returns an empty frame rather than an error for a valid-but-wrong MIC, a
+non-trading date, a listing that was not alive, or a missing entitlement. These
+helpers turn that silence into an exception or an explicit report, so a hole in the
+data cannot pass downstream as a zero.
+
+Usage::
+
+    from bmll_checks import (
+        assert_non_empty_per_date, printable_only, drop_price_point_sentinels,
+        normalise_enum_flags, coerce_range_timestamps, describe_coverage,
+    )
+
+    df = printable_only(df)
+    assert_non_empty_per_date(df, expected_dates, date_col="TradeDate")
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+# Trades Plus string-enum columns. Comparing these to a Python bool silently
+# yields an empty frame, so they are normalised explicitly.
+STRING_ENUM_COLS: tuple[str, ...] = (
+    "IsBlock", "LotType", "ParticipantType", "BMLLParticipantType",
+)
+
+# PricePoint sentinels used when best bid == best ask.
+PRICE_POINT_SENTINEL = 99999.0
+
+
+class EmptyResultError(AssertionError):
+    """Raised when a BMLL query returned no rows where rows were expected."""
+
+
+def assert_non_empty(df: pd.DataFrame, what: str = "query") -> pd.DataFrame:
+    """Raise if the frame is empty. Empty means 'asked wrong' as often as 'no trades'."""
+    if len(df) == 0:
+        raise EmptyResultError(
+            f"{what} returned 0 rows. BMLL does not error on a valid-but-wrong MIC, a "
+            "non-trading date, a listing that was not alive, or a missing entitlement — "
+            "check reference.availability() before treating this as zero activity."
+        )
+    return df
+
+
+def assert_non_empty_per_date(
+    df: pd.DataFrame,
+    expected_dates: Iterable,
+    date_col: str = "TradeDate",
+) -> pd.DataFrame:
+    """Raise if any expected date is missing from the frame.
+
+    An overall row count hides a single blank date inside a range; per-date is the
+    granularity at which the gap actually appears.
+    """
+    if date_col not in df.columns:
+        raise KeyError(f"assert_non_empty_per_date: no column {date_col!r}")
+    present = set(pd.to_datetime(pd.Series(list(df[date_col].unique()))).dt.date)
+    expected = set(pd.to_datetime(pd.Series(list(expected_dates))).dt.date)
+    missing = sorted(expected - present)
+    if missing:
+        raise EmptyResultError(
+            f"{len(missing)} expected date(s) returned no rows: "
+            f"{[str(d) for d in missing[:10]]}"
+            f"{'...' if len(missing) > 10 else ''}. "
+            "Verify these were trading days and that the venue has coverage."
+        )
+    return df
+
+
+def printable_only(df: pd.DataFrame, warn: bool = True) -> pd.DataFrame:
+    """Keep only prints that count toward cumulative volume.
+
+    ``Size`` is negative for cancellations and ``Printable`` is the inclusion flag;
+    summing without this filter is wrong in both directions at once.
+    """
+    if "Printable" not in df.columns:
+        if warn:
+            print("printable_only: no 'Printable' column — returning frame unchanged")
+        return df
+    out = df[df["Printable"] == True]  # noqa: E712 — may be object dtype
+    if warn:
+        dropped = len(df) - len(out)
+        if dropped:
+            print(f"printable_only: dropped {dropped:,} non-printable rows "
+                  f"({dropped / len(df):.2%})")
+    return out
+
+
+def drop_price_point_sentinels(
+    df: pd.DataFrame,
+    col: str = "PricePoint",
+    lower: float = -2.0,
+    upper: float = 2.0,
+) -> pd.DataFrame:
+    """Filter PricePoint to a plausible band.
+
+    ``±99999`` is emitted when best bid equals best ask; an unfiltered mean is
+    dominated by those rows and is not a spread-capture number.
+    """
+    if col not in df.columns:
+        raise KeyError(f"drop_price_point_sentinels: no column {col!r}")
+    return df[df[col].between(lower, upper)]
+
+
+def normalise_enum_flags(
+    df: pd.DataFrame,
+    cols: Sequence[str] = STRING_ENUM_COLS,
+    inplace: bool = False,
+) -> pd.DataFrame:
+    """Upper-case and strip the string-enum columns so comparisons are predictable.
+
+    Does **not** cast to bool: ``UNKNOWN`` is a real level and collapsing it into
+    ``False`` overstates the confident negatives.
+    """
+    if not inplace:
+        df = df.copy()
+    for c in cols:
+        if c in df.columns:
+            df[c] = df[c].astype("string").str.strip().str.upper()
+    return df
+
+
+def coerce_range_timestamps(
+    df: pd.DataFrame,
+    cols: Sequence[str] = ("TradeTimestampNanoseconds", "PublicationTimestampNanoseconds"),
+    inplace: bool = False,
+) -> pd.DataFrame:
+    """Convert integer-nanosecond timestamps from ``get_market_data_range`` to datetimes.
+
+    ``get_market_data`` returns these as ``datetime64``; the Spark-backed ``_range``
+    variant returns integer nanoseconds. Columns already datetime-typed are skipped,
+    so this is safe to call on either.
+    """
+    if not inplace:
+        df = df.copy()
+    for c in cols:
+        if c in df.columns and not pd.api.types.is_datetime64_any_dtype(df[c]):
+            df[c] = pd.to_datetime(df[c], unit="ns", utc=True, errors="coerce")
+    return df
+
+
+def describe_coverage(
+    df: pd.DataFrame,
+    date_col: str = "TradeDate",
+    venue_col: str = "ExecutionVenue",
+) -> pd.DataFrame:
+    """Row counts per date and venue — the cheapest way to see a hole before aggregating."""
+    keys = [c for c in (date_col, venue_col) if c in df.columns]
+    if not keys:
+        raise KeyError(f"describe_coverage: neither {date_col!r} nor {venue_col!r} present")
+    return (df.groupby(keys, dropna=False)
+              .size()
+              .rename("rows")
+              .reset_index()
+              .sort_values(keys))

--- a/skills/bmll/scripts/bmll_impact.py
+++ b/skills/bmll/scripts/bmll_impact.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Event-time market impact (markout curves) from a BMLL L3 order book.
+
+Different from Trades Plus markouts (``bmll_markouts.py``), which read pre-computed
+midpoint columns at fixed intervals off each trade row. This computes impact from the
+book itself, which buys three things Trades Plus cannot give you:
+
+* **Arbitrary events.** Impact around any event you can express as a query on the
+  incremental book — large liquidity removals, passive inserts, cancellations — not
+  only executed trades.
+* **Arbitrary horizons.** Any window, including sub-millisecond, rather than the 15
+  published intervals.
+* **Cross-product impact.** Events from one book measured against the midpoint of
+  *another* — the futures/ETF lead-lag case (a trade on the CME E-mini vs the
+  midpoint of SPY on NYSE, where the response appears ~4ms later, the New
+  York/Chicago round trip).
+
+Adapted from BMLL's "Market Impact with BMLL" tutorial, with the sign convention
+made explicit (see ``impact_bps``).
+
+Usage::
+
+    from bmll_impact import (MarketImpactComputer, liquidity_removal_events,
+                             mid_from_book, impact_bps, geometric_window)
+
+    book = (NormalisedSecurity.from_listing_id(121317, "2021-05-05")
+            .market_data().incremental_book_L3().set_index("event_timestamp"))
+
+    im = MarketImpactComputer(
+        events=liquidity_removal_events(book),
+        books={"VOD:XLON": book},
+        impact_metric=mid_from_book,
+        impact_measure=impact_bps,
+        window=geometric_window(seconds=10, n=20),
+    )
+    curve = im.mean_curve()          # tidy: offset_seconds | ID | impact_bps
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+# The book is already impacted at the event timestamp itself, so the pre-event
+# reference is taken one nanosecond earlier.
+_EPS = pd.Timedelta("1ns")
+
+
+def geometric_window(seconds: float = 10.0, n: int = 20,
+                     scaling: float | None = None) -> list[pd.Timedelta]:
+    """Geometrically spaced offsets out to ``seconds``, densest near the event.
+
+    Impact decays fast and most of the structure is in the first milliseconds; even
+    spacing spends nearly all its resolution on the flat tail.
+    """
+    if scaling is None:
+        scaling = 10 ** (1.0 / 3.0)
+    return [pd.Timedelta(seconds=seconds * scaling ** (-n + i + 1)) for i in range(n)]
+
+
+def linear_window(seconds: float = 1e-4, n: int = 80) -> list[pd.Timedelta]:
+    """Evenly spaced offsets — for sub-millisecond work where decay is roughly linear."""
+    return [pd.Timedelta(seconds=seconds * i) for i in range(1, n)]
+
+
+def mid_from_book(book: pd.DataFrame, continuous_only: bool = True) -> pd.Series:
+    """Midpoint series from an L3 incremental book indexed by ``event_timestamp``."""
+    if continuous_only and "market_state" in book.columns:
+        book = book.query('market_state == "CONTINUOUS_TRADING"')
+    return (book["best_bid_price"] + book["best_ask_price"]) / 2
+
+
+def liquidity_removal_events(book: pd.DataFrame, num_events: int = -1) -> pd.DataFrame:
+    """Executions that removed liquidity, largest first, then re-sorted by time.
+
+    ``num_events`` keeps the N largest (``-1`` keeps all) — impact of the biggest
+    removals is usually the question, and it bounds the cost of the reindexing below.
+    """
+    if "lob_action" not in book.columns:
+        raise KeyError("liquidity_removal_events: expected an L3 incremental book")
+
+    sel = book.query("(lob_action == 'REMOVE') & (execution_size > 0)")
+    cols = ["event_timestamp", "side", "execution_size", "execution_price",
+            "original_order_id"]
+    sel = sel.sort_values("execution_size", ascending=False)
+    if num_events != -1:
+        sel = sel.iloc[:num_events]
+    return (sel.reset_index()[cols].drop_duplicates()
+               .sort_values("event_timestamp").reset_index(drop=True))
+
+
+def impact_bps(events: pd.DataFrame, reference: pd.Series, metric: pd.Series) -> pd.Series:
+    """Basis-point deviation of ``metric`` from ``reference``, signed to the aggressor.
+
+    ``events['side']`` is the side of the **resting** order that was executed, so an
+    executed ASK means an aggressive **buyer** and an executed BID an aggressive
+    **seller**. Normalising to the aggressor makes buy- and sell-initiated impact add
+    rather than cancel; without it the mean curve collapses toward zero and reads as
+    "no impact".
+    """
+    side = events["side"].reset_index(drop=True)
+    aggressor_sign = np.where(side.astype(str).str.upper().eq("ASK"), 1.0, -1.0)
+    ref = pd.Series(np.asarray(reference), dtype="float64")
+    met = pd.Series(np.asarray(metric), dtype="float64")
+    return ((met - ref) / ref) * aggressor_sign * 1e4
+
+
+class MarketImpactComputer:
+    """Compute an impact curve for a set of events against one or more books.
+
+    Parameters
+    ----------
+    events : DataFrame with ``event_timestamp`` and ``side``.
+    books : mapping of label -> book DataFrame indexed by ``event_timestamp``.
+        More than one book measures the same events against several instruments;
+        a book different from the one the events came from gives cross-product impact.
+    impact_metric : book -> Series (e.g. :func:`mid_from_book`).
+    impact_measure : (events, reference, metric) -> Series (e.g. :func:`impact_bps`).
+    window : offsets after the event; mirrored to produce the pre-event side.
+    """
+
+    def __init__(
+        self,
+        events: pd.DataFrame,
+        books: Mapping[str, pd.DataFrame],
+        impact_metric: Callable[[pd.DataFrame], pd.Series] = mid_from_book,
+        impact_measure: Callable[..., pd.Series] = impact_bps,
+        window: Sequence[pd.Timedelta] | None = None,
+    ):
+        if "event_timestamp" not in events.columns:
+            raise KeyError("MarketImpactComputer: events need an 'event_timestamp' column")
+        if "side" not in events.columns:
+            raise KeyError("MarketImpactComputer: events need a 'side' column")
+        self.events = events.reset_index(drop=True)
+        self.books = dict(books)
+        self.impact_metric = impact_metric
+        self.impact_measure = impact_measure
+        self.window = list(window) if window is not None else geometric_window()
+        self.raw_impact: pd.DataFrame | None = None
+
+    @staticmethod
+    def _shift(metric: pd.Series, offset: pd.Timedelta) -> pd.Series:
+        """Shift the metric's index back by ``offset`` so an as-of lookup reads ahead."""
+        return pd.Series(np.asarray(metric), index=metric.index - offset)
+
+    def offsets(self) -> list[pd.Timedelta]:
+        """Full offset axis: negative (pre-event), zero, then positive (post-event)."""
+        return ([-w for w in self.window[::-1]]
+                + [pd.Timedelta(seconds=0)]
+                + list(self.window))
+
+    def _impact_for_book(self, book: pd.DataFrame) -> pd.DataFrame:
+        metric = self.impact_metric(book)
+        metric = metric[~metric.index.duplicated(keep="last")].sort_index()
+
+        at = np.asarray(self.events["event_timestamp"] - _EPS)
+        unique = np.asarray(pd.Index(self.events["event_timestamp"] - _EPS).unique())
+
+        reference = metric.reindex(unique, method="ffill").reindex(at, method="ffill")
+
+        cols = {}
+        for w in self.offsets():
+            shifted = (self._shift(metric, w)
+                       .reindex(unique, method="ffill")
+                       .reindex(at))
+            cols[w.total_seconds()] = self.impact_measure(
+                self.events, reference.reset_index(drop=True),
+                shifted.reset_index(drop=True)).to_numpy()
+
+        out = pd.DataFrame(cols)
+        out.index = self.events.index
+        return out
+
+    def compute(self) -> pd.DataFrame:
+        """Per-event impact at every offset, for every book. One row per event per book."""
+        frames = []
+        for label, book in self.books.items():
+            frames.append(pd.concat(
+                [self.events["event_timestamp"], self._impact_for_book(book)], axis=1
+            ).assign(ID=label))
+        self.raw_impact = pd.concat(frames, ignore_index=True)
+        return self.raw_impact
+
+    def mean_curve(self) -> pd.DataFrame:
+        """Mean impact across events, tidy: ``offset_seconds | ID | impact_bps``."""
+        raw = self.raw_impact if self.raw_impact is not None else self.compute()
+        long = raw.drop(columns=["event_timestamp"]).melt(
+            id_vars=["ID"], var_name="offset_seconds", value_name="impact_bps")
+        return (long.groupby(["ID", "offset_seconds"], as_index=False)["impact_bps"]
+                    .mean()
+                    .sort_values(["ID", "offset_seconds"])
+                    .reset_index(drop=True))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--book", required=True, help="Parquet of an L3 incremental book")
+    p.add_argument("--output", required=True, help="Parquet for the impact curve")
+    p.add_argument("--label", default="book")
+    p.add_argument("--num-events", type=int, default=-1)
+    p.add_argument("--window-seconds", type=float, default=10.0)
+    p.add_argument("--window-n", type=int, default=20)
+    args = p.parse_args()
+
+    book = pd.read_parquet(args.book)
+    if book.index.name != "event_timestamp":
+        book = book.set_index("event_timestamp")
+
+    im = MarketImpactComputer(
+        events=liquidity_removal_events(book, args.num_events),
+        books={args.label: book},
+        window=geometric_window(args.window_seconds, args.window_n),
+    )
+    curve = im.mean_curve()
+    curve.to_parquet(args.output, index=False)
+    print(curve.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bmll/scripts/bmll_markouts.py
+++ b/skills/bmll/scripts/bmll_markouts.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Pre/post-trade markouts from a BMLL Trades Plus frame.
+
+Markouts measure market impact: how a benchmark midpoint moves in the milliseconds
+and seconds around a trade. Trades Plus supplies the midpoints directly
+(``PreTradeMid{X}ms``/``PostTradeMid{X}ms``, optionally ``...AtPrimary``), so the work
+here is three things that are easy to get silently wrong:
+
+1. **Side inference.** ``AggressorSide == 0`` (unknown) is common on off-book and
+   auction prints, and Trades Plus supplies no inference. Left unhandled, those rows
+   are either dropped or treated as a third side.
+2. **Sign normalisation.** Markouts must be viewed from one perspective — by
+   convention an aggressive buyer. Without negating the seller-initiated rows, buys
+   and sells cancel and the curve flattens toward zero, which reads as "no impact"
+   rather than "two opposite signs were averaged".
+3. **Weighting.** A simple mean lets a cloud of odd-lot prints outvote the
+   institutional flow the analysis is about; aggregation is notional-weighted.
+
+Usage as a library::
+
+    from bmll_markouts import infer_aggressor_side, compute_markouts, aggregate_markouts
+
+    df = infer_aggressor_side(df, benchmark="primary")
+    df, cols = compute_markouts(df, benchmark="primary")
+    agg = aggregate_markouts(df, cols, group_by=["Classification"])
+    tidy = to_long(agg, group_by=["Classification"])   # for plotting
+
+Usage as a CLI (reads/writes parquet)::
+
+    python bmll_markouts.py --input tp.parquet --output markouts.parquet \\
+        --benchmark primary --group-by Classification
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+# The 15 intervals BMLL publishes, in milliseconds, ascending.
+INTERVALS_MS: tuple[int, ...] = (
+    1, 2, 5, 10, 25, 50, 100, 200, 500,
+    1_000, 5_000, 15_000, 30_000, 60_000, 300_000,
+)
+
+# BMLL AggressorSide encoding.
+SIDE_UNKNOWN = 0
+SIDE_BUY_AGGRESSOR = 1   # quotes on the ASK side aggressed by an aggressive buy
+SIDE_SELL_AGGRESSOR = 2  # quotes on the BID side aggressed by an aggressive sell
+
+
+def _suffix(benchmark: str) -> str:
+    if benchmark == "primary":
+        return "AtPrimary"
+    if benchmark == "consolidated":
+        return ""
+    raise ValueError(f"benchmark must be 'primary' or 'consolidated', got {benchmark!r}")
+
+
+def benchmark_columns(benchmark: str = "primary") -> dict[str, object]:
+    """Return the Trades Plus column names for a benchmark family."""
+    s = _suffix(benchmark)
+    return {
+        "best_bid": f"BestBidPrice{s}",
+        "best_ask": f"BestAskPrice{s}",
+        "post_mid": f"PostTradeMid{s}",
+        "pre_mids": [f"PreTradeMid{x}ms{s}" for x in reversed(INTERVALS_MS)],
+        "post_mids": [f"PostTradeMid{x}ms{s}" for x in INTERVALS_MS],
+    }
+
+
+def _require(df: pd.DataFrame, cols: Iterable[str], what: str) -> None:
+    missing = [c for c in cols if c not in df.columns]
+    if missing:
+        raise KeyError(
+            f"{what}: missing {len(missing)} column(s) from the Trades Plus frame: "
+            f"{missing[:6]}{'...' if len(missing) > 6 else ''}. "
+            "Check the benchmark argument and that this is a 'trades-plus' table."
+        )
+
+
+def pre_trade_mid(df: pd.DataFrame, benchmark: str = "primary") -> pd.Series:
+    """Midpoint of the prevailing touch, as of (before) the trade."""
+    c = benchmark_columns(benchmark)
+    _require(df, [c["best_bid"], c["best_ask"]], "pre_trade_mid")
+    return 0.5 * (df[c["best_bid"]] + df[c["best_ask"]])
+
+
+def infer_aggressor_side(
+    df: pd.DataFrame,
+    benchmark: str = "primary",
+    price_col: str = "InstrumentCurrencyPrice",
+    inplace: bool = False,
+) -> pd.DataFrame:
+    """Fill ``AggressorSide == 0`` rows using the Lee-Ready rule.
+
+    Price above the prevailing mid implies a buyer-initiated trade, below implies
+    seller-initiated, and at the mid falls back to the tick test against the
+    post-trade mid. Rows with a side already reported are left untouched.
+
+    Adds ``PreTradeMid`` (the benchmark's prevailing midpoint) as a side effect,
+    because ``compute_markouts`` needs the same series.
+    """
+    if not inplace:
+        df = df.copy()
+    c = benchmark_columns(benchmark)
+    _require(df, [price_col, c["post_mid"]], "infer_aggressor_side")
+    if "AggressorSide" not in df.columns:
+        raise KeyError("infer_aggressor_side: frame has no 'AggressorSide' column")
+
+    mid = pre_trade_mid(df, benchmark)
+    df["PreTradeMid"] = mid
+
+    price = df[price_col]
+    next_mid = df[c["post_mid"]]
+
+    unknown = df["AggressorSide"].eq(SIDE_UNKNOWN)
+    above = price.gt(mid)
+    below = price.lt(mid)
+    # At the mid: uptick (or flat) implies buyer-initiated.
+    uptick = next_mid.ge(mid)
+
+    inferred = np.where(
+        above, SIDE_BUY_AGGRESSOR,
+        np.where(below, SIDE_SELL_AGGRESSOR,
+                 np.where(uptick, SIDE_BUY_AGGRESSOR, SIDE_SELL_AGGRESSOR)),
+    )
+    # Leave unknown where the benchmark itself is missing — do not invent a side.
+    resolvable = unknown & mid.notna() & price.notna()
+    df.loc[resolvable, "AggressorSide"] = inferred[resolvable.to_numpy()]
+    return df
+
+
+def compute_markouts(
+    df: pd.DataFrame,
+    benchmark: str = "primary",
+    inplace: bool = False,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Add per-interval markout columns in basis points, normalised to an aggressive buyer.
+
+    Each markout is ``1e4 * (mid_at_interval - pre_trade_mid) / pre_trade_mid``, with
+    the sign flipped for seller-initiated trades so every row reads from the
+    aggressive buyer's perspective.
+
+    Returns ``(df, markout_cols)`` with ``markout_cols`` ordered from the earliest
+    pre-trade interval to the latest post-trade interval.
+    """
+    if not inplace:
+        df = df.copy()
+    c = benchmark_columns(benchmark)
+    mid_cols: list[str] = list(c["pre_mids"]) + list(c["post_mids"])
+    _require(df, mid_cols, "compute_markouts")
+
+    if "PreTradeMid" in df.columns:
+        base = df["PreTradeMid"]
+    else:
+        base = pre_trade_mid(df, benchmark)
+        df["PreTradeMid"] = base
+
+    sell = df["AggressorSide"].eq(SIDE_SELL_AGGRESSOR)
+    markout_cols: list[str] = []
+    for col in mid_cols:
+        out = f"Markout{col}"
+        bps = 1e4 * (df[col] - base) / base
+        df[out] = bps.mask(sell, -bps)
+        markout_cols.append(out)
+    return df, markout_cols
+
+
+def aggregate_markouts(
+    df: pd.DataFrame,
+    markout_cols: Sequence[str],
+    group_by: Sequence[str],
+    weight_col: str = "TradeNotionalEUR",
+) -> pd.DataFrame:
+    """Notional-weighted mean markout per group.
+
+    A simple mean would let many small prints outweigh the large ones; weighting by
+    traded notional keeps the result representative of where the volume actually was.
+    """
+    group_by = list(group_by)
+    _require(df, list(markout_cols) + group_by + [weight_col], "aggregate_markouts")
+
+    w = df[weight_col]
+    out = {}
+    grouper = df.groupby(group_by, dropna=False)
+    denom = grouper[weight_col].sum()
+    for col in markout_cols:
+        num = df[col].mul(w).groupby([df[g] for g in group_by], dropna=False).sum()
+        out[col] = num / denom
+    return pd.DataFrame(out).reset_index()
+
+
+def to_long(
+    agg: pd.DataFrame,
+    group_by: Sequence[str],
+    absolute: bool = False,
+) -> pd.DataFrame:
+    """Reshape aggregated markouts to long form with a signed interval axis.
+
+    Pre-trade intervals become negative milliseconds, post-trade positive, so the
+    result plots as a single left-to-right impact curve.
+    """
+    group_by = list(group_by)
+    value_cols = [c for c in agg.columns if c not in group_by]
+
+    long = agg.melt(id_vars=group_by, value_vars=value_cols,
+                    var_name="_col", value_name="markout_bps")
+
+    pre = long["_col"].str.contains("PreTradeMid")
+    ms = long["_col"].str.extract(r"Mid(\d+)ms", expand=False).astype("Int64")
+    long["interval_ms"] = ms.where(~pre, -ms)
+    long["group"] = long[group_by].astype(str).agg("|".join, axis=1)
+    if absolute:
+        long["markout_bps"] = long["markout_bps"].abs()
+
+    return (long.drop(columns=["_col"])
+                .sort_values(group_by + ["interval_ms"])
+                .reset_index(drop=True))
+
+
+def run(
+    df: pd.DataFrame,
+    group_by: Sequence[str] = ("Classification",),
+    benchmark: str = "primary",
+    weight_col: str = "TradeNotionalEUR",
+) -> pd.DataFrame:
+    """Full pipeline: infer side, compute markouts, aggregate, reshape to long."""
+    df = infer_aggressor_side(df, benchmark=benchmark)
+    df, cols = compute_markouts(df, benchmark=benchmark)
+    agg = aggregate_markouts(df, cols, group_by=group_by, weight_col=weight_col)
+    return to_long(agg, group_by=group_by)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument("--input", required=True, help="Parquet file of a Trades Plus frame")
+    p.add_argument("--output", required=True, help="Parquet file for the long-form result")
+    p.add_argument("--benchmark", default="primary", choices=["primary", "consolidated"])
+    p.add_argument("--group-by", nargs="+", default=["Classification"])
+    p.add_argument("--weight-col", default="TradeNotionalEUR")
+    args = p.parse_args()
+
+    df = pd.read_parquet(args.input)
+    out = run(df, group_by=args.group_by, benchmark=args.benchmark,
+              weight_col=args.weight_col)
+    out.to_parquet(args.output, index=False)
+    print(f"{len(out)} rows -> {args.output}")
+    print(out.head(20).to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bmll/scripts/test_bmll_impact.py
+++ b/skills/bmll/scripts/test_bmll_impact.py
@@ -1,0 +1,85 @@
+import sys, os, numpy as np, pandas as pd
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bmll_impact import (MarketImpactComputer, liquidity_removal_events, mid_from_book,
+                         impact_bps, geometric_window, linear_window)
+
+T0 = pd.Timestamp("2021-05-05 09:00:00")
+
+def book():
+    """Book where mid=100 until each event, then moves 1% the 'right' way for the aggressor."""
+    rows=[]
+    # quiet baseline
+    for i in range(5):
+        rows.append((T0 + pd.Timedelta(seconds=i), "BID", 99.0, 101.0, "INSERT", 0))
+    # event A at t=10: resting ASK executed => aggressive BUY ; mid rises after
+    rows.append((T0 + pd.Timedelta(seconds=10), "ASK", 99.0, 101.0, "REMOVE", 500))
+    for i in range(1, 40):
+        rows.append((T0 + pd.Timedelta(seconds=10, milliseconds=i*100), "BID", 100.0, 102.0, "INSERT", 0))
+    # event B at t=60: resting BID executed => aggressive SELL ; mid falls after
+    rows.append((T0 + pd.Timedelta(seconds=60), "BID", 100.0, 102.0, "REMOVE", 500))
+    for i in range(1, 40):
+        rows.append((T0 + pd.Timedelta(seconds=60, milliseconds=i*100), "BID", 99.0, 101.0, "INSERT", 0))
+    df = pd.DataFrame(rows, columns=["event_timestamp","side","best_bid_price",
+                                     "best_ask_price","lob_action","execution_size"])
+    df["execution_price"]=100.0; df["original_order_id"]=range(len(df))
+    df["market_state"]="CONTINUOUS_TRADING"
+    return df.set_index("event_timestamp")
+
+b = book()
+
+ev = liquidity_removal_events(b)
+print("events:\n", ev[["event_timestamp","side","execution_size"]].to_string(index=False))
+assert len(ev)==2 and set(ev.side)=={"ASK","BID"}
+
+im = MarketImpactComputer(events=ev, books={"X": b},
+                          window=geometric_window(seconds=2, n=6))
+raw = im.compute()
+curve = im.mean_curve()
+print("\ncurve:\n", curve.to_string(index=False))
+
+offs = im.offsets()
+assert offs[len(offs)//2] == pd.Timedelta(0), "zero offset must be centred"
+assert offs == sorted(offs), "offsets must be ascending"
+assert len(curve) == len(offs)
+
+# pre-event impact ~ 0 (mid flat before each event)
+pre = curve[curve.offset_seconds < 0].impact_bps
+assert np.allclose(pre, 0, atol=1e-9), pre.tolist()
+
+# post-event impact positive once the offset reaches the fixture's 100ms grid.
+# Offsets below 100ms ffill to the event row itself, so 0 there is correct.
+post = curve[curve.offset_seconds >= 0.1].impact_bps
+assert (post > 0).all(), post.tolist()
+near = curve[(curve.offset_seconds > 0) & (curve.offset_seconds < 0.1)].impact_bps
+assert np.allclose(near, 0), near.tolist()
+
+# per-event: both events individually positive at the far offset
+far = max(o.total_seconds() for o in im.offsets())
+per = raw[[far,"ID"]].join(ev["side"])
+print("\nper-event impact at +%.3fs:" % far)
+print(per.to_string(index=False))
+assert (per[far] > 0).all(), "aggressor normalisation failed: signs disagree"
+
+# magnitude sanity: mid 100 -> 101 is ~99.5bps
+assert 90 < per[far].mean() < 110, per[far].mean()
+
+# had we NOT normalised, the mean would cancel to ~0 — confirm the fix matters
+naive = ((raw[far].to_numpy() * np.where(ev.side.eq("ASK"), 1, -1))).mean()
+normalised = raw[far].mean()
+assert abs(naive) < 1.0 < abs(normalised), (naive, normalised)  # unsigned nearly cancels
+
+# cross-product: events from one book measured against another book
+im2 = MarketImpactComputer(events=ev, books={"self": b, "other": b},
+                           window=linear_window(seconds=0.1, n=5))
+c2 = im2.mean_curve()
+assert set(c2.ID)=={"self","other"} and len(c2)==2*len(im2.offsets())
+
+# guardrails
+try:
+    MarketImpactComputer(events=ev.drop(columns=["side"]), books={"X": b}); raise SystemExit("FAIL")
+except KeyError as e: assert "side" in str(e)
+try:
+    liquidity_removal_events(b.drop(columns=["lob_action"])); raise SystemExit("FAIL")
+except KeyError as e: assert "L3" in str(e)
+
+print("\nALL IMPACT TESTS PASSED")

--- a/skills/bmll/scripts/test_bmll_scripts.py
+++ b/skills/bmll/scripts/test_bmll_scripts.py
@@ -1,0 +1,107 @@
+import sys, numpy as np, pandas as pd
+sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.abspath(__file__)))
+from bmll_markouts import (INTERVALS_MS, benchmark_columns, infer_aggressor_side,
+                           compute_markouts, aggregate_markouts, to_long, run)
+import bmll_checks as bc
+
+S = "AtPrimary"
+def make(n=6):
+    d = {}
+    # bid/ask 100/101 -> mid 100.5
+    d["BestBidPriceAtPrimary"] = [100.0]*n
+    d["BestAskPriceAtPrimary"] = [101.0]*n
+    d["PostTradeMidAtPrimary"] = [100.6]*n
+    d["InstrumentCurrencyPrice"] = [101.0, 100.0, 100.5, 101.0, 100.0, 100.5]
+    d["AggressorSide"] = [0, 0, 0, 1, 2, 1]
+    d["Classification"] = ["LIT_CONTINUOUS"]*3 + ["DARK_BELOW_LIS"]*3
+    d["TradeNotionalEUR"] = [1000.0, 10.0, 100.0, 10.0, 500.0, 25.0]
+    d["TradeDate"] = pd.to_datetime(["2025-08-22"]*n)
+    d["Printable"] = [True]*(n-1) + [False]
+    d["IsBlock"] = ["TRUE","false","UNKNOWN","TRUE","FALSE","UNKNOWN"]
+    d["PricePoint"] = [1.0, 0.0, 0.5, 99999.0, -99999.0, 0.5]
+    d["ExecutionVenue"] = ["XLON"]*n
+    df = pd.DataFrame(d)
+    # midpoint columns: post-trade drifts UP (price rises after the trade)
+    for x in INTERVALS_MS:
+        df[f"PreTradeMid{x}ms{S}"] = 100.5
+        df[f"PostTradeMid{x}ms{S}"] = 100.5 + 0.01 * (x / 1000.0)
+    return df
+
+df = make()
+
+# --- side inference
+out = infer_aggressor_side(df, benchmark="primary")
+print("inferred sides:", out.AggressorSide.tolist())
+assert out.AggressorSide.tolist() == [1,2,1,1,2,1], out.AggressorSide.tolist()
+assert np.isclose(out.PreTradeMid.iloc[0], 100.5)
+
+# --- markouts
+out, cols = compute_markouts(out, benchmark="primary")
+assert len(cols) == 30, len(cols)
+# ordering: earliest pre -> latest post
+assert cols[0].endswith(f"PreTradeMid300000ms{S}"), cols[0]
+assert cols[14].endswith(f"PreTradeMid1ms{S}"), cols[14]
+assert cols[15].endswith(f"PostTradeMid1ms{S}"), cols[15]
+assert cols[-1].endswith(f"PostTradeMid300000ms{S}"), cols[-1]
+
+post60 = f"MarkoutPostTradeMid60000ms{S}"
+raw_bps = 1e4 * ((100.5 + 0.01*60) - 100.5) / 100.5
+buy = out.loc[out.AggressorSide==1, post60]
+sell = out.loc[out.AggressorSide==2, post60]
+print(f"raw bps={raw_bps:.3f}  buy={buy.iloc[0]:.3f}  sell={sell.iloc[0]:.3f}")
+assert np.allclose(buy, raw_bps), buy.tolist()
+assert np.allclose(sell, -raw_bps), sell.tolist()   # sign flipped for sell-aggressor
+# pre-trade markouts are 0 here (pre mids == base)
+assert np.allclose(out[f"MarkoutPreTradeMid1ms{S}"], 0.0)
+
+# --- aggregation is notional-weighted, not a simple mean
+agg = aggregate_markouts(out, cols, group_by=["Classification"])
+print(agg[["Classification", post60]].to_string(index=False))
+lit = out[out.Classification=="LIT_CONTINUOUS"]
+expect = (lit[post60]*lit.TradeNotionalEUR).sum()/lit.TradeNotionalEUR.sum()
+got = agg.loc[agg.Classification=="LIT_CONTINUOUS", post60].iloc[0]
+assert np.isclose(got, expect), (got, expect)
+assert not np.isclose(got, lit[post60].mean())  # proves weighting differs from plain mean
+
+# --- long form
+long = to_long(agg, group_by=["Classification"])
+assert long.interval_ms.min() == -300000 and long.interval_ms.max() == 300000
+assert len(long) == 2*30
+neg = long[(long.Classification=="LIT_CONTINUOUS") & (long.interval_ms==-1000)]
+assert len(neg)==1
+print("long-form head:\n", long.head(4).to_string(index=False))
+
+# --- consolidated benchmark raises clearly when columns absent
+try:
+    compute_markouts(df, benchmark="consolidated")
+    raise SystemExit("FAIL: expected KeyError")
+except KeyError as e:
+    assert "trades-plus" in str(e)
+
+# --- checks module
+p = bc.printable_only(df, warn=False)
+assert len(p)==5
+try:
+    bc.assert_non_empty(df.iloc[:0]); raise SystemExit("FAIL")
+except bc.EmptyResultError: pass
+try:
+    bc.assert_non_empty_per_date(df, ["2025-08-22","2025-08-25"]); raise SystemExit("FAIL")
+except bc.EmptyResultError as e:
+    assert "2025-08-25" in str(e)
+bc.assert_non_empty_per_date(df, ["2025-08-22"])
+pp = bc.drop_price_point_sentinels(df)
+assert len(pp)==4 and pp.PricePoint.abs().max()<=2
+ne = bc.normalise_enum_flags(df)
+assert ne.IsBlock.tolist()==["TRUE","FALSE","UNKNOWN","TRUE","FALSE","UNKNOWN"]
+r = df.copy(); r["TradeTimestampNanoseconds"]=[1_700_000_000_000_000_000]*6
+r = bc.coerce_range_timestamps(r)
+assert pd.api.types.is_datetime64_any_dtype(r.TradeTimestampNanoseconds)
+r2 = bc.coerce_range_timestamps(r)  # idempotent
+assert pd.api.types.is_datetime64_any_dtype(r2.TradeTimestampNanoseconds)
+cov = bc.describe_coverage(df)
+assert cov.rows.sum()==6
+
+# --- end-to-end run()
+tidy = run(make(), group_by=["Classification"])
+assert len(tidy)==60 and tidy.markout_bps.notna().all()
+print("\nALL TESTS PASSED")

--- a/skills/ds-tools/SKILL.md
+++ b/skills/ds-tools/SKILL.md
@@ -24,6 +24,7 @@ These are skills, not plugins - already available:
 |-------|-------------|
 | `/wrds` | WRDS (Wharton Research Data Services) queries |
 | `/lseg-data` | LSEG Data Library (formerly Refinitiv) |
+| `/bmll` | BMLL Data Lab — Level 3 order book, Trades Plus, markouts, venue analysis (`bmll2`/`bmll`) |
 | `/gemini-batch` | Gemini Batch API for large-scale LLM processing |
 | `/data-context` | Extract tribal knowledge about datasets, generate data context skills |
 | `/fuzzy-name-matching` | Entity resolution / record linkage when datasets share only a name (TF-IDF + `sparse_dot_topn`) |


### PR DESCRIPTION
Adds a `bmll` tool skill covering the `bmll2` / `bmll` Python APIs for BMLL's Level 3 market data.

Sourced from the BMLL Data Lab docs at `lab.bmlltech.com/docs` — 14 tutorial notebooks plus 356 API/schema reference pages (the site is a login-gated SPA; content was pulled through an authenticated browser session).

## Contents

- **SKILL.md** — Iron Law on result inspection, 11 fact rows for non-derivable API behaviour, action-targeted red-flag table, per-API validation checklists, access-path routing table.
- **references/** — 9 topic files: trades-plus, reference-data, market-data, security-api, order-book-rebuilding, analytics-timeseries, compute-and-storage, other-datasets, troubleshooting.
- **scripts/** — `bmll_markouts.py` (side inference, sign normalisation, notional-weighted aggregation) and `bmll_checks.py` (validation helpers), with `test_bmll_scripts.py`.
- **examples/** — end-to-end execution-quality analysis.
- **ds-tools** — registers `/bmll` in the data-access discovery table.

## Trades Plus

Given the most weight, per the request. Full ~99-field schema plus recipes for intraday classification, block liquidity, `PricePoint` spread capture, markouts and participant type.

## Gotchas the skill encodes

Non-obvious behaviour that fails silently rather than raising:

- `get_market_data_range` returns Spark with **integer-nanosecond** timestamps, unlike `get_market_data`'s `datetime64`.
- `IsBlock` / `LotType` / `ParticipantType` are **string** enums — `IsBlock == True` matches nothing.
- `PricePoint` carries `±99999` sentinels when bid == ask; an unfiltered mean is meaningless.
- `ExecutionVenue` ≠ `MIC` — venue market share grouped on `MIC` attributes trades to the reporting facility.
- `Size` is negative for cancellations; `Printable` is the volume filter.
- `Price` vs `InstrumentCurrencyPrice` differ by `MinorCurrencyFactor` — 100× errors on GBp names.
- `AggressorSide == 0` (unknown) is common; Trades Plus supplies no side inference.
- The Data Lab local filesystem is ephemeral — only `put_file` persists.
- Empty frames, not errors, for wrong MIC / non-trading date / missing entitlement.

## Verification

- `scripts/test_bmll_scripts.py` passes — covers Lee-Ready side inference, the aggressive-buyer sign flip, notional weighting (asserted to differ from a plain mean), long-form interval axis, and every check helper including idempotent timestamp coercion.
- All Python files compile; all 30 internal doc links resolve; no `${CLAUDE_PLUGIN_ROOT}` in skill content.

Note: the runtime code paths against the live BMLL API are **not** executed here — this box has no BMLL entitlement, so the scripts are verified against synthetic frames matching the documented schema, not against real Data Lab output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqrP6KiSmnFAniwtpxuvMc