### PR TITLE
feat(skills): add bmll skill as a private submodule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.77.1"
+    "version": "5.78.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.77.1",
+      "version": "5.78.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.77.1",
+  "version": "5.78.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "skills/marimo/marimo-pair"]
 	path = skills/marimo/marimo-pair
 	url = https://github.com/marimo-team/marimo-pair.git
+[submodule "skills/bmll"]
+	path = skills/bmll
+	url = git@github.com:edwinhu/bmll-skill.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [5.78.0] - 2026-07-24
+
+### Added
+- **`bmll` skill — BMLL Data Lab** (`bmll2` / `bmll` Python APIs over BMLL's Level 3 market data), as a **private submodule** at `skills/bmll` pointing at [`edwinhu/bmll-skill`](https://github.com/edwinhu/bmll-skill). Covers Trades Plus, reference data, whole-market and per-listing access, order-book rebuilding, event-time market impact, retail flow, Data Feed analytics, compute/storage, per-venue datasets and the schema layer — 14 reference files, tested helper scripts, and a worked execution-quality example.
+  - **Private deliberately.** The reference material is derived from BMLL's login-gated documentation — schema field descriptions, enum and MMT value tables, the classified-trade taxonomy, per-venue detail — and the submodule vendors the 23 tutorial notebooks and 445 extracted doc pages as the provenance record, since the source cannot be re-fetched without an authenticated session. That content is licensed to the account holder and is not ours to republish from a public marketplace. Field names, types, MIC codes and enum *values* are facts; the prose and notebook code are BMLL's expression.
+  - **Consequence, intended:** installing this plugin without access to `edwinhu/bmll-skill` yields an empty `skills/bmll` and no `bmll` skill. The plugin installer does recurse submodules (verified against the existing `skills/marimo/marimo-pair` and `external/anthropic-skills`, both fully populated in the plugin cache), so it resolves normally for those with access.
+  - `ds-tools` registers `/bmll` in the data-access table with the access requirement noted.
+  - The two helper scripts exist because the logic is deterministic and fails silently when hand-rolled: markout sign normalisation (buy- and sell-initiated impact cancel to ~0 without it) and event-time impact. Both are covered by tests against synthetic frames built to the documented schema — **the live BMLL API is not exercised**, so API behaviour and entitlement handling remain unverified against reality.
+
 ## [5.77.1] - 2026-07-23
 
 ### Fixed

--- a/skills/ds-tools/SKILL.md
+++ b/skills/ds-tools/SKILL.md
@@ -24,6 +24,7 @@ These are skills, not plugins - already available:
 |-------|-------------|
 | `/wrds` | WRDS (Wharton Research Data Services) queries |
 | `/lseg-data` | LSEG Data Library (formerly Refinitiv) |
+| `/bmll` | BMLL Data Lab — Level 3 order book, Trades Plus, markouts, venue analysis (`bmll2`/`bmll`). Private submodule; needs access to `edwinhu/bmll-skill` |
 | `/gemini-batch` | Gemini Batch API for large-scale LLM processing |
 | `/data-context` | Extract tribal knowledge about datasets, generate data context skills |
 | `/fuzzy-name-matching` | Entity resolution / record linkage when datasets share only a name (TF-IDF + `sparse_dot_topn`) |


### PR DESCRIPTION
Adds the **BMLL Data Lab** skill (`bmll2` / `bmll` Python APIs over BMLL's Level 3 market data) as a git submodule at `skills/bmll`, pointing at the private repo **[`edwinhu/bmll-skill`](https://github.com/edwinhu/bmll-skill)**.

Supersedes #72, which is closed and its branch deleted — see [Why private](#why-private).

## What this PR changes

Three files. No BMLL-derived content enters this repository.

- `.gitmodules` — new `skills/bmll` submodule
- `skills/bmll` — gitlink pinned at `4f6593a`
- `skills/ds-tools/SKILL.md` — registers `/bmll` in the data-access discovery table, noting the access requirement

## Why private

The skill's reference material is derived from BMLL's **login-gated** documentation: schema field descriptions, enum and MMT value tables, the classified-trade taxonomy, and per-venue dataset detail. It also vendors the 23 tutorial notebooks and 445 extracted doc pages under `vendor/`, because the source cannot be re-fetched without an authenticated session and that archive is the provenance record for every claim in the reference files.

That content is licensed to the BMLL account holder. Publishing it from a public plugin marketplace is not ours to do. Field names, types, MIC codes and enum *values* are facts; the descriptive prose and notebook code are BMLL's expression, and the skill contains a lot of the latter.

**Intended consequence:** anyone installing this plugin without access to `edwinhu/bmll-skill` gets an empty `skills/bmll` directory and no `bmll` skill. Verified that the plugin installer *does* populate submodule content (the existing `skills/marimo/marimo-pair` and `external/anthropic-skills` submodules are fully populated in `~/.claude/plugins/cache/`), so it resolves normally for those with access.

## What's in the submodule

| | |
|---|---|
| `SKILL.md` | Iron Law on result inspection, fact rows for non-derivable API behaviour, red-flag table, validation checklists, routing |
| `references/` | 14 topic files — trades-plus, schemas, venues, reference-data, market-data, security-api, order-book-rebuilding, market-impact, retail, analytics-timeseries, compute-and-storage, other-datasets, advanced-tutorials, troubleshooting |
| `scripts/` | Tested helpers: Trades Plus markouts, event-time market impact, validation |
| `examples/` | End-to-end execution-quality analysis |
| `vendor/` | 23 notebooks + 445 doc pages (provenance) |

## Verification

- `skills/bmll` is a gitlink (`160000`), not a tree; the staged diff against `main` contains no BMLL schema text
- Submodule populates on `git submodule update --init` and the plugin cache mechanism recurses submodules
- Both test files in the submodule pass; all internal links resolve

Tests use synthetic frames built to the documented schema — **the live BMLL API is not exercised**, as there is no entitlement on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqrP6KiSmnFAniwtpxuvMc