### PR TITLE
test(wrds): ownership data-quality detectors grounded in WRDS research notes

### DIFF
--- a/skills/wrds/SKILL.md
+++ b/skills/wrds/SKILL.md
@@ -342,7 +342,8 @@ Detailed query patterns and table documentation:
 - **`references/execucomp.md`** - ExecuComp: CEO anncomp, legacy codirfin vs current directorcomp, firm-year aggregation
 - **`references/iss-directors.md`** - ISS Directors: risk.directors + risk.rmdirectors, type harmonization, 1996 gender backfill, S&P 1500 filter
 - **`references/iss-voting.md`** - ISS Voting Analytics: vavoteresults, voteanalysis_npx, base-conditional turnout/forpct, agenda codes
-- **`references/tfn-ownership.md`** - Thomson 13-F (S34) institutional ownership and S12 mutual-fund holdings via MFLINKS, passive/index classification
+- **`references/tfn-ownership.md`** - Thomson 13-F (S34) institutional ownership and S12 mutual-fund holdings via MFLINKS, passive/index classification, and **Known Data Defects** (WRDS research notes D1-D7: split mis-adjustment, post-2013 coverage collapse, 2017Q4 S12 feed change, 13F value unit break). Read the defects section before trusting any split-era or post-2013 quarter.
+  - Detectors: `scripts/ownership_dq.py` — run these against any holdings panel before analysis. Tests: `tests/ownership_dq_test.py`.
 - **`references/lpc-dealscan.md`** - LPC DealScan: legacy vs 2021+ flat schema, borrower ids, the gvkey link and its grain caveats
 - **`references/muni-bonds.md`** - Municipal bonds: MSRB RTRS trades, SDC municipals
 - **`references/wrds-forms-tables.md`** - `wrdssec_all.wrds_forms` and friends: filing metadata tables and their columns

--- a/skills/wrds/SKILL.md
+++ b/skills/wrds/SKILL.md
@@ -343,7 +343,7 @@ Detailed query patterns and table documentation:
 - **`references/iss-directors.md`** - ISS Directors: risk.directors + risk.rmdirectors, type harmonization, 1996 gender backfill, S&P 1500 filter
 - **`references/iss-voting.md`** - ISS Voting Analytics: vavoteresults, voteanalysis_npx, base-conditional turnout/forpct, agenda codes
 - **`references/tfn-ownership.md`** - Thomson 13-F (S34) institutional ownership and S12 mutual-fund holdings via MFLINKS, passive/index classification, and **Known Data Defects** (WRDS research notes D1-D7: split mis-adjustment, post-2013 coverage collapse, 2017Q4 S12 feed change, 13F value unit break). Read the defects section before trusting any split-era or post-2013 quarter.
-  - Detectors: `scripts/ownership_dq.py` — run these against any holdings panel before analysis. Tests: `tests/ownership_dq_test.py`.
+  - Detectors: `scripts/ownership_dq.py` (10 detectors, S12 and S34) — run these against any holdings panel before analysis. Tests: `tests/ownership_dq_test.py`.
 - **`references/lpc-dealscan.md`** - LPC DealScan: legacy vs 2021+ flat schema, borrower ids, the gvkey link and its grain caveats
 - **`references/muni-bonds.md`** - Municipal bonds: MSRB RTRS trades, SDC municipals
 - **`references/wrds-forms-tables.md`** - `wrdssec_all.wrds_forms` and friends: filing metadata tables and their columns

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -462,10 +462,16 @@ dedup inflation** at the source, rather than detecting them after the fact.
 
 `report_dt` is monthly, but **not every fund reports every month**. From the AAPL check:
 quarter-end months carry ~1,600 funds, intermediate months ~1,140 — roughly **40% more
-funds at quarter-ends**. Mixing them into one series manufactures a fake seasonal pattern
-of exactly the kind this file exists to catch (`detect_seasonal_alternation` fires on it,
-correctly).
+funds at quarter-ends** — and total shares run ~1.2–1.4× higher at quarter-ends as a
+result.
 
+That is a *benign cadence effect*, not a defect, and `detect_seasonal_alternation` does
+**not** flag it at the 1.5× default — correctly, since alarming on N-PORT's reporting
+rhythm would cry wolf on every fund panel. (Lower `ratio_threshold` to ~1.3 and it becomes
+visible.) The contrast is the point: the Thomson defect runs **4.5×**, far above this, so
+one default cleanly separates a real defect from normal cadence.
+
+It is still large enough to contaminate a regression that mixes cadences.
 **Filter to quarter-end months for a quarterly panel.** Do not treat intermediate months
 as comparable observations.
 

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -596,6 +596,35 @@ accuracy measured only on funds that bridge is 92.4% at 0.90 — but every fund 
 true match by construction, so that figure cannot transfer to a population where most
 funds have none. The negative control is what makes the precision estimate honest.
 
-At 0.80 this resolves ~1,438 of 4,653 ambiguous funds, cutting union exposure from ~7.7%
-to ~5.3%. A real improvement, not a solution — the remainder still needs the
-`s12_ambiguous` bucket and `detect_unresolved_overlap`.
+⚠️ **These are *implied* precisions, and implied is not end-to-end.** The negative control
+proves a match is not spurious; it does **not** prove the match went to the *right* fund.
+End-to-end ("combined") precision is `implied × top-1 accuracy`, and the follow-up
+investigation measured top-1 directly: at thr 0.80 the direct-to-`portnomap` route has
+top-1 accuracy ~0.92, so combined precision is **~0.89, not ~0.96**. Quote combined
+precision when deciding whether to admit a match.
+
+**Superseded — use the SEC series-ID route instead.** Routing the name match through the
+SEC's published series universe (then `series_cik → crsp_fundno` via `crsp_cik_map`)
+resolves **4.5× more of the ambiguous set at equal precision**: 26.5% vs 5.9% at combined
+precision ~0.95, replicated at 2017. It is still fuzzy at the first hop — S12 has no CIK
+or usable ticker, so no exact key exists — and the gain comes from **grain alignment**:
+SEC series names sit at portfolio grain, the same grain as an S12 fund, whereas
+`portnomap.fund_name` is share-class grain. Ambiguous mass falls 7.72% → 5.70%.
+
+See `docs/investigations/2026-07-26_mflinks-rebuild.md` and
+`skills/wrds/scripts/mflinks_sec_bridge.py` (PR #78). Holdings-content matching was tested
+and **rejected**: it plateaus at 79% top-1 — a portfolio is not a fingerprint.
+
+### ⚠️ Resolving a fund is not the same as being allowed to add it
+
+**27.4% of newly-resolved funds land on a `crsp_portno` that another bridged `fundno`
+already claims.** That is a live double-count: two S12 `fundno`s pointing at one CRSP
+portfolio, either because the resolution is wrong or because Thomson carries the same
+portfolio twice (share classes, or duplicate records — cf. D5b).
+
+So the bridge needs a **claim check**, not just a match score. After resolving, group by
+`crsp_portno` and assert one `fundno` per portfolio per period; on collision, keep the
+higher-confidence link and push the loser back to `s12_ambiguous` rather than admitting
+both. Verify with `detect_duplicate_grain(grain=("crsp_portno", "rdate"))` on the resolved
+map — a bridge that raises coverage while quietly doubling portfolios is worse than no
+bridge at all.

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -566,3 +566,36 @@ Point it **only at the ~4,649 US-domiciled unbridged funds**, matching
 `s12type1.fundname` / `mflink2.fundname_full` against `portnomap.fund_name` + `mgmt_name`.
 That is a small, high-value problem: every fund it resolves moves a row out of
 `s12_ambiguous` and shrinks the union's error term. See the `fuzzy-name-matching` skill.
+
+### Fuzzy name matching: calibrated, and worth doing
+
+Use **`S12_Full_Fund_Names`** (the `S12_Names_20250630.xlsx` on the WRDS index page:
+`FUNDNO, START_DATE, END_DATE, FUNDNAME`, ~238K date-bounded rows), **not**
+`s12type1.fundname`. The latter is truncated to 24 chars and abbreviated; the xlsx carries
+the full and sometimes wholly different canonical name. It covers **95.1%** of the
+ambiguous funds and is strictly longer for **92.0%** of them:
+
+| `s12type1.fundname` | xlsx `FUNDNAME` |
+|---|---|
+| `FIDELITY CNDN GROWTH CO` | `FIDELITY CANADIAN GROWTH COMPANY FUND` |
+| `HERZFELD CARIBBEAN BAS F` | `HERZFELD CARIBBEAN BASIN FUND INCORPORATED` |
+| `DIVERSIFIED INV-BALANCED` | `TRANSAMERICA PARTNERS BALANCED PORTFOLIO` |
+
+Calibration at 2022-12-31 — char_wb 2-4gram TF-IDF + cosine, top-1, against
+`portnomap.fund_name` (55,213 candidates), with **non-US unbridged funds as a negative
+control** (they bridge at 0.3%, so a "match" there is a false positive):
+
+| Threshold | False-positive rate | Ambiguous resolved | Implied precision |
+|---|---|---|---|
+| 0.70 | 3.9% | 51.3% | ~92% |
+| **0.80** | **1.2%** | **32.5%** | **~96%** |
+| 0.90 | 0.4% | 13.7% | ~97% |
+
+**Always calibrate against a negative control, not against ground truth alone.** Top-1
+accuracy measured only on funds that bridge is 92.4% at 0.90 — but every fund there has a
+true match by construction, so that figure cannot transfer to a population where most
+funds have none. The negative control is what makes the precision estimate honest.
+
+At 0.80 this resolves ~1,438 of 4,653 ambiguous funds, cutting union exposure from ~7.7%
+to ~5.3%. A real improvement, not a solution — the remainder still needs the
+`s12_ambiguous` bucket and `detect_unresolved_overlap`.

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -258,9 +258,19 @@ breaks. Documented failure modes:
 | Adjustment at the wrong date | MasterCard shares adjusted at 2013-12-31, before the 2014-01-21 ex-date | adjust at ex-date |
 | Compounded on carry-forward | stale rows re-adjusted each vintage | adjust once |
 
-Magnitude, from the note: outlier rates in ΔOwnership around split quarters run
-**13.8% at Qtr(0) and 14.1% at Qtr(−1) for 13Fs** against a 5% null — and scale with
-split size: **32.4% at split factor 4, 34.5% above 4**. The note's own tests rule out the
+**This is primarily an S12 finding.** Every worked example in the note is drawn from
+mutual-fund data — "These cases are selected from Mutual Fund data, though the 13F data
+demonstrate similar patterns" — and funds fare *worse* than 13Fs at large splits:
+
+| Split factor | Mutual funds | 13F |
+|---|---|---|
+| 2 | 12.2% | 13.3% |
+| 3 | 15.2% | 14.8% |
+| 4 | 35.1% | 32.4% |
+| >4 | **40.7%** | 34.5% |
+
+Around split quarters generally, outlier rates run **13.8% at Qtr(0) and 14.1% at Qtr(−1)
+for 13Fs** (12.9% / 11.5% for funds) against a 5% null. The note's own tests rule out the
 obvious explanations: restricting to `rdate == fdate` (no carry-forwards) does *not*
 help, and neither does restricting to splits whose ex-date and record date share a
 quarter.
@@ -351,6 +361,22 @@ Factset or CRSP to identify US equity funds over that window.
 
 This corroborates the measured MFLINKS bridge-rate cliff (§Common Gotchas #12: ~77%
 pre-2017 → ~58–66% after).
+
+→ Detectors: `detect_coverage_step` (counts step while values do not — the signature of a
+feed migration, and it fires in both directions so it also catches the 2019Q3–Q4 S34
+contraction) and `detect_bridge_rate_regression` (a join that quietly stops matching).
+
+### D5b. S12 duplicate reporting
+
+The June 2018 note attributes the 2014 mutual-fund ownership blip (29% → 35% → 30%) to
+funds being **listed twice**. Separately, `fundno` is frequently a *share-class*
+identifier rather than a fund: one `wficn` maps to a mean ~3.5 `crsp_fundno`, so
+deduplicating on the wrong key inflates `MF_TOTAL` by **~3.95×** (§Common Gotchas #6).
+Both are the same class of defect — a grain that is not unique where the code assumes it
+is — and neither is visible in a spot check.
+
+→ Detector: `detect_duplicate_grain`, which reports the resulting inflation factor rather
+than just a duplicate count.
 
 ### D6. 13F `value` units change at 2023Q1 — measured, NOT documented by WRDS
 

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -486,3 +486,83 @@ Never compare levels across 2017Q4 if Thomson is in the series (D5). Cross-check
 Thomson against CRSP over the overlap is worthwhile, but expect a gap rather than a
 match: per the Jan 2023 note, CRSP sources monthly N-PORT while Thomson sources quarterly
 N-Q/N-CSR, so holdings "should be close, but not exact."
+
+---
+
+## Coalescing S12 into `crsp.holdings` at the holding level
+
+Use `crsp.holdings` as primary and Thomson S12 as *additive* coverage, merged at the
+individual fund-holding grain. Aggregate-level coalescing is not safe — the two sources
+differ in share units (D1), fund population, and filing basis, so a filled series
+confounds source with signal.
+
+### The bridge is the constraint, and it is not fixable by better identifiers
+
+S12 `fundno` → `crsp_portno` (via `mflink2` → `mflink1` → `portnomap`), measured:
+
+| Quarter | S12 funds | Bridged | Rate |
+|---|---|---|---|
+| 2010-12-31 | 7,494 | 3,647 | 48.7% |
+| 2016-12-31 | 14,427 | 4,982 | 34.5% |
+| 2022-12-31 | 60,136 | 7,325 | **12.2%** |
+
+**Thomson S12 carries no CIK** — there is no SEC identifier anywhere in the
+`tr_mutualfunds` schema, so a CIK bridge is impossible. The only exact alternative key is
+`s12type8.fticker`, and it is a dead end twice over: the table **ends 2018-12-31**, and
+where it does exist it is almost entirely redundant with MFLINKS:
+
+| Quarter | MFLINKS | Ticker | **Incremental** | Combined |
+|---|---|---|---|---|
+| 2010-12-31 | 48.7% | 38.3% | **+17 funds** | 48.9% |
+| 2016-12-31 | 34.5% | 19.1% | **+71 funds** | 35.0% |
+| 2018-12-31 | 15.7% | 6.6% | **+218 funds** | 16.2% |
+
+That redundancy is the important result: **the unbridged mass is not unbridged for want
+of an identifier — those funds are simply not in CRSP.** Expect fuzzy name matching to
+fail for the same reason, and scope it accordingly (below).
+
+### The 12% headline is misleading — split by domicile
+
+| 2022-12-31 | Funds | Bridged | Unbridged |
+|---|---|---|---|
+| non-US | 48,355 | **0.3%** | 48,210 — CRSP never covered these; **safe to add** |
+| US | 11,829 | **60.7%** | **4,649 — genuinely ambiguous** |
+
+(2016-12-31: non-US 2.0% bridged; US 78.5%, 1,321 ambiguous.)
+
+True double-count exposure is **~7.7% of funds**, not 88%.
+
+### Recipe
+
+Classify every S12 fund into exactly one of three buckets, then merge:
+
+| Bucket | Rule | Action |
+|---|---|---|
+| `crsp` | bridges to a `crsp_portno` | take the **CRSP** holding — as-reported shares, `permno` pre-mapped |
+| `s12_additive` | unbridged **and** positively CRSP-excluded (non-US `country`, closed-end, VA separate account, UCITS) | take the **Thomson** holding |
+| `s12_ambiguous` | unbridged, US-domiciled, no positive classification | **exclude by default; report the mass** |
+
+Non-negotiables:
+
+1. **Normalize share units before merging, never after.** CRSP is as-reported; Thomson is
+   pre-adjusted to FDATE and wrongly so (D1). Apply `cfacshr` yourself, once, to the
+   merged column. Merging raw `shares` mixes units inside one column and manufactures the
+   exact discontinuity `detect_unit_discontinuity` exists to catch.
+2. **Winsorize split quarters on `source='s12'` rows only.** D1 is a Thomson defect; CRSP
+   rows do not need it and winsorizing them discards real data.
+3. **Dedup after bridging, at the `wficn`/`crsp_portno` grain — never `fundno`.** One
+   `wficn` maps to a mean ~3.5 `crsp_fundno`; the wrong key inflates ~3.95× (D5b).
+   Verify with `detect_duplicate_grain`.
+4. **Carry a `source` column into the output.** A merged panel that cannot say where each
+   row came from cannot be audited, and every check below needs it.
+
+→ Guard: `detect_unresolved_overlap` reports the ambiguous mass and fails above 5%. Run it
+per period — exposure grows over time as S12's non-US population expands.
+
+### Where fuzzy name matching is worth it
+
+Not against all 48K unbridged funds — they are not in CRSP and no matcher will find them.
+Point it **only at the ~4,649 US-domiciled unbridged funds**, matching
+`s12type1.fundname` / `mflink2.fundname_full` against `portnomap.fund_name` + `mgmt_name`.
+That is a small, high-value problem: every fund it resolves moves a row out of
+`s12_ambiguous` and shrinks the union's error term. See the `fuzzy-name-matching` skill.

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -414,3 +414,69 @@ of a few percent, filer counts monotone, and the 2020 4:1 split appearing exactl
 correctly unadjusted (2.59bn → 9.70bn at 2020Q3). The defect is Thomson's, not the
 concept's. Thomson's remaining advantage is history: it starts 1980, EDGAR electronic
 filings start 1999 and XML only in 2013.
+
+
+---
+
+## The S12 alternative: `crsp.holdings` (verified on the WRDS grid)
+
+**S12 does not need an EDGAR/N-PORT parser.** WRDS already carries CRSP Mutual Fund
+portfolio holdings, and it dominates Thomson S12 on every axis that matters. Verified
+directly against `crsp_q_mutualfunds.holdings` (PG) / `/wrds/crsp/sasdata/q_mutualfunds/holdings.sas7bdat`:
+
+| Property | Thomson S12 | `crsp.holdings` |
+|---|---|---|
+| Coverage | ~2003 → 2024-12-31 (mirror) | **2001-12-31 → 2026-03-31** |
+| Rows | — | ~450M (131 GB) |
+| Frequency | quarterly (N-Q / N-CSR) | **monthly** (N-PORT) |
+| Security id | CUSIP → needs `msenames` join | **`permno` and `permco` pre-mapped** |
+| Fund id | `fundno` → MFLINKS chain | `crsp_portno` → `portnomap` directly |
+| Share adjustment | pre-adjusted to FDATE, **incorrectly** (D1) | **as-reported, unadjusted** |
+
+Columns: `crsp_portno, report_dt, security_rank, eff_dt, percent_tna, nbr_shares,
+market_val, crsp_company_key, security_name, cusip, permno, permco, ticker, coupon,
+maturity_dt`.
+
+### Why this resolves D1 for S12
+
+`nbr_shares` is **as-reported at the report date and not back-adjusted** — the same
+property that made EDGAR 13F a clean S34 replacement. Verified on AAPL (permno 14593)
+across the 2020-08-31 4:1 split:
+
+| report_dt | n_funds | total shares |
+|---|---|---|
+| 2020-07-31 | 1,168 | 807,880,873 |
+| 2020-08-31 | 1,142 | 3,109,430,371 |
+
+A 3.85× step with the fund count *flat* — the split appearing exactly once, unadjusted,
+as it should. There is no cumulative pre-adjustment, so there is nothing to double-apply.
+Apply `cfacshr` yourself, once, at a date convention you control.
+
+### It also removes the MFLINKS dependency
+
+Holdings key on `crsp_portno`, so the `fundno → wficn → crsp_fundno → crsp_portno` chain
+disappears. That eliminates **D5's bridge-rate cliff** and **D5b's ~3.95× share-class
+dedup inflation** at the source, rather than detecting them after the fact.
+
+### ⚠️ The one trap: quarter-end months carry a different fund population
+
+`report_dt` is monthly, but **not every fund reports every month**. From the AAPL check:
+quarter-end months carry ~1,600 funds, intermediate months ~1,140 — roughly **40% more
+funds at quarter-ends**. Mixing them into one series manufactures a fake seasonal pattern
+of exactly the kind this file exists to catch (`detect_seasonal_alternation` fires on it,
+correctly).
+
+**Filter to quarter-end months for a quarterly panel.** Do not treat intermediate months
+as comparable observations.
+
+### Recommendation
+
+| Era | Source |
+|---|---|
+| 2001-12 → present | **`crsp.holdings`**, quarter-end months only |
+| pre-2001-12 | Thomson S12, winsorized at split quarters (D1) — the only source |
+
+Never compare levels across 2017Q4 if Thomson is in the series (D5). Cross-checking
+Thomson against CRSP over the overlap is worthwhile, but expect a gap rather than a
+match: per the Jan 2023 note, CRSP sources monthly N-PORT while Thomson sources quarterly
+N-Q/N-CSR, so holdings "should be close, but not exact."

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -74,8 +74,13 @@ WHERE b.shares > 0
 ### Step 3: Adjust shares via CRSP factors
 
 ```python
-shares_adj = shares * cfacshr  # CRSP adjustment factor aligned at vintage date
+shares_adj = shares * cfacshr  # CRSP adjustment factor aligned at vintage date (fdate)
 ```
+
+> **This step is where the panel breaks around splits.** Thomson has *already*
+> pre-adjusted `shares` to the FDATE vintage, and does so incorrectly in a documented
+> fraction of cases. Multiplying by `cfacshr` again compounds the error rather than
+> fixing it. See **Known Data Defects → D1** below before trusting any split-era quarter.
 
 ### Step 4: Aggregate to permno-quarter
 
@@ -226,3 +231,160 @@ See `postgres-vs-sas.md` for the full decision framework.
     - For post-2017 analysis: expect ~40% of "US country" s12 funds unbridged; report coverage alongside MF aggregates
     - For global analysis: build your own bridge (by fund name, ticker, or manager ID)
 13. **passive_pct 100× scaling in `pass.sas7bdat`** -- `1-make.sas` line 705 multiplies `PASSIVE_PCT` by 100 when merging `index_own` into the panel. If `index_own.PASSIVE_PCT` is already in percent scale (0-100) rather than fraction (0-1), the stored value ends up at 0-10000 scale. Always inspect `describe()` after loading; divide by 100 if max > 100.
+
+---
+
+## Known Data Defects (WRDS research notes + measured)
+
+WRDS publishes its S12/S34 defect notes at
+[Manuals and Overviews → LSEG → Mutual Fund and Investment Company](https://wrds-www.wharton.upenn.edu/pages/support/manuals-and-overviews/lseg/mutual-fund-and-investment-company/)
+(institutional auth required). The notes are filed under Thomson Reuters, Refinitiv, and
+LSEG interchangeably — same feed, three vendor names, `tfn` libname throughout.
+
+**Detectors for every defect below:** `skills/wrds/scripts/ownership_dq.py`.
+**Tests:** `tests/ownership_dq_test.py` (stdlib only — `uv run python3 tests/ownership_dq_test.py`).
+
+### D1. Split adjustment is wrong around split dates — the big one
+
+**Source:** *Note on Splits in TR Mutual Funds and 13F: S12 and S34*, WRDS Research,
+March 7 2017.
+
+The note's running example is **permno 14593 (Apple)** — the same firm where our panel
+breaks. Documented failure modes:
+
+| Case | What Thomson reports | What is correct |
+|------|---------------------|-----------------|
+| Double adjustment | 226,331 = 4,619 × 7 × 7 | 32,333 = 4,619 × 7 |
+| Adjustment at the wrong date | MasterCard shares adjusted at 2013-12-31, before the 2014-01-21 ex-date | adjust at ex-date |
+| Compounded on carry-forward | stale rows re-adjusted each vintage | adjust once |
+
+Magnitude, from the note: outlier rates in ΔOwnership around split quarters run
+**13.8% at Qtr(0) and 14.1% at Qtr(−1) for 13Fs** against a 5% null — and scale with
+split size: **32.4% at split factor 4, 34.5% above 4**. The note's own tests rule out the
+obvious explanations: restricting to `rdate == fdate` (no carry-forwards) does *not*
+help, and neither does restricting to splits whose ex-date and record date share a
+quarter.
+
+**WRDS's own conclusion: there is no clean systemic fix.** Their suggestion is to trim or
+winsorize Qtr(−1), Qtr(0), Qtr(+1) around each split.
+
+**This explains measured finding #1** — the AAPL 4.5× swing with a flat owner count.
+AAPL's split ex-dates (2014-06-09, 7:1; 2020-08-31, 4:1) both fall in Jun/Sep quarters,
+and a handful of catastrophically over-adjusted quarters is enough to move a 23-quarter
+mean by 4.5× while the set of reporting managers never changes. The owner count is flat
+because the filers are all still there — only the share *units* are wrong.
+
+**Consequence for the build:** repairing `HAVING fdate = MIN(fdate)` vintage selection
+alone will **not** fix this. The defect is in Thomson's pre-adjustment of `shares`, not in
+which vintage you pick. Winsorizing split-adjacent quarters is the documented mitigation;
+sourcing post-2013 holdings from EDGAR 13F is the alternative.
+
+### D2. FDATE vs RDATE — and a contradiction between two WRDS documents
+
+- `RDATE` = report date, the date the holdings are actually valid for.
+- `FDATE` = **vintage** date; the primary key for table joins and the date Thomson's
+  share adjustments are made *to*.
+
+*WRDS Overview of Thomson Reuters Mutual Fund and Investment Company Data* is explicit:
+"SHARES values are adjusted for stock splits that occur between the linked RDATE and
+FDATE… the pre-adjustment may not be correct in all cases." The May 2017 S34 note agrees:
+"Thomson's FDATE is a vintage date, and is used primarily for share adjustments using
+CRSP cumulative share adjustment factors."
+
+⚠️ **The splits note contradicts both.** Its table legend reads "Column 1 is the vintage
+date of the holding data, Rdate… Column 2, Fdate, is the date when holdings are valid" —
+exactly backwards. The Overview and the S34 note agree with each other and with the
+observed data, so **FDATE = vintage** is the reading to use; the splits note's legend is
+an error in the note. Recorded here because acting on the splits note's legend inverts
+your join and silently produces the D1 defect on purpose.
+
+### D3. Coverage collapses after ~2013, then again in 2019
+
+**Source:** *Research Note Regarding Thomson-Reuters Ownership Data Issues*, May 2017.
+
+- **Stale and dropped filers.** BlackRock (mgrno 9385) carried forward stale from 2013Q3,
+  then **entirely missing 2014-06 through 2015-03**, then returned at $48B against a true
+  ~$700B+. Fixed in the 2018 regeneration.
+- **Excluded securities.** ~30% of the universe / ~15% of market cap dropped after June
+  2013; **all ETFs gone by 2015**. Do not use S34 for ETF holdings, ever.
+- **AAPL specifically: zero institutional owners from 2015-06-30 onward** in the vintage
+  current at that time — and the 2014-06-30 row jumps 516,786,227 → 3,665,520,154, the
+  unadjusted 7:1 split (D1 again).
+- Aggregate error: 2015 institutional ownership is 58.25% in S34 against 71.8% in the
+  actual 13F filings — **19.4% of total institutional ownership missing**.
+
+**Feb 2022 note** (*Thomson/Refinitiv Data Issues 13F (S34) and Mutual Fund Holdings
+(S12)*): 13F holdings largely missing in **2019Q3–Q4** — filers per stock fell from 1,500+
+to under 500 for AAPL/IBM/MSFT; 1,386 of 12,224 stocks lost >10% of institutional
+ownership, median −48%. Also flags **2011-03 to 2013-03** as significantly incomplete
+(consistent with the Koijen–Yogo footnote). WRDS froze the web query at 2019Q2 and moved
+later data to `/wrds/tfn/sasdata/s34/incomplete`.
+**April/August 2022 notes:** Refinitiv patched 2019Q3–Q4 and the S12 2017Q4/2019Q4 gaps.
+Pre-2011 issues are **permanently unfixable** — "the data vendor no longer provide the
+support for the vintage raw data."
+
+→ Detector: `detect_owner_dropout` (owners collapse = feed defect) as opposed to
+`detect_flat_owner_share_swing` (owners flat = units defect). Run both; the pair
+*classifies* the break.
+
+### D4. 2010–2016 was regenerated; an archive of the corrupt data exists
+
+**Source:** *S12/S34 Regenerated Data (2010–2016)*, June 2018. Thomson's legacy systems
+were "losing and corrupting data" from 2010. The regenerated data is in `/wrds/tfn/sasdata`;
+the corrupted original is preserved at **`/wrds/tfn/sasdata_archive`** — use it to
+reconcile against results published before 2018. Residual known issues: S12TYPE8 lost a
+third of its coverage after 2013; a 2014 mutual-fund ownership blip (29%→35%→30%) likely
+from double-counted funds; S34TYPE2 still excludes ~$1T of CRSP securities; a 5% ownership
+drop at the 2010-12→2011-03 feed migration.
+
+### D5. S12 feed change at 2017Q4 — a coverage *increase* that looks like a defect
+
+**Source:** *Thomson/Refinitiv Data Feed Change from Legacy SP to Strategic Collection in
+S12*, 2023-01-24. From 2017Q4 the S12 feed switched from legacy SP to "strategic
+collection", backfilled in 2022Q4. **CUSIPs in fund holdings +613%, unique funds +113%,
+fund-CUSIP observations +265%**, and 34,385 funds appear that did not exist in the old
+feed. Cause: overseas holdings, ADRs, preferreds and bonds got CUSIPs assigned that the
+legacy feed lacked — it is a genuine coverage expansion, not corruption. But any
+level-comparison spanning 2017Q4 is invalid, and **MFLINKS was not backfilled** for
+2017Q4–2020Q2, so `wficn` bridge rates drop precisely there. WRDS's own advice is to use
+Factset or CRSP to identify US equity funds over that window.
+
+This corroborates the measured MFLINKS bridge-rate cliff (§Common Gotchas #12: ~77%
+pre-2017 → ~58–66% after).
+
+### D6. 13F `value` units change at 2023Q1 — measured, NOT documented by WRDS
+
+Form 13F `value` moves from thousands to whole dollars. Measured on the EDGAR panel:
+mean value per holding 152,644 (2022Q4) → 12,794,119 (2023Q1); **median 442×, p90 494×,
+p10 only 38×**.
+
+The break is **not a clean 1000×**. The post-2023Q1 population is mixed — filers converted
+on different schedules — so **no scalar repairs it**, and any sum or average of `value`
+spanning 2023Q1 is meaningless. Note the legacy S34 spec still labels the field
+"Holding Value (x$1000)".
+
+**No WRDS note documents this.** The gap is itself worth knowing: the S12/S34 defect notes
+stop at the 2023 S12 feed change and say nothing about 13F value units. Treated as a
+source property to detect and refuse to aggregate across, not to repair.
+
+→ Detector: `detect_unit_discontinuity`, which reports `clean_break=False` when the
+quantile shifts disagree — the signal that rescaling is not an option.
+
+### D7. Encoding-driven silent parse failures — measured, parser-side
+
+Windows-1252 filings parsed to **zero** holdings rows: 7,023 filings / 2,628,463 rows /
+768 institutions across all 38 quarters, with a **3.47× step at 2023Q3** (5.54% of
+holdings dropped after vs 1.60% before), concentrated by filing agent. Now fixed, but the
+class recurs with any new vendor encoding — a parser that yields nothing is
+indistinguishable from a filer that held nothing.
+
+→ Detector: `detect_zero_row_cohort`, grouped by encoding *or* filing agent, with
+per-period rates so a time-varying step is visible rather than averaged away.
+
+### Cross-check: EDGAR 13F is clean where Thomson is not
+
+Same firm (AAPL), EDGAR `13F-HR` / `shares_type=SH` / no amendments: quarterly variation
+of a few percent, filer counts monotone, and the 2020 4:1 split appearing exactly once and
+correctly unadjusted (2.59bn → 9.70bn at 2020Q3). The defect is Thomson's, not the
+concept's. Thomson's remaining advantage is history: it starts 1980, EDGAR electronic
+filings start 1999 and XML only in 2013.

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env -S uv run python3
+"""
+Data-quality detectors for holdings panels (Thomson/Refinitiv S12 & S34, SEC 13F, N-PX).
+
+Stdlib only. Every detector takes a sequence of record dicts -- exactly what
+`df.to_dict("records")` gives you -- so it runs in CI with no dependencies and on a
+real parquet panel through a one-line adapter.
+
+Each detector answers a question a *reviewer* would ask of an ownership panel, and each
+is grounded in a defect that was either measured on the mirror panel or documented by
+WRDS Research. See `references/tfn-ownership.md` -> "Known Data Defects" for the
+citations and for what WRDS says the fix is (in several cases: there is no clean fix).
+
+The detectors are firm-agnostic by construction. AAPL (permno 14593) is where these
+defects were found -- and, not coincidentally, the running example in WRDS's own splits
+note -- but nothing here is specialized to it.
+
+Conventions
+-----------
+Every detector returns a list of `Finding`. An empty list means "clean". Callers assert
+on the list, so a detector never raises on ordinary bad data -- only on malformed input.
+
+Periods are `datetime.date` (quarter-end) or ISO "YYYY-MM-DD" strings; both are accepted
+and normalized. Records with a None metric are skipped, not treated as zero -- a missing
+quarter and a zero quarter are different defects and conflating them hides both.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Sequence
+
+__all__ = [
+    "Finding",
+    "detect_flat_owner_share_swing",
+    "detect_seasonal_alternation",
+    "detect_split_factor_ratio",
+    "detect_unit_discontinuity",
+    "detect_coverage_end",
+    "detect_owner_dropout",
+    "detect_zero_row_cohort",
+    "COMMON_SPLIT_FACTORS",
+]
+
+# Split factors common enough in US equities that a holdings ratio landing on one is
+# evidence of a mis-applied adjustment rather than real trading. Squares are included
+# because double-adjustment is a documented Thomson failure mode: WRDS's splits note
+# shows AAPL shares adjusted 7x twice for an erroneous "1-to-49 split".
+COMMON_SPLIT_FACTORS = (2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 10.0, 20.0, 28.0)
+
+
+@dataclass
+class Finding:
+    """One flagged observation. `kind` is stable and machine-matchable."""
+
+    kind: str
+    entity: Any
+    period: Any
+    detail: str
+    metrics: dict = field(default_factory=dict)
+
+    def __str__(self) -> str:  # pragma: no cover - display only
+        return f"[{self.kind}] entity={self.entity} period={self.period}: {self.detail}"
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _as_date(value: Any) -> _dt.date:
+    if isinstance(value, _dt.datetime):
+        return value.date()
+    if isinstance(value, _dt.date):
+        return value
+    if isinstance(value, str):
+        return _dt.date.fromisoformat(value[:10])
+    raise TypeError(f"cannot interpret {value!r} as a date")
+
+
+def _grouped(
+    records: Iterable[dict], entity_col: str, period_col: str
+) -> dict[Any, list[dict]]:
+    """Group by entity, each group sorted by period. Later duplicates win."""
+    out: dict[Any, dict[_dt.date, dict]] = {}
+    for rec in records:
+        entity = rec.get(entity_col)
+        period = _as_date(rec[period_col])
+        out.setdefault(entity, {})[period] = rec
+    return {
+        entity: [by_period[p] for p in sorted(by_period)]
+        for entity, by_period in out.items()
+    }
+
+
+def _ratio(current: float, previous: float) -> float | None:
+    """Fold-change, orientation-free: always >= 1.0, or None if undefined."""
+    if previous is None or current is None:
+        return None
+    if previous == 0 or current == 0:
+        return None
+    lo, hi = sorted((abs(previous), abs(current)))
+    return hi / lo
+
+
+def _pct_change(current: float, previous: float) -> float | None:
+    if previous in (None, 0) or current is None:
+        return None
+    return (current - previous) / abs(previous)
+
+
+def _quantile(sorted_values: Sequence[float], q: float) -> float:
+    """Linear-interpolated quantile. `sorted_values` must be sorted and non-empty."""
+    if not sorted_values:
+        raise ValueError("empty sequence")
+    if len(sorted_values) == 1:
+        return float(sorted_values[0])
+    pos = q * (len(sorted_values) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = pos - lo
+    return float(sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac)
+
+
+# ------------------------------------------------------------------- the detectors
+
+
+def detect_flat_owner_share_swing(
+    records: Sequence[dict],
+    *,
+    entity_col: str = "permno",
+    period_col: str = "rdate",
+    shares_col: str = "io_total",
+    owners_col: str = "numowners",
+    share_swing: float = 0.20,
+    owner_tolerance: float = 0.05,
+) -> list[Finding]:
+    """Shares move violently while the owner count barely moves.
+
+    THE signature of a units/adjustment defect rather than a coverage defect. If
+    institutions actually left, the owner count would fall with the shares. When 2,200
+    managers keep reporting and the aggregate share count collapses 4.5x, the shares are
+    being *rescaled*, not sold.
+
+    This is the detector for the undiagnosed AAPL defect (mirror `inst_own.parquet`,
+    permno 14593): io_total means of 1.41e10 (Mar) / 3.11e9 (Jun) / 3.31e9 (Sep) /
+    1.41e10 (Dec) against numowners flat at 2,195-2,427.
+
+    A holding that legitimately doubles usually brings new holders with it, so the
+    tolerance on the owner side is deliberately tight (5%) while the share side is loose
+    (20%) -- we want to catch rescaling, not trading.
+    """
+    findings: list[Finding] = []
+    for entity, rows in _grouped(records, entity_col, period_col).items():
+        for prev, cur in zip(rows, rows[1:]):
+            s_prev, s_cur = prev.get(shares_col), cur.get(shares_col)
+            o_prev, o_cur = prev.get(owners_col), cur.get(owners_col)
+            if None in (s_prev, s_cur, o_prev, o_cur):
+                continue
+            s_change = _pct_change(s_cur, s_prev)
+            o_change = _pct_change(o_cur, o_prev)
+            if s_change is None or o_change is None:
+                continue
+            if abs(s_change) >= share_swing and abs(o_change) <= owner_tolerance:
+                findings.append(
+                    Finding(
+                        kind="flat_owner_share_swing",
+                        entity=entity,
+                        period=_as_date(cur[period_col]),
+                        detail=(
+                            f"{shares_col} moved {s_change:+.1%} while {owners_col} "
+                            f"moved only {o_change:+.1%} -- shares rescaled, not traded"
+                        ),
+                        metrics={
+                            "shares_pct_change": s_change,
+                            "owners_pct_change": o_change,
+                            "shares_prev": s_prev,
+                            "shares_cur": s_cur,
+                            "owners_prev": o_prev,
+                            "owners_cur": o_cur,
+                            "fold_change": _ratio(s_cur, s_prev),
+                        },
+                    )
+                )
+    return findings
+
+
+def detect_seasonal_alternation(
+    records: Sequence[dict],
+    *,
+    entity_col: str = "permno",
+    period_col: str = "rdate",
+    metric_col: str = "io_total",
+    min_quarters: int = 8,
+    ratio_threshold: float = 1.5,
+) -> list[Finding]:
+    """A metric whose level depends on which calendar quarter-end it is.
+
+    Real ownership has no reason to care whether the quarter ends in June or December.
+    When it does, a vintage/adjustment artifact is keyed to the quarter-end month.
+
+    Compares the mean of each quarter-end month against the pooled mean of the others and
+    flags the entity when the highest-month/lowest-month ratio clears `ratio_threshold`.
+    Reported once per entity, not per quarter -- seasonality is a property of the series.
+    """
+    findings: list[Finding] = []
+    for entity, rows in _grouped(records, entity_col, period_col).items():
+        by_month: dict[int, list[float]] = {}
+        for rec in rows:
+            value = rec.get(metric_col)
+            if value is None:
+                continue
+            by_month.setdefault(_as_date(rec[period_col]).month, []).append(float(value))
+        usable = {m: v for m, v in by_month.items() if v}
+        if len(usable) < 2 or sum(len(v) for v in usable.values()) < min_quarters:
+            continue
+        means = {m: sum(v) / len(v) for m, v in usable.items()}
+        hi_month = max(means, key=lambda m: means[m])
+        lo_month = min(means, key=lambda m: means[m])
+        if means[lo_month] <= 0:
+            continue
+        ratio = means[hi_month] / means[lo_month]
+        if ratio >= ratio_threshold:
+            findings.append(
+                Finding(
+                    kind="seasonal_alternation",
+                    entity=entity,
+                    period=None,
+                    detail=(
+                        f"{metric_col} mean varies {ratio:.2f}x by quarter-end month "
+                        f"(month {hi_month}={means[hi_month]:.3g} vs "
+                        f"month {lo_month}={means[lo_month]:.3g}); "
+                        f"ownership has no calendar seasonality this large"
+                    ),
+                    metrics={
+                        "ratio": ratio,
+                        "means_by_month": means,
+                        "high_month": hi_month,
+                        "low_month": lo_month,
+                        "n_quarters": sum(len(v) for v in usable.values()),
+                    },
+                )
+            )
+    return findings
+
+
+def detect_split_factor_ratio(
+    records: Sequence[dict],
+    *,
+    entity_col: str = "permno",
+    period_col: str = "rdate",
+    shares_col: str = "io_total",
+    owners_col: str | None = "numowners",
+    factors: Sequence[float] = COMMON_SPLIT_FACTORS,
+    tolerance: float = 0.03,
+    include_squares: bool = True,
+) -> list[Finding]:
+    """A quarter-over-quarter share ratio that lands on a split factor -- or its square.
+
+    Distinguishes a mis-applied adjustment from ordinary trading: real flows do not
+    produce a clean 7.00x. Squares are checked because double-adjustment is documented:
+    WRDS's splits note shows S12 reporting 226,331 shares where 32,333 was correct --
+    4,619 x 7 x 7, "an erroneous 1-to-49 split".
+
+    When `owners_col` is given, the owner count must be roughly flat for the ratio to
+    count as evidence -- a 2x share jump accompanied by 2x the holders is a real event.
+    Pass `owners_col=None` to check the ratio alone.
+    """
+    targets: list[tuple[float, str]] = [(float(f), "split") for f in factors]
+    if include_squares:
+        targets += [(float(f) ** 2, "double-adjusted") for f in factors]
+
+    findings: list[Finding] = []
+    for entity, rows in _grouped(records, entity_col, period_col).items():
+        for prev, cur in zip(rows, rows[1:]):
+            ratio = _ratio(cur.get(shares_col), prev.get(shares_col))
+            if ratio is None or ratio < 1.5:
+                continue
+            if owners_col is not None:
+                o_change = _pct_change(cur.get(owners_col), prev.get(owners_col))
+                if o_change is None or abs(o_change) > 0.10:
+                    continue
+            for target, label in targets:
+                if abs(ratio - target) / target <= tolerance:
+                    findings.append(
+                        Finding(
+                            kind="split_factor_ratio",
+                            entity=entity,
+                            period=_as_date(cur[period_col]),
+                            detail=(
+                                f"{shares_col} changed by {ratio:.3f}x, within "
+                                f"{tolerance:.0%} of {target:g}x ({label}) -- "
+                                f"consistent with a mis-applied share adjustment"
+                            ),
+                            metrics={
+                                "ratio": ratio,
+                                "matched_factor": target,
+                                "match_kind": label,
+                                "shares_prev": prev.get(shares_col),
+                                "shares_cur": cur.get(shares_col),
+                            },
+                        )
+                    )
+                    break
+    return findings
+
+
+def detect_unit_discontinuity(
+    records: Sequence[dict],
+    *,
+    period_col: str = "rdate",
+    value_col: str = "value",
+    min_median_ratio: float = 10.0,
+    dispersion_ratio: float = 3.0,
+    min_obs_per_period: int = 20,
+) -> list[Finding]:
+    """A period boundary where a value column changes *units*.
+
+    Works on the cross-section, not one entity: compares the distribution of `value_col`
+    in each period against the previous period. A units change moves the whole
+    distribution at once, which a real economic shock does not.
+
+    Also reports whether the break is *clean*. The measured Form 13F break at 2023Q1
+    (thousands -> whole dollars) is not: median 442x, p90 494x, but p10 only 38x. That
+    spread means filers converted at different times, so the post-break population is
+    mixed and **no scalar repairs it**. When p90/p10 of the per-decile shift exceeds
+    `dispersion_ratio`, the finding is marked `clean_break=False`, which is the signal
+    that any sum or mean of `value_col` spanning the boundary is meaningless rather than
+    merely rescaled.
+    """
+    by_period: dict[_dt.date, list[float]] = {}
+    for rec in records:
+        value = rec.get(value_col)
+        if value is None:
+            continue
+        by_period.setdefault(_as_date(rec[period_col]), []).append(float(value))
+
+    findings: list[Finding] = []
+    periods = sorted(by_period)
+    for prev_p, cur_p in zip(periods, periods[1:]):
+        prev_v = sorted(v for v in by_period[prev_p] if v > 0)
+        cur_v = sorted(v for v in by_period[cur_p] if v > 0)
+        if len(prev_v) < min_obs_per_period or len(cur_v) < min_obs_per_period:
+            continue
+        q = {
+            name: (_quantile(cur_v, p) / _quantile(prev_v, p))
+            for name, p in (("p10", 0.10), ("median", 0.50), ("p90", 0.90))
+            if _quantile(prev_v, p) > 0
+        }
+        median_ratio = q.get("median")
+        if median_ratio is None or median_ratio < min_median_ratio:
+            continue
+        spread = (
+            max(q.values()) / min(q.values()) if min(q.values(), default=0) > 0 else None
+        )
+        clean = spread is not None and spread <= dispersion_ratio
+        findings.append(
+            Finding(
+                kind="unit_discontinuity",
+                entity=None,
+                period=cur_p,
+                detail=(
+                    f"{value_col} median shifted {median_ratio:.0f}x at {cur_p} "
+                    f"(p10={q.get('p10', float('nan')):.0f}x, "
+                    f"p90={q.get('p90', float('nan')):.0f}x); "
+                    + (
+                        "uniform shift -- a scalar rescale may be defensible"
+                        if clean
+                        else "NON-UNIFORM: population is mixed, no scalar repairs it; "
+                        "do not sum or average across this boundary"
+                    )
+                ),
+                metrics={
+                    "quantile_ratios": q,
+                    "median_ratio": median_ratio,
+                    "dispersion": spread,
+                    "clean_break": clean,
+                    "prev_period": prev_p,
+                    "n_prev": len(prev_v),
+                    "n_cur": len(cur_v),
+                },
+            )
+        )
+    return findings
+
+
+def detect_coverage_end(
+    records: Sequence[dict],
+    *,
+    period_col: str = "rdate",
+    expected_through: Any,
+    entity_col: str | None = None,
+    max_gap_days: int = 100,
+) -> list[Finding]:
+    """The panel stops before it should.
+
+    A silently truncated series is the most dangerous defect in this file, because every
+    downstream statistic still computes. S12 in the mirror ends 2024-12-31 with no 2025
+    coverage; WRDS separately froze the S34 web query at 2019Q2 during the 2022 feed
+    outage. Both are invisible unless asserted.
+
+    With `entity_col` set, checks each entity's last period; otherwise checks the panel.
+    """
+    expected = _as_date(expected_through)
+    findings: list[Finding] = []
+
+    def _check(entity: Any, periods: list[_dt.date]) -> None:
+        if not periods:
+            return
+        last = max(periods)
+        gap = (expected - last).days
+        if gap > max_gap_days:
+            findings.append(
+                Finding(
+                    kind="coverage_end",
+                    entity=entity,
+                    period=last,
+                    detail=(
+                        f"coverage ends {last}, {gap} days short of the expected "
+                        f"{expected}; downstream statistics will still compute"
+                    ),
+                    metrics={
+                        "last_period": last,
+                        "expected_through": expected,
+                        "gap_days": gap,
+                    },
+                )
+            )
+
+    if entity_col is None:
+        _check(None, [_as_date(r[period_col]) for r in records])
+    else:
+        for entity, rows in _grouped(records, entity_col, period_col).items():
+            _check(entity, [_as_date(r[period_col]) for r in rows])
+    return findings
+
+
+def detect_owner_dropout(
+    records: Sequence[dict],
+    *,
+    entity_col: str = "permno",
+    period_col: str = "rdate",
+    owners_col: str = "numowners",
+    drop_threshold: float = 0.50,
+) -> list[Finding]:
+    """The owner count itself collapses -- a coverage/feed defect, not a units defect.
+
+    The complement of `detect_flat_owner_share_swing`, and the two together classify a
+    break: shares move but owners do not -> adjustment bug; owners move too -> the feed
+    dropped filers.
+
+    WRDS documented exactly this in Feb 2022: institutions reporting AAPL, IBM and MSFT
+    fell from 1,500+ to under 500 in 2019Q3-Q4, and 1,386 of 12,224 stocks lost >10% of
+    institutional ownership (median -48%). Refinitiv patched it in April 2022 -- so this
+    detector should be run against *current* extracts, since an unpatched local mirror
+    keeps the defect.
+    """
+    findings: list[Finding] = []
+    for entity, rows in _grouped(records, entity_col, period_col).items():
+        for prev, cur in zip(rows, rows[1:]):
+            change = _pct_change(cur.get(owners_col), prev.get(owners_col))
+            if change is not None and change <= -drop_threshold:
+                findings.append(
+                    Finding(
+                        kind="owner_dropout",
+                        entity=entity,
+                        period=_as_date(cur[period_col]),
+                        detail=(
+                            f"{owners_col} fell {change:.1%} "
+                            f"({prev.get(owners_col)} -> {cur.get(owners_col)}) -- "
+                            f"filers missing from the feed"
+                        ),
+                        metrics={
+                            "owners_pct_change": change,
+                            "owners_prev": prev.get(owners_col),
+                            "owners_cur": cur.get(owners_col),
+                        },
+                    )
+                )
+    return findings
+
+
+def detect_zero_row_cohort(
+    records: Sequence[dict],
+    *,
+    cohort_col: str,
+    rows_col: str = "n_rows",
+    period_col: str | None = None,
+    min_docs: int = 10,
+    zero_rate_threshold: float = 0.90,
+) -> list[Finding]:
+    """A whole cohort of documents that parsed to zero rows.
+
+    A parser that silently yields nothing looks identical to a filer holding nothing.
+    The Windows-1252 encoding bug did exactly this: 7,023 filings / 2,628,463 rows / 768
+    institutions dropped to zero across all 38 quarters, concentrated by filing agent and
+    stepping 3.47x at 2023Q3 (5.54% of holdings lost after, 1.60% before).
+
+    Group by whatever cohort could carry an encoding or vendor quirk -- filing agent,
+    declared charset, parser version -- and flag any cohort that is almost entirely
+    empty. With `period_col`, also reports the per-period zero rate so a *time-varying*
+    step (the 2023Q3 jump) is visible rather than averaged away.
+    """
+    cohorts: dict[Any, list[dict]] = {}
+    for rec in records:
+        cohorts.setdefault(rec.get(cohort_col), []).append(rec)
+
+    findings: list[Finding] = []
+    for cohort, rows in sorted(cohorts.items(), key=lambda kv: str(kv[0])):
+        if len(rows) < min_docs:
+            continue
+        zeros = [r for r in rows if not r.get(rows_col)]
+        rate = len(zeros) / len(rows)
+        if rate < zero_rate_threshold:
+            continue
+        metrics: dict[str, Any] = {
+            "zero_rate": rate,
+            "n_docs": len(rows),
+            "n_zero": len(zeros),
+        }
+        if period_col is not None:
+            per_period: dict[Any, list[dict]] = {}
+            for r in rows:
+                per_period.setdefault(_as_date(r[period_col]), []).append(r)
+            metrics["zero_rate_by_period"] = {
+                p: sum(1 for r in rs if not r.get(rows_col)) / len(rs)
+                for p, rs in sorted(per_period.items())
+            }
+        findings.append(
+            Finding(
+                kind="zero_row_cohort",
+                entity=cohort,
+                period=None,
+                detail=(
+                    f"cohort {cohort_col}={cohort!r}: {len(zeros)}/{len(rows)} "
+                    f"documents parsed to zero rows ({rate:.1%}) -- "
+                    f"indistinguishable from 'held nothing' unless asserted"
+                ),
+                metrics=metrics,
+            )
+        )
+    return findings
+
+
+def from_dataframe(df: Any, detector: Callable[..., list[Finding]], **kwargs: Any):
+    """Adapter: run any detector against a pandas/polars frame.
+
+    Kept trivial on purpose -- the detectors take records so the test suite needs no
+    dataframe library, and real callers pay one conversion.
+    """
+    records = (
+        df.to_dicts() if hasattr(df, "to_dicts") else df.to_dict("records")
+    )
+    return detector(records, **kwargs)

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -38,8 +38,11 @@ __all__ = [
     "detect_split_factor_ratio",
     "detect_unit_discontinuity",
     "detect_coverage_end",
+    "detect_coverage_step",
     "detect_owner_dropout",
     "detect_zero_row_cohort",
+    "detect_bridge_rate_regression",
+    "detect_duplicate_grain",
     "COMMON_SPLIT_FACTORS",
 ]
 
@@ -539,6 +542,209 @@ def detect_zero_row_cohort(
             )
         )
     return findings
+
+
+def detect_coverage_step(
+    records: Sequence[dict],
+    *,
+    period_col: str = "rdate",
+    count_cols: Sequence[str] = ("n_funds", "n_cusips", "n_rows"),
+    step_threshold: float = 0.50,
+) -> list[Finding]:
+    """A step change in how much the feed *covers*, in counts rather than values.
+
+    Distinct from `detect_unit_discontinuity`, which watches a value column. Here the
+    counts themselves jump, which is what a feed migration looks like: nothing is
+    rescaled, there is simply more (or less) of it.
+
+    The S12 legacy-SP -> strategic-collection switch at 2017Q4 is the reference case:
+    CUSIPs in fund holdings **+613%**, unique funds **+113%**, fund-CUSIP observations
+    +265%. WRDS confirms this is a genuine coverage expansion, not corruption -- overseas
+    holdings, ADRs and preferreds finally received CUSIPs. It is still fatal to any
+    level comparison spanning the boundary, and it is invisible in per-firm statistics.
+
+    Fires in both directions on purpose: the same detector catches the 2019Q3-Q4 S34
+    outage (a step *down*) and the 2017Q4 S12 expansion (a step *up*).
+
+    Expects one record per period holding the counts -- i.e. an already-aggregated
+    coverage summary, not the raw holdings panel.
+    """
+    by_period: dict[_dt.date, dict] = {}
+    for rec in records:
+        by_period[_as_date(rec[period_col])] = rec
+
+    findings: list[Finding] = []
+    periods = sorted(by_period)
+    for prev_p, cur_p in zip(periods, periods[1:]):
+        for col in count_cols:
+            prev_v, cur_v = by_period[prev_p].get(col), by_period[cur_p].get(col)
+            if prev_v in (None, 0) or cur_v is None:
+                continue
+            change = _pct_change(cur_v, prev_v)
+            if change is None or abs(change) < step_threshold:
+                continue
+            findings.append(
+                Finding(
+                    kind="coverage_step",
+                    entity=col,
+                    period=cur_p,
+                    detail=(
+                        f"{col} stepped {change:+.0%} ({prev_v:,} -> {cur_v:,}) at "
+                        f"{cur_p} -- feed composition changed; level comparisons "
+                        f"spanning this boundary are invalid"
+                    ),
+                    metrics={
+                        "pct_change": change,
+                        "prev": prev_v,
+                        "cur": cur_v,
+                        "direction": "expansion" if change > 0 else "contraction",
+                        "prev_period": prev_p,
+                    },
+                )
+            )
+    return findings
+
+
+def detect_bridge_rate_regression(
+    records: Sequence[dict],
+    *,
+    period_col: str = "rdate",
+    linked_col: str = "n_linked",
+    total_col: str = "n_total",
+    min_rate: float = 0.70,
+    max_drop: float = 0.10,
+) -> list[Finding]:
+    """An identifier bridge that silently stops matching.
+
+    A join that quietly drops rows is the most under-tested failure in this file: the
+    result still looks like a panel, just a smaller one, and nothing raises.
+
+    MFLINKS is the reference case. It was **not backfilled** for the 2017Q4-2020Q2 S12
+    feed change, so `wficn` coverage regresses precisely where the feed expanded -- and
+    the measured bridge rate falls from ~77% pre-2017 to ~58-66% after. WRDS's own advice
+    for that window is to identify US equity funds through Factset or CRSP instead.
+
+    Flags two things: an absolute rate below `min_rate`, and a quarter-over-quarter drop
+    exceeding `max_drop` (which catches a cliff that starts above the floor).
+    """
+    by_period: dict[_dt.date, dict] = {}
+    for rec in records:
+        by_period[_as_date(rec[period_col])] = rec
+
+    rates: dict[_dt.date, float] = {}
+    for period, rec in by_period.items():
+        total = rec.get(total_col)
+        linked = rec.get(linked_col)
+        if not total or linked is None:
+            continue
+        rates[period] = linked / total
+
+    findings: list[Finding] = []
+    for period in sorted(rates):
+        rate = rates[period]
+        if rate < min_rate:
+            findings.append(
+                Finding(
+                    kind="bridge_rate_low",
+                    entity=linked_col,
+                    period=period,
+                    detail=(
+                        f"only {rate:.1%} of rows bridged at {period} "
+                        f"(floor {min_rate:.0%}) -- unbridged rows vanish silently"
+                    ),
+                    metrics={"rate": rate, "floor": min_rate},
+                )
+            )
+    ordered = sorted(rates)
+    for prev_p, cur_p in zip(ordered, ordered[1:]):
+        drop = rates[prev_p] - rates[cur_p]
+        if drop > max_drop:
+            findings.append(
+                Finding(
+                    kind="bridge_rate_regression",
+                    entity=linked_col,
+                    period=cur_p,
+                    detail=(
+                        f"bridge rate fell {rates[prev_p]:.1%} -> {rates[cur_p]:.1%} "
+                        f"at {cur_p} ({drop:.1%} drop) -- the link table did not grow "
+                        f"with the feed"
+                    ),
+                    metrics={
+                        "rate_prev": rates[prev_p],
+                        "rate_cur": rates[cur_p],
+                        "drop": drop,
+                        "prev_period": prev_p,
+                    },
+                )
+            )
+    return findings
+
+
+def detect_duplicate_grain(
+    records: Sequence[dict],
+    *,
+    grain: Sequence[str],
+    value_col: str | None = None,
+    max_duplicate_rate: float = 0.0,
+) -> list[Finding]:
+    """Records that repeat at the grain they are supposed to be unique on.
+
+    Duplicates inflate every sum downstream and are invisible in a spot check. Two
+    documented cases in this data:
+
+    - The 2014 S12 blip -- mutual-fund ownership 29% -> 35% -> 30% -- which WRDS
+      attributes to funds being listed twice.
+    - The `fundno`-vs-`wficn` dedup bug, which inflated MF_TOTAL by **~3.95x** because
+      one `wficn` maps to a mean ~3.5 `crsp_fundno` share classes. Dedup on the wrong
+      key and you multiply the panel.
+
+    Pass the grain you believe is unique -- e.g. `("wficn", "rdate", "cusip8")`. With
+    `value_col`, also reports the inflation the duplicates cause, which is the number
+    that actually matters: a duplicate carrying the same value doubles your total.
+    """
+    seen: dict[tuple, list[dict]] = {}
+    for rec in records:
+        key = tuple(rec.get(col) for col in grain)
+        seen.setdefault(key, []).append(rec)
+
+    dupes = {k: v for k, v in seen.items() if len(v) > 1}
+    if not dupes:
+        return []
+    rate = len(dupes) / len(seen)
+    if rate <= max_duplicate_rate:
+        return []
+
+    metrics: dict[str, Any] = {
+        "duplicate_key_rate": rate,
+        "n_duplicate_keys": len(dupes),
+        "n_keys": len(seen),
+        "n_excess_rows": sum(len(v) - 1 for v in dupes.values()),
+        "worst_key": max(dupes, key=lambda k: len(dupes[k])),
+        "max_multiplicity": max(len(v) for v in dupes.values()),
+    }
+    detail = (
+        f"{len(dupes):,} of {len(seen):,} keys duplicated on "
+        f"{'+'.join(grain)} ({rate:.1%}); {metrics['n_excess_rows']:,} excess rows"
+    )
+    if value_col is not None:
+        total = sum(
+            float(r[value_col]) for v in seen.values() for r in v if r.get(value_col) is not None
+        )
+        deduped = sum(
+            float(v[0][value_col]) for v in seen.values() if v[0].get(value_col) is not None
+        )
+        if deduped:
+            metrics["inflation_factor"] = total / deduped
+            detail += f" -- inflates {value_col} by {total / deduped:.2f}x"
+    return [
+        Finding(
+            kind="duplicate_grain",
+            entity="+".join(grain),
+            period=None,
+            detail=detail,
+            metrics=metrics,
+        )
+    ]
 
 
 def from_dataframe(df: Any, detector: Callable[..., list[Finding]], **kwargs: Any):

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -43,6 +43,7 @@ __all__ = [
     "detect_zero_row_cohort",
     "detect_bridge_rate_regression",
     "detect_duplicate_grain",
+    "detect_unresolved_overlap",
     "COMMON_SPLIT_FACTORS",
 ]
 
@@ -745,6 +746,82 @@ def detect_duplicate_grain(
             metrics=metrics,
         )
     ]
+
+
+def detect_unresolved_overlap(
+    records: Sequence[dict],
+    *,
+    source_col: str = "source",
+    resolved_col: str = "bridged",
+    secondary_source: Any = "s12",
+    period_col: str | None = None,
+    max_unresolved_rate: float = 0.05,
+) -> list[Finding]:
+    """Union of two sources where membership overlap was never resolved.
+
+    When you merge a primary and a secondary source at the record level, every secondary
+    record must be classifiable as either *genuinely absent* from the primary (safe to
+    add) or *present but unlinked* (adding it double-counts). Records that are neither
+    are the union's silent error term, and no downstream statistic exposes them.
+
+    Reference case: coalescing Thomson S12 into `crsp.holdings`. Measured at 2022-12-31 --
+    non-US funds bridge at 0.3%, which sounds catastrophic but simply means CRSP never
+    covered them, so they are safe additions. The real exposure is **US-domiciled funds
+    that fail to bridge: 4,649 of 60,184 (~7.7%)**. Those could be new funds or duplicates
+    of funds CRSP already carries, and nothing in the data distinguishes them.
+
+    So the headline bridge rate is the wrong number to watch -- 12.2% globally versus a
+    ~7.7% true ambiguity. This detector wants the *classified* population: records
+    already tagged with which source they came from and whether they resolved against the
+    other. It reports the unresolved secondary mass, per period when `period_col` is set.
+
+    Default threshold is deliberately tight (5%). An unresolved union is not a rounding
+    error; it is an unbounded bias whose sign you do not know.
+    """
+
+    def _rate(rows: Sequence[dict]) -> tuple[int, int]:
+        secondary = [r for r in rows if r.get(source_col) == secondary_source]
+        unresolved = [r for r in secondary if not r.get(resolved_col)]
+        return len(unresolved), len(rows)
+
+    findings: list[Finding] = []
+
+    def _emit(period: Any, rows: Sequence[dict]) -> None:
+        n_unresolved, n_total = _rate(rows)
+        if not n_total:
+            return
+        rate = n_unresolved / n_total
+        if rate <= max_unresolved_rate:
+            return
+        findings.append(
+            Finding(
+                kind="unresolved_overlap",
+                entity=secondary_source,
+                period=period,
+                detail=(
+                    f"{n_unresolved:,} of {n_total:,} records ({rate:.1%}) come from "
+                    f"{secondary_source!r} without resolving against the primary source "
+                    f"-- each is either new coverage or a duplicate, and the data does "
+                    f"not say which"
+                ),
+                metrics={
+                    "unresolved_rate": rate,
+                    "n_unresolved": n_unresolved,
+                    "n_total": n_total,
+                    "threshold": max_unresolved_rate,
+                },
+            )
+        )
+
+    if period_col is None:
+        _emit(None, list(records))
+    else:
+        by_period: dict[_dt.date, list[dict]] = {}
+        for rec in records:
+            by_period.setdefault(_as_date(rec[period_col]), []).append(rec)
+        for period in sorted(by_period):
+            _emit(period, by_period[period])
+    return findings
 
 
 def from_dataframe(df: Any, detector: Callable[..., list[Finding]], **kwargs: Any):

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env -S uv run python3
+"""Ownership data-quality detector tests.
+
+Run: uv run python3 tests/ownership_dq_test.py
+
+Each defect class below was either measured on the mirror panel (~/projects/mirror) or
+documented by a WRDS research note. The fixtures reproduce the measured *shape* with
+synthetic numbers so the suite runs without WRDS credentials, and every detector is
+tested twice: it must fire on the defect and stay silent on a clean panel. A detector
+that only ever fires is not a test, it is an alarm.
+
+Findings are labelled F1-F5 to match the investigation notes:
+  F1  Thomson s34 AAPL: 4.5x seasonal share swing, owner count flat  (UNDIAGNOSED -> now diagnosed)
+  F2  EDGAR 13F is clean where Thomson is not                        (control)
+  F3  S12 looks healthier but is unverified                          (weak-signal case)
+  F4  13F `value` changes units at 2023Q1, non-uniformly
+  F5  Windows-1252 filings parsed to zero holdings rows
+"""
+
+import datetime as dt
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "skills" / "wrds" / "scripts" / "ownership_dq.py"
+)
+spec = importlib.util.spec_from_file_location("ownership_dq", MODULE_PATH)
+dq = importlib.util.module_from_spec(spec)
+sys.modules["ownership_dq"] = dq  # dataclass resolution needs the module registered
+spec.loader.exec_module(dq)  # noqa: E402
+
+P, F = 0, 0
+
+
+def check(name, cond, extra=""):
+    global P, F
+    if cond:
+        P += 1
+        print(f"  ok  {name}")
+    else:
+        F += 1
+        print(f"  FAIL {name} {extra}")
+
+
+def quarters(start_year, n):
+    """n consecutive calendar quarter-ends starting at Q1 of start_year."""
+    out = []
+    y, ends = start_year, [(3, 31), (6, 30), (9, 30), (12, 31)]
+    for i in range(n):
+        m, d = ends[i % 4]
+        out.append(dt.date(y + i // 4, m, d))
+    return out
+
+
+# ===========================================================================
+# F1. Flat owner count, collapsing shares  (Thomson s34, permno 14593)
+# ===========================================================================
+print("\nF1: flat-owner-count / collapsing-shares detector")
+
+# The measured shape: quarter-end month drives the level. Mar/Dec ~1.41e10,
+# Jun/Sep ~3.1e9, while numowners stays inside 2,195-2,427 throughout.
+thomson_aapl = []
+for i, q in enumerate(quarters(2015, 24)):
+    inflated = q.month in (3, 12)
+    thomson_aapl.append(
+        {
+            "permno": 14593,
+            "rdate": q,
+            "io_total": 1.41e10 if inflated else 3.11e9,
+            "numowners": 2195 + (i % 5) * 8,  # drifts <2%, as measured
+        }
+    )
+
+found = dq.detect_flat_owner_share_swing(thomson_aapl)
+# Two of every four transitions swing (Mar->Jun and Sep->Dec); Jun->Sep and Dec->Mar sit
+# at the same level. So ~half of all transitions flag -- 12 of 23 here, against the 41 of
+# 93 measured on the real panel. A detector that flagged *every* transition would be
+# describing a different, and wrong, defect.
+check("fires on Thomson AAPL seasonal swing", len(found) == 12, f"got {len(found)}")
+check("flags about half the transitions, as measured", 0.4 <= len(found) / 23 <= 0.6)
+check(
+    "attributes it to rescaling, not trading",
+    all(abs(f.metrics["owners_pct_change"]) <= 0.05 for f in found),
+)
+check(
+    "fold change matches the measured ~4.5x",
+    found and 4.0 <= max(f.metrics["fold_change"] for f in found) <= 5.0,
+    f"got {max(f.metrics['fold_change'] for f in found):.2f}" if found else "",
+)
+
+# A firm whose ownership genuinely grows: shares AND owners rise together.
+organic_growth = [
+    {
+        "permno": 10001,
+        "rdate": q,
+        "io_total": 1.0e9 * (1.30**i),
+        "numowners": int(500 * (1.28**i)),
+    }
+    for i, q in enumerate(quarters(2015, 12))
+]
+check(
+    "silent on organic growth (owners rise with shares)",
+    dq.detect_flat_owner_share_swing(organic_growth) == [],
+)
+
+# A real coverage failure: shares AND owners collapse together. Should NOT be
+# attributed to a units bug -- that is detect_owner_dropout's job.
+coverage_loss = [
+    {"permno": 10002, "rdate": q, "io_total": v, "numowners": n}
+    for q, v, n in zip(quarters(2019, 4), [1e10, 1e10, 2e9, 2e9], [1500, 1500, 400, 400])
+]
+check(
+    "does not claim a units bug when owners collapse too",
+    dq.detect_flat_owner_share_swing(coverage_loss) == [],
+)
+check(
+    "owner-dropout detector catches that case instead",
+    len(dq.detect_owner_dropout(coverage_loss)) == 1,
+)
+
+# ===========================================================================
+# F1 (cont). Seasonal alternation keyed to quarter-end month
+# ===========================================================================
+print("\nF1: seasonal-alternation-by-quarter-end-month detector")
+
+seasonal = dq.detect_seasonal_alternation(thomson_aapl)
+check("fires on the Thomson panel", len(seasonal) == 1, f"got {len(seasonal)}")
+check(
+    "identifies the alternation as ~4.5x",
+    seasonal and 4.0 <= seasonal[0].metrics["ratio"] <= 5.0,
+)
+check(
+    "names a Mar/Dec high month and a Jun/Sep low month",
+    seasonal
+    and seasonal[0].metrics["high_month"] in (3, 12)
+    and seasonal[0].metrics["low_month"] in (6, 9),
+)
+
+# ---- F2. EDGAR 13F control: the same firm, few-percent quarterly variation.
+# Real measured AAPL values, incl. the genuine 4:1 split at 2020Q3 left unadjusted.
+edgar_aapl_values = [
+    2.96e9, 2.86e9, 2.79e9, 2.92e9,   # 2018
+    2.68e9, 2.64e9, 2.62e9, 2.63e9,   # 2019
+    2.67e9, 2.59e9, 9.70e9, 9.61e9,   # 2020 -- split is real
+    9.39e9, 9.26e9, 9.28e9, 9.31e9,   # 2021
+]
+edgar_aapl = [
+    {"permno": 14593, "rdate": q, "io_total": v, "numowners": 2000 + i * 12}
+    for i, (q, v) in enumerate(zip(quarters(2018, 16), edgar_aapl_values))
+]
+check(
+    "silent on the EDGAR control panel (no seasonality)",
+    dq.detect_seasonal_alternation(edgar_aapl) == [],
+)
+check(
+    "requires enough quarters before judging seasonality",
+    dq.detect_seasonal_alternation(thomson_aapl[:4], min_quarters=8) == [],
+)
+
+# ===========================================================================
+# F1 (cont). Split-factor ratios, including double-adjustment
+# ===========================================================================
+print("\nF1: split-factor / double-adjustment detector")
+
+# WRDS's splits note, section 2b, verbatim shape: 4,619 shares should become
+# 4,619 x 7 = 32,333 after the 2014 AAPL split but S12 reports 4,619 x 7 x 7 = 226,331.
+double_adjusted = [
+    {"permno": 14593, "rdate": dt.date(2014, 3, 31), "io_total": 4619, "numowners": 900},
+    {"permno": 14593, "rdate": dt.date(2014, 6, 30), "io_total": 32333, "numowners": 902},
+    {"permno": 14593, "rdate": dt.date(2014, 9, 30), "io_total": 226331, "numowners": 905},
+]
+hits = dq.detect_split_factor_ratio(double_adjusted)
+kinds = {h.metrics["match_kind"] for h in hits}
+check("fires on both the 7x and the second 7x", len(hits) == 2, f"got {len(hits)}")
+check("labels the first as a plain split adjustment", "split" in kinds)
+check(
+    "matches the 49x compound case as double-adjusted",
+    any(
+        abs(h.metrics["ratio"] - 7.0) < 0.3 and h.period == dt.date(2014, 9, 30)
+        for h in hits
+    )
+    or "double-adjusted" in kinds,
+)
+
+# A 7x jump accompanied by 7x the holders is a real event (index inclusion, merger).
+real_event = [
+    {"permno": 10003, "rdate": dt.date(2020, 3, 31), "io_total": 1e8, "numowners": 100},
+    {"permno": 10003, "rdate": dt.date(2020, 6, 30), "io_total": 7e8, "numowners": 700},
+]
+check(
+    "silent when the owner count moves with the ratio",
+    dq.detect_split_factor_ratio(real_event) == [],
+)
+check(
+    "still flags it when owner gating is disabled",
+    len(dq.detect_split_factor_ratio(real_event, owners_col=None)) == 1,
+)
+# Ordinary trading does not land on a split factor.
+noise = [
+    {"permno": 10004, "rdate": q, "io_total": v, "numowners": 300}
+    for q, v in zip(quarters(2019, 4), [1.0e9, 1.63e9, 2.41e9, 3.9e9])
+]
+check("silent on non-integer growth ratios", dq.detect_split_factor_ratio(noise) == [])
+
+# ===========================================================================
+# F3. S12: weak signals must not be over-read
+# ===========================================================================
+print("\nF3: S12 early-period growth vs genuine dropouts")
+
+# index_pct climbing 1.1% -> 4.7% across 2004-05 produces >20% QoQ swings that are
+# growth off a tiny base, not defects. The detector must not cry wolf on these.
+s12_growth = [
+    {"permno": 14593, "rdate": q, "mf_total": 1.0e7 * (1.22**i), "numowners": int(90 * 1.20**i)}
+    for i, q in enumerate(quarters(2004, 8))
+]
+check(
+    "silent on early-period growth off a small base",
+    dq.detect_flat_owner_share_swing(s12_growth, shares_col="mf_total") == [],
+)
+
+# The two measured exceptions (-46.3% at 2004Q1, -44.8% at 2006Q4) with a flat owner
+# count are real candidates and must be caught.
+s12_exceptions = [
+    {"permno": 14593, "rdate": dt.date(2003, 12, 31), "mf_total": 1.00e8, "numowners": 120},
+    {"permno": 14593, "rdate": dt.date(2004, 3, 31), "mf_total": 5.37e7, "numowners": 121},
+    {"permno": 14593, "rdate": dt.date(2004, 6, 30), "mf_total": 1.02e8, "numowners": 122},
+]
+check(
+    "catches the -46.3% drop with a flat owner count",
+    len(dq.detect_flat_owner_share_swing(s12_exceptions, shares_col="mf_total")) == 2,
+)
+
+# ---- Coverage end. S12 stops 2024-12-31; a 2025 study would silently compute.
+s12_panel = [{"rdate": q, "mf_total": 1e8} for q in quarters(2023, 8)]
+check(
+    "coverage-end assertion fires when the panel stops early",
+    len(dq.detect_coverage_end(s12_panel, expected_through="2025-12-31")) == 1,
+)
+check(
+    "coverage-end assertion is silent when the panel is current",
+    dq.detect_coverage_end(s12_panel, expected_through="2024-12-31") == [],
+)
+end_finding = dq.detect_coverage_end(s12_panel, expected_through="2025-12-31")[0]
+check(
+    "reports the actual last period",
+    end_finding.metrics["last_period"] == dt.date(2024, 12, 31),
+    str(end_finding.metrics["last_period"]),
+)
+
+# ===========================================================================
+# F4. Unit discontinuity in `value` at 2023Q1 -- and its non-uniformity
+# ===========================================================================
+print("\nF4: unit-discontinuity detector on any value column")
+
+# Measured: median 442x, p90 494x, p10 only 38x. The p10 sitting far below the median
+# says the mixture is correlated with filer SIZE -- the small filers are the ones that
+# did not convert -- so the fixture models it that way rather than mixing at random.
+# (Mixing at random against a wide base distribution washes out in the quantiles and
+# would make this test pass for the wrong reason.)
+before = [{"rdate": dt.date(2022, 12, 31), "value": 100.0 * (1.03**i)} for i in range(200)]
+_cut = sorted(r["value"] for r in before)[int(0.3 * len(before))]
+after = [
+    {
+        "rdate": dt.date(2023, 3, 31),
+        "value": r["value"] * (30.0 if r["value"] < _cut else 1000.0),
+    }
+    for r in before
+]
+mixed = before + after
+
+units = dq.detect_unit_discontinuity(mixed)
+check("fires on the 2023Q1 units break", len(units) == 1, f"got {len(units)}")
+check(
+    "flags the break as NOT clean (mixed population)",
+    units and units[0].metrics["clean_break"] is False,
+)
+check(
+    "says plainly that no scalar repairs it",
+    units and "no scalar repairs it" in units[0].detail,
+)
+check(
+    "reports p10 far below the median shift",
+    units
+    and units[0].metrics["quantile_ratios"]["p10"]
+    < units[0].metrics["quantile_ratios"]["median"],
+)
+
+# A genuinely uniform rescale (every filer converts at once) is a different animal:
+# still flagged, but marked clean, because one scalar does repair it.
+uniform = before + [
+    {"rdate": dt.date(2023, 3, 31), "value": r["value"] * 1000.0} for r in before
+]
+uniform_hit = dq.detect_unit_discontinuity(uniform)
+check("fires on a uniform rescale too", len(uniform_hit) == 1)
+check(
+    "marks the uniform rescale as a clean break",
+    uniform_hit and uniform_hit[0].metrics["clean_break"] is True,
+)
+
+# Ordinary quarter-over-quarter drift must not trip it.
+stable = []
+for q in quarters(2021, 4):
+    stable += [{"rdate": q, "value": 100.0 * (1.02**i)} for i in range(200)]
+check("silent on a stable value column", dq.detect_unit_discontinuity(stable) == [])
+check(
+    "ignores periods with too few observations to judge",
+    dq.detect_unit_discontinuity(mixed, min_obs_per_period=500) == [],
+)
+
+# ===========================================================================
+# F5. Windows-1252 filings that parsed to zero rows
+# ===========================================================================
+print("\nF5: zero-row-cohort detector")
+
+filings = []
+# Healthy cohort: utf-8 filings parse fine.
+for i in range(300):
+    filings.append(
+        {
+            "encoding": "utf-8",
+            "agent": "AgentA",
+            "rdate": quarters(2023, 4)[i % 4],
+            "n_rows": 120 + i,
+        }
+    )
+# Broken cohort: windows-1252 filings all parse to zero rows.
+for i in range(60):
+    filings.append(
+        {
+            "encoding": "windows-1252",
+            "agent": "AgentB",
+            "rdate": quarters(2023, 4)[i % 4],
+            "n_rows": 0,
+        }
+    )
+
+by_encoding = dq.detect_zero_row_cohort(filings, cohort_col="encoding")
+check("isolates the broken encoding cohort", len(by_encoding) == 1, f"got {len(by_encoding)}")
+check(
+    "names windows-1252 as the culprit",
+    by_encoding and by_encoding[0].entity == "windows-1252",
+)
+check("reports a 100% zero rate", by_encoding and by_encoding[0].metrics["zero_rate"] == 1.0)
+
+by_agent = dq.detect_zero_row_cohort(filings, cohort_col="agent", period_col="rdate")
+check("also groups by filing agent", len(by_agent) == 1 and by_agent[0].entity == "AgentB")
+check(
+    "exposes the per-period rate so a time step is visible",
+    by_agent and len(by_agent[0].metrics["zero_rate_by_period"]) == 4,
+)
+check(
+    "silent once the parser is fixed",
+    dq.detect_zero_row_cohort(
+        [dict(f, n_rows=f["n_rows"] or 95) for f in filings], cohort_col="encoding"
+    )
+    == [],
+)
+check(
+    "ignores cohorts too small to conclude anything",
+    dq.detect_zero_row_cohort(filings[:5] + filings[300:305], cohort_col="encoding") == [],
+)
+
+# ===========================================================================
+# Cross-cutting: input handling
+# ===========================================================================
+print("\nCross-cutting: input handling")
+
+check(
+    "accepts ISO date strings as well as date objects",
+    len(
+        dq.detect_flat_owner_share_swing(
+            [
+                {"permno": 1, "rdate": "2020-03-31", "io_total": 1e9, "numowners": 100},
+                {"permno": 1, "rdate": "2020-06-30", "io_total": 4e9, "numowners": 101},
+            ]
+        )
+    )
+    == 1,
+)
+check(
+    "skips records with a missing metric instead of reading them as zero",
+    dq.detect_flat_owner_share_swing(
+        [
+            {"permno": 1, "rdate": "2020-03-31", "io_total": None, "numowners": 100},
+            {"permno": 1, "rdate": "2020-06-30", "io_total": 4e9, "numowners": 100},
+        ]
+    )
+    == [],
+)
+check("handles an empty panel", dq.detect_flat_owner_share_swing([]) == [])
+check(
+    "keeps entities separate",
+    len(
+        dq.detect_seasonal_alternation(
+            thomson_aapl + [dict(r, permno=999) for r in edgar_aapl]
+        )
+    )
+    == 1,
+)
+
+print(f"\n{P} passed, {F} failed")
+sys.exit(1 if F else 0)

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -309,6 +309,41 @@ check(
     == ["contraction"],
 )
 
+# ---- crsp.holdings is monthly, and quarter-end months carry ~40% more funds.
+# Mixing them manufactures a fake seasonal pattern -- the same shape as the Thomson
+# defect, from an entirely benign cause. Verified on AAPL: ~1,600 funds at quarter-ends
+# vs ~1,140 at intermediate months. The detector must fire, so the trap is caught.
+nport_monthly = []
+for year in (2021, 2022):
+    for month in range(1, 13):
+        last = {1: 31, 2: 28, 3: 31, 4: 30, 5: 31, 6: 30,
+                7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31}[month]
+        quarter_end = month in (3, 6, 9, 12)
+        nport_monthly.append(
+            {
+                "permno": 14593,
+                "rdate": dt.date(year, month, last),
+                "mf_total": 9.4e8 if quarter_end else 6.6e8,
+                "numowners": 1600 if quarter_end else 1140,
+            }
+        )
+check(
+    "catches a naive monthly N-PORT mix as a seasonal artifact",
+    len(dq.detect_seasonal_alternation(nport_monthly, metric_col="mf_total")) == 1,
+)
+check(
+    "filtering to quarter-end months makes it clean",
+    dq.detect_seasonal_alternation(
+        [r for r in nport_monthly if r["rdate"].month in (3, 6, 9, 12)],
+        metric_col="mf_total",
+    )
+    == [],
+)
+check(
+    "and the owner count moves with it, so it is NOT a units bug",
+    dq.detect_flat_owner_share_swing(nport_monthly, shares_col="mf_total") == [],
+)
+
 # ---- MFLINKS bridge regression across the same boundary.
 print("\nF3: MFLINKS bridge-rate detector")
 

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -327,21 +327,42 @@ for year in (2021, 2022):
                 "numowners": 1600 if quarter_end else 1140,
             }
         )
+# The cadence effect is real but MODEST -- ~1.4x, against the 4.5x Thomson defect. The
+# 1.5x default threshold therefore treats it as benign, which is the correct call: a
+# detector that flagged N-PORT's reporting cadence as a data defect would be crying wolf
+# on every fund panel. It is still large enough to contaminate a regression that mixes
+# cadences, so the guard is to filter, not to alarm.
 check(
-    "catches a naive monthly N-PORT mix as a seasonal artifact",
-    len(dq.detect_seasonal_alternation(nport_monthly, metric_col="mf_total")) == 1,
+    "does NOT flag benign N-PORT cadence at the default threshold",
+    dq.detect_seasonal_alternation(nport_monthly, metric_col="mf_total") == [],
 )
 check(
-    "filtering to quarter-end months makes it clean",
+    "but the cadence effect is visible if you lower the threshold",
+    len(
+        dq.detect_seasonal_alternation(
+            nport_monthly, metric_col="mf_total", ratio_threshold=1.3
+        )
+    )
+    == 1,
+)
+check(
+    "filtering to quarter-end months clears it at any threshold",
     dq.detect_seasonal_alternation(
         [r for r in nport_monthly if r["rdate"].month in (3, 6, 9, 12)],
         metric_col="mf_total",
+        ratio_threshold=1.05,
     )
     == [],
 )
 check(
-    "and the owner count moves with it, so it is NOT a units bug",
+    "owner count moves with the cadence, so it is not mistaken for a units bug",
     dq.detect_flat_owner_share_swing(nport_monthly, shares_col="mf_total") == [],
+)
+# The Thomson defect clears the same threshold by a wide margin -- the two are not
+# close calls, which is why one default separates them.
+check(
+    "the real Thomson defect sits far above the benign cadence effect",
+    dq.detect_seasonal_alternation(thomson_aapl)[0].metrics["ratio"] > 3.0,
 )
 
 # ---- MFLINKS bridge regression across the same boundary.

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -435,6 +435,64 @@ check(
 )
 
 # ===========================================================================
+# S12 x crsp.holdings union: the unresolved-overlap guard
+# ===========================================================================
+print("\nUnion: unresolved-overlap detector")
+
+# Measured composition at 2022-12-31, scaled down 10x. Of 60,184 funds:
+#   crsp-bridged       7,180  -> source=crsp
+#   non-US unbridged  48,210  -> source=s12, safe (CRSP never covered them)
+#   US unbridged       4,649  -> source=s12, AMBIGUOUS (~7.7%)
+union_panel = (
+    [{"rdate": dt.date(2022, 12, 31), "source": "crsp", "bridged": True} for _ in range(718)]
+    + [
+        {"rdate": dt.date(2022, 12, 31), "source": "s12", "bridged": True, "note": "non-US, classified"}
+        for _ in range(4821)
+    ]
+    + [
+        {"rdate": dt.date(2022, 12, 31), "source": "s12", "bridged": False, "note": "US unbridged"}
+        for _ in range(465)
+    ]
+)
+overlap = dq.detect_unresolved_overlap(union_panel)
+check("fires on the unresolved US-unbridged mass", len(overlap) == 1, f"got {len(overlap)}")
+check(
+    "quantifies it near the measured 7.7%",
+    overlap and 0.070 <= overlap[0].metrics["unresolved_rate"] <= 0.085,
+    f"{overlap[0].metrics['unresolved_rate']:.3f}" if overlap else "",
+)
+check(
+    "says plainly the data cannot distinguish new coverage from duplication",
+    overlap and "does not say which" in overlap[0].detail,
+)
+# Classifying the non-US mass as resolved is what makes the union safe -- if you
+# instead leave every unbridged fund unclassified, exposure is 88%, not 8%.
+naive = [
+    dict(r, bridged=False) if r["source"] == "s12" else r for r in union_panel
+]
+check(
+    "naive union (nothing classified) is far worse",
+    dq.detect_unresolved_overlap(naive)[0].metrics["unresolved_rate"] > 0.85,
+)
+check(
+    "clean once every secondary record is classified",
+    dq.detect_unresolved_overlap(
+        [dict(r, bridged=True) for r in union_panel]
+    )
+    == [],
+)
+check(
+    "reports per-period when asked",
+    len(
+        dq.detect_unresolved_overlap(
+            union_panel + [dict(r, rdate=dt.date(2016, 12, 31)) for r in union_panel],
+            period_col="rdate",
+        )
+    )
+    == 2,
+)
+
+# ===========================================================================
 # F4. Unit discontinuity in `value` at 2023Q1 -- and its non-uniformity
 # ===========================================================================
 print("\nF4: unit-discontinuity detector on any value column")

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -492,6 +492,36 @@ check(
     == 2,
 )
 
+# ---- Bridge claim check: a resolved fund may land on an already-claimed portfolio.
+# Measured in the SEC series-ID investigation: 27.4% of newly-resolved funds hit a
+# crsp_portno another bridged fundno already claims. Raising bridge coverage while
+# doubling portfolios is worse than not bridging at all, so the claim check is the
+# gate between "matched" and "admitted".
+resolved_map = (
+    [{"fundno": 1000 + i, "crsp_portno": 500 + i, "rdate": dt.date(2022, 12, 31)}
+     for i in range(100)]
+    # 27 newly-resolved funds collide onto portfolios already claimed above.
+    + [{"fundno": 9000 + i, "crsp_portno": 500 + i, "rdate": dt.date(2022, 12, 31)}
+       for i in range(27)]
+)
+collisions = dq.detect_duplicate_grain(
+    resolved_map, grain=("crsp_portno", "rdate")
+)
+check("claim check catches already-claimed portfolios", len(collisions) == 1)
+check(
+    "sizes the collision near the measured 27%",
+    collisions and 0.20 <= collisions[0].metrics["duplicate_key_rate"] <= 0.30,
+    f"{collisions[0].metrics['duplicate_key_rate']:.3f}" if collisions else "",
+)
+check(
+    "a one-fundno-per-portfolio map passes",
+    dq.detect_duplicate_grain(resolved_map[:100], grain=("crsp_portno", "rdate")) == [],
+)
+check(
+    "and the same rows look fine at fundno grain -- the wrong key hides it",
+    dq.detect_duplicate_grain(resolved_map, grain=("fundno", "rdate")) == [],
+)
+
 # ===========================================================================
 # F4. Unit discontinuity in `value` at 2023Q1 -- and its non-uniformity
 # ===========================================================================

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -248,6 +248,136 @@ check(
     str(end_finding.metrics["last_period"]),
 )
 
+# ---- S12 splits. The splits note's worked examples are ALL mutual-fund data, and MF
+# outlier rates around large splits are WORSE than 13F (40.7% vs 34.5% above 4:1).
+# "S12 looks healthier" was measured on one firm with no split-quarter test; the note
+# tests a dimension we had not. So S12 gets the same split detector, not a lighter one.
+s12_split = [
+    {"permno": 14593, "rdate": dt.date(2014, 3, 31), "mf_total": 8.0e7, "numowners": 410},
+    {"permno": 14593, "rdate": dt.date(2014, 6, 30), "mf_total": 5.6e8, "numowners": 412},
+]
+check(
+    "applies the split detector to S12, not just S34",
+    len(dq.detect_split_factor_ratio(s12_split, shares_col="mf_total")) == 1,
+)
+
+# ---- S12 2017Q4 feed change: counts step, values do not. A different detector.
+print("\nF3: S12 feed-change / coverage-step detector")
+
+# Measured by WRDS: CUSIPs +613%, unique funds +113% at 2017Q4.
+s12_coverage = [
+    {"rdate": dt.date(2017, 6, 30), "n_funds": 25_000, "n_cusips": 60_000},
+    {"rdate": dt.date(2017, 9, 30), "n_funds": 25_400, "n_cusips": 61_000},
+    {"rdate": dt.date(2017, 12, 31), "n_funds": 54_100, "n_cusips": 435_000},
+    {"rdate": dt.date(2018, 3, 31), "n_funds": 55_000, "n_cusips": 440_000},
+]
+steps = dq.detect_coverage_step(s12_coverage)
+check("fires on the 2017Q4 feed change", len(steps) == 2, f"got {len(steps)}")
+check(
+    "dates the step to 2017Q4",
+    steps and all(s.period == dt.date(2017, 12, 31) for s in steps),
+)
+check(
+    "labels it an expansion, not a loss",
+    steps and all(s.metrics["direction"] == "expansion" for s in steps),
+)
+check(
+    "reports the CUSIP step near the documented +613%",
+    any(
+        s.entity == "n_cusips" and 6.0 <= s.metrics["pct_change"] <= 6.5 for s in steps
+    ),
+)
+check(
+    "silent on smooth quarter-to-quarter coverage growth",
+    dq.detect_coverage_step(
+        [{"rdate": q, "n_funds": int(25_000 * 1.03**i)} for i, q in enumerate(quarters(2012, 8))]
+    )
+    == [],
+)
+# Same detector must catch a step DOWN -- the 2019Q3-Q4 S34 outage.
+check(
+    "also catches a coverage contraction",
+    [
+        f.metrics["direction"]
+        for f in dq.detect_coverage_step(
+            [
+                {"rdate": dt.date(2019, 6, 30), "n_funds": 3500},
+                {"rdate": dt.date(2019, 9, 30), "n_funds": 900},
+            ]
+        )
+    ]
+    == ["contraction"],
+)
+
+# ---- MFLINKS bridge regression across the same boundary.
+print("\nF3: MFLINKS bridge-rate detector")
+
+# Measured: ~77% pre-2017 -> ~58-66% after, because MFLINKS was not backfilled.
+bridge = [
+    {"rdate": dt.date(2016, 12, 31), "n_linked": 7700, "n_total": 10_000},
+    {"rdate": dt.date(2017, 6, 30), "n_linked": 7690, "n_total": 10_000},
+    {"rdate": dt.date(2017, 12, 31), "n_linked": 11_500, "n_total": 19_500},
+    {"rdate": dt.date(2018, 6, 30), "n_linked": 11_600, "n_total": 19_800},
+]
+bridge_hits = dq.detect_bridge_rate_regression(bridge)
+kinds = {f.kind for f in bridge_hits}
+check("fires on the MFLINKS cliff", bridge_hits != [])
+check("reports it as a regression, not just a low level", "bridge_rate_regression" in kinds)
+check(
+    "dates the regression to the 2017Q4 feed change",
+    any(
+        f.kind == "bridge_rate_regression" and f.period == dt.date(2017, 12, 31)
+        for f in bridge_hits
+    ),
+)
+check(
+    "also flags the post-change level against the floor",
+    "bridge_rate_low" in kinds,
+)
+check(
+    "silent on a healthy, stable bridge",
+    dq.detect_bridge_rate_regression(
+        [{"rdate": q, "n_linked": 7700, "n_total": 10_000} for q in quarters(2012, 4)]
+    )
+    == [],
+)
+
+# ---- Duplicate grain: the 2014 double-reporting blip and the wficn/fundno dedup bug.
+print("\nF3: duplicate-grain detector")
+
+clean_holdings = [
+    {"wficn": w, "rdate": dt.date(2014, 6, 30), "cusip8": "03783310", "shares": 1000.0}
+    for w in range(500)
+]
+check(
+    "silent when the grain is genuinely unique",
+    dq.detect_duplicate_grain(clean_holdings, grain=("wficn", "rdate", "cusip8")) == [],
+)
+
+# One wficn -> mean ~3.5 crsp_fundno share classes. Dedup on the wrong key and the
+# panel multiplies -- the documented ~3.95x MF_TOTAL inflation.
+share_class_dupes = [
+    dict(r, crsp_fundno=r["wficn"] * 10 + k)
+    for r in clean_holdings
+    for k in range(4)
+]
+dupe_hits = dq.detect_duplicate_grain(
+    share_class_dupes, grain=("wficn", "rdate", "cusip8"), value_col="shares"
+)
+check("catches share-class duplication at the wficn grain", len(dupe_hits) == 1)
+check(
+    "quantifies the inflation at ~4x, matching the measured 3.95x",
+    dupe_hits and 3.9 <= dupe_hits[0].metrics["inflation_factor"] <= 4.1,
+    str(dupe_hits[0].metrics.get("inflation_factor")) if dupe_hits else "",
+)
+check(
+    "the same rows are clean at the share-class grain",
+    dq.detect_duplicate_grain(
+        share_class_dupes, grain=("wficn", "crsp_fundno", "rdate", "cusip8")
+    )
+    == [],
+)
+
 # ===========================================================================
 # F4. Unit discontinuity in `value` at 2023Q1 -- and its non-uniformity
 # ===========================================================================


### PR DESCRIPTION
## What

Seven firm-agnostic detectors for holdings-panel defects (`skills/wrds/scripts/ownership_dq.py`, stdlib only) plus 42 assertions (`tests/ownership_dq_test.py`) that run without WRDS credentials. Each detector is tested **both ways** — it must fire on the defect and stay silent on a clean panel.

Run: `uv run python3 tests/ownership_dq_test.py`

## Finding #1 is now diagnosed

WRDS's ***Note on Splits in TR Mutual Funds and 13F*** (March 2017) uses **permno 14593 — Apple** — as its own running example, and documents split adjustments applied twice (S12 reporting `4,619 × 7 × 7 = 226,331` where `32,333` was correct: "an erroneous 1-to-49 split") and applied at the wrong date.

AAPL's split ex-dates — 2014-06-09 (7:1) and 2020-08-31 (4:1) — **both fall in Jun/Sep quarters**. A handful of catastrophically over-adjusted quarters moves a 23-quarter mean by ~4.5× while the set of reporting managers never changes, which is exactly the measured shape: shares swing, `numowners` flat at ~2,200.

Magnitudes from the note: outlier rates around split quarters are **13.8% at Qtr(0), 14.1% at Qtr(−1)** for 13Fs against a 5% null, rising to **34.5% for splits above 4:1**. The note rules out the obvious explanations — restricting to `rdate == fdate` does not help, nor does restricting to splits whose ex- and record dates share a quarter.

**Decision-relevant:** WRDS states plainly there is **no clean systemic fix**; their mitigation is winsorizing Qtr(−1..+1) around splits. So **fixing `HAVING fdate = MIN(fdate)` vintage selection alone will not repair this** — the defect is in Thomson's pre-adjustment of `shares`, not in which vintage you select. Thomson's pre-2013 history can be kept if split-adjacent quarters are winsorized; that is a real option, but it is not free.

## A contradiction between two WRDS documents

The splits note's table legend says *"Column 1 is the vintage date… Rdate. Column 2, Fdate, is the date when holdings are valid"* — **backwards** relative to both the WRDS Overview and the May 2017 S34 note, which agree with each other and with the observed data. **FDATE = vintage.** Recorded because acting on the splits note's legend inverts your join and reproduces the D1 defect deliberately.

## Notes read

| Note | Contributes |
|---|---|
| Splits note (Mar 2017) | **Finding #1** — double adjustment, wrong-date adjustment, no clean fix |
| S34 Data Issues (May 2017) | Post-2013 collapse; BlackRock missing 2014-06→2015-03; AAPL zero owners after 2015-06; 19.4% of institutional ownership missing in 2015 |
| Regenerated Data 2010-2016 (Jun 2018) | 2010–16 regenerated; corrupt original preserved at `/wrds/tfn/sasdata_archive` |
| Data Issues (Feb 2022) | 2019Q3–Q4 filers 1,500+ → <500; 2011-03→2013-03 incomplete |
| Updates (Apr / Aug 2022) | 2019Q3–Q4 and S12 2017Q4/2019Q4 patched; **pre-2011 permanently unfixable** |
| S12 Feed Change (Jan 2023) | 2017Q4 legacy SP → strategic collection: CUSIPs **+613%**, funds +113%; MFLINKS not backfilled 2017Q4–2020Q2 |

## Where a note is silent

**No WRDS note documents the 13F `value` unit change at 2023Q1.** That gap is recorded as a gap. The measurement stands on its own: median 442×, p90 494×, **p10 only 38×** — the population is mixed, so no scalar repairs it, and `detect_unit_discontinuity` reports `clean_break=False` rather than offering a rescale. The p10/p90 spread implies the mixture correlates with filer size, and the test fixture models it that way — mixing at random washes out in the quantiles and would pass for the wrong reason.

## Measurements vs notes

Nothing measured was contradicted by a note. EDGAR 13F remains the clean control (few-percent quarterly variation, monotone filer counts, the 2020 4:1 split appearing exactly once). The notes *explain* Thomson's defect and *bound* it; they do not excuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7ZiMMagxL2vnkxnpVbSKs