### PR TITLE
test(wrds): detectors for the defect class that imitates a vendor defect

### DIFF
--- a/skills/wrds/SKILL.md
+++ b/skills/wrds/SKILL.md
@@ -342,8 +342,9 @@ Detailed query patterns and table documentation:
 - **`references/execucomp.md`** - ExecuComp: CEO anncomp, legacy codirfin vs current directorcomp, firm-year aggregation
 - **`references/iss-directors.md`** - ISS Directors: risk.directors + risk.rmdirectors, type harmonization, 1996 gender backfill, S&P 1500 filter
 - **`references/iss-voting.md`** - ISS Voting Analytics: vavoteresults, voteanalysis_npx, base-conditional turnout/forpct, agenda codes
-- **`references/tfn-ownership.md`** - Thomson 13-F (S34) institutional ownership and S12 mutual-fund holdings via MFLINKS, passive/index classification, and **Known Data Defects** (WRDS research notes D1-D7: split mis-adjustment, post-2013 coverage collapse, 2017Q4 S12 feed change, 13F value unit break). Read the defects section before trusting any split-era or post-2013 quarter.
-  - Detectors: `scripts/ownership_dq.py` (10 detectors, S12 and S34) — run these against any holdings panel before analysis. Tests: `tests/ownership_dq_test.py`.
+- **`references/tfn-ownership.md`** - Thomson 13-F (S34) institutional ownership and S12 mutual-fund holdings via MFLINKS, passive/index classification, and **Known Data Defects** (D1-D9: split mis-adjustment, post-2013 coverage collapse, 2017Q4 S12 feed change, 13F value unit break, and two that are *yours* not the vendor's — D8 silent Int8 date overflow, D9 ownership above 100%). Read the defects section before trusting any split-era or post-2013 quarter.
+  - Detectors: `scripts/ownership_dq.py` (14 detectors, S12 and S34) — run these against any holdings panel before analysis. Tests: `tests/ownership_dq_test.py` (79 assertions, stdlib only).
+  - Run `detect_calendar_bucket_gap` on every **reference/dimension table** at build time, not just on the output panel. It is the one detector that catches a root cause rather than a symptom: a reference table missing a whole calendar bucket makes every downstream join fall back to a default, silently, and the result looks like a vendor defect (see D8).
 - **`references/lpc-dealscan.md`** - LPC DealScan: legacy vs 2021+ flat schema, borrower ids, the gvkey link and its grain caveats
 - **`references/muni-bonds.md`** - Municipal bonds: MSRB RTRS trades, SDC municipals
 - **`references/wrds-forms-tables.md`** - `wrdssec_all.wrds_forms` and friends: filing metadata tables and their columns

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -418,6 +418,83 @@ filings start 1999 and XML only in 2013.
 
 ---
 
+### D8. Your own date arithmetic — the defect that imitates a vendor defect
+
+**Not a WRDS issue at all.** Recorded here because it cost weeks of misattribution: the
+symptom is indistinguishable from D1 (Thomson's split double-adjustment), and it was
+blamed on Thomson before being traced home.
+
+polars' `dt.month()` returns **Int8**. The ubiquitous date-key idiom
+
+```python
+pl.col("date").dt.year() * 10000 + pl.col("date").dt.month() * 100 + pl.col("date").dt.day()
+```
+
+overflows for every month ≥ 2 — `2 * 100 = 200 > 127` — and wraps **negative**, silently.
+Only January survives:
+
+| date | produced | correct |
+|---|---|---|
+| 2020-01-31 | 20200131 | ✓ |
+| 2020-02-29 | 20199973 | 20200229 |
+| 2020-03-31 | 20200075 | 20200331 |
+| 2020-12-31 | 20199951 | 20201231 |
+
+A quarter-snap downstream read `20199973` as "month 99" and `20200075` as "month 0",
+bucketing them into Q4-of-the-prior-year and Q1. The CRSP reference panel ended up
+holding **only March and December** quarter-ends: 193,335 rows where 370,630 were
+correct.
+
+**What made it expensive is that nothing raised.** The output was a full-looking table of
+plausible eight-digit integers. Every June and September holdings quarter missed the
+join, fell back to `cfacshr = 1` and a null denominator, and produced `ior = 0` for
+**49% of the panel** — while March and December carried 4× and 28× split factors. Net
+effect on AAPL: quarter means of 1.41e10 / 3.11e9 / 3.31e9 / 1.41e10 with `numowners`
+flat at ~2,200, because owner counts do not depend on `cfacshr` so only the shares moved.
+That is exactly the D1 signature.
+
+**Fix:** cast before the multiply, and cast back afterwards if a downstream frame is
+typed Int32 (`vstack` raises on a widened type).
+
+```python
+(pl.col("date").dt.year().cast(pl.Int64) * 10000
+ + pl.col("date").dt.month().cast(pl.Int64) * 100
+ + pl.col("date").dt.day().cast(pl.Int64)).cast(pl.Int32)
+```
+
+`dt.quarter()` is Int8 too — the same trap caught the *comparison script written to check
+this very bug*, which is a fair measure of how easy it is to hit.
+
+**Guard, do not eyeball.** Assert bucket coverage on every reference panel at build time,
+and assert it again on load — a cached input accepted without a coverage check is how a
+March/December-only panel survived into production.
+
+→ Detectors: `detect_calendar_bucket_gap` (run it on the **reference table**, where it
+catches the root cause; it is silent on the output panel, whose holdings side was always
+complete) and `detect_join_gap_clustering` (run it on the **output**, where the null rate
+for the joined column was 100% in Jun/Sep against 53% in Mar/Dec — a 47.5% spread that
+collapsed to 0.9% after the fix). Note the *level* of the null rate is not the signal:
+~54% is correct and expected, because 13F legitimately holds ADRs and closed-end funds
+with no CRSP common-stock match. The **spread across buckets** is the signal.
+
+### D9. Held shares exceeding shares outstanding — open, in EDGAR 13F
+
+Surfaced by `detect_impossible_ratio` on the rebuilt EDGAR panel: **7.0% of non-zero
+observations exceed 100% ownership, 2.9% exceed 120%**, concentrated in the pre-XML
+`parse_mode = "text"` era. AAPL 2003-09-30 shows 4.90e10 shares held against 2.05e10
+outstanding (239%), bracketed by quarters at a sane 45% and 60%.
+
+The aggregation sums `shares` within `(cik, cusip8, rdate)`, so duplicate rows *inside* a
+single accession inflate rather than deduplicate. Candidate causes not yet separated:
+text-parser row duplication, one manager filing under multiple CIKs, and 13F
+double-counting proper — `investment_discretion` (SOLE/DFND/OTR) and `other_manager`
+exist precisely so shares reported by both a sub-advisor and its parent are not counted
+twice, and the current build ignores both.
+
+Worth knowing: **vendor panels often clip this ratio at 100%, so the defect is invisible
+in them.** A panel built from raw filings does not clip, which is why the violations are
+visible and countable here. Do not read the clip as cleanliness.
+
 ## The S12 alternative: `crsp.holdings` (verified on the WRDS grid)
 
 **S12 does not need an EDGAR/N-PORT parser.** WRDS already carries CRSP Mutual Fund

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -477,23 +477,118 @@ collapsed to 0.9% after the fix). Note the *level* of the null rate is not the s
 ~54% is correct and expected, because 13F legitimately holds ADRs and closed-end funds
 with no CRSP common-stock match. The **spread across buckets** is the signal.
 
-### D9. Held shares exceeding shares outstanding — open, in EDGAR 13F
+### D9. Held shares exceeding shares outstanding — DIAGNOSED (EDGAR 13F parser)
 
 Surfaced by `detect_impossible_ratio` on the rebuilt EDGAR panel: **7.0% of non-zero
 observations exceed 100% ownership, 2.9% exceed 120%**, concentrated in the pre-XML
-`parse_mode = "text"` era. AAPL 2003-09-30 shows 4.90e10 shares held against 2.05e10
-outstanding (239%), bracketed by quarters at a sane 45% and 60%.
+`parse_mode = "text"` era. AAPL 2003-09-30 showed 239%, bracketed by quarters at a sane
+45% and 60%.
 
-The aggregation sums `shares` within `(cik, cusip8, rdate)`, so duplicate rows *inside* a
-single accession inflate rather than deduplicate. Candidate causes not yet separated:
-text-parser row duplication, one manager filing under multiple CIKs, and 13F
-double-counting proper — `investment_discretion` (SOLE/DFND/OTR) and `other_manager`
-exist precisely so shares reported by both a sub-advisor and its parent are not counted
-twice, and the current build ignores both.
+**Root cause: mis-parsed rows in the text parser, identifiable by `value = 0` with a large
+`shares`.** Not any of the three original suspects.
 
-Worth knowing: **vendor panels often clip this ratio at 100%, so the defect is invisible
-in them.** A panel built from raw filings does not clip, which is why the violations are
-visible and countable here. Do not read the clip as cleanliness.
+AAPL 2003-09-30, decomposed at the row level, is one row:
+
+| cik | shares | value | form | parse_mode | issuer |
+|---|---|---|---|---|---|
+| 728100 | **719,257,141** | **0** | 13F-HR/A | text | `APPLE COMPUTER, INC.` |
+
+The next-largest holder that quarter reports 19.8M. The same CIK reports 3,038,253,827
+shares of Exxon Mobil with `value = 0` — more than Exxon's entire float. A 13F holding
+with zero value and hundreds of millions of shares is not a holding; it is a parse
+failure, and `value` is what exposes it.
+
+#### The three candidate causes were tested and all three are ruled out
+
+| Candidate | Test | Result |
+|---|---|---|
+| Duplicate rows within an accession | dedup on `(accession, cusip8, shares, discretion, other_manager)` | removes **~0.0%** — not duplication |
+| `shares_type` contamination (PRN) | filter `shares_type = 'SH'` | removes **0.0%** — every AAPL row is already `SH` |
+| Sub-advisor double-counting | `other_manager` populated? | **0.0% of text-era rows populate it** |
+
+The third deserves emphasis: **`other_manager` is never populated in `parse_mode = "text"`,
+and `investment_discretion` is NULL on ~70% of those rows.** The text parser does not
+extract either column. So no discretion-based dedup rule — WRDS's or anyone's — can be
+applied before 2013. The columns are not merely unused; the data is absent. Filtering to
+`investment_discretion = 'SOLE'` "fixes" the violating quarters only because it discards
+70–94% of all rows, including in quarters that were already clean (2003-06-30 falls from
+45% to 13.5%). That is data destruction, not a fix.
+
+#### The fix, measured
+
+Drop rows where `value = 0 AND shares > 100,000`. A genuine holding worth under $1,000
+(value is in $1000s) cannot carry 100,000 shares at any plausible price.
+
+| Quarter | before | after | rows dropped |
+|---|---|---|---|
+| 2003-09-30 | 239% | **47.8%** | 1 |
+| 2004-06-30 | 262% | **58.8%** | 1 |
+| 2004-12-31 | 194% | **65.1%** | 2 |
+| 2003-06-30 (clean) | 45% | **45.0%** | 0 |
+| 2003-12-31 (clean) | 60% | **60.0%** | 0 |
+
+Violating quarters fall below 100%; already-clean quarters are untouched. Panel-wide the
+rule removes **86,509 rows** carrying **13.88% of all share mass** — the mass is real and
+enormous, the row count is tiny.
+
+**Choose the threshold, do not drop all `value = 0` rows.** At `T = 0` the rule removes
+2,820,455 rows for the same 13.89% of mass: 33× the rows for no additional benefit,
+because a legitimate sub-$1,000 holding rounds to `value = 0` (median such row is 479
+shares). `T = 100,000` captures 99.9% of the bad mass at 3% of the row cost.
+
+**Safe to apply panel-wide.** The pathology is text-specific: `text` + `value=0` carries
+13.87% of all share mass, `xml` + `value=0` carries **0.02%** (p99 of 100,000 shares, so
+the threshold barely bites). Applying it everywhere costs almost nothing after 2013 and
+needs no era switch.
+
+Proposed change to `mirror scripts/build_inst_own.py`, in `load_13f_holdings` alongside
+the existing F6 safety net — **proposed, not landed; that repo has its own open PR**:
+
+```python
+# F8: drop parse-failure rows — zero value with a large share count is not a
+# holding. Text parser only in practice; harmless post-2013.
+.filter(~((pl.col("value") == 0) & (pl.col("shares") > 100_000)))
+```
+
+#### What WRDS prescribes — and why it is not enough here
+
+*Research Note Regarding Thomson-Reuters Ownership Data Issues*, WRDS Research, May 2017
+(`/documents/533/Research_Note_-Thomson_S34_Data_Issues.pdf`) does address this, in the
+Data Fix Code rather than the prose. Step 3 is titled "using CRSP shares outstanding to
+winsorize holdings values at the 50% level of total shares outstanding":
+
+```sas
+if pct>0.5 then pct=0.5;   /* pct = shares / (shrout*1000), per cik-rdate-permno */
+```
+
+Three things to note, and each one matters:
+
+1. **It is a cap, not a repair, and WRDS says so.** Their comment: *"Further investigation
+   is warranted to determine if a single institution is truely holding more than 50% of
+   total shares outstanding."* They screen the symptom without diagnosing it — the same
+   posture as the splits note. Our row-level diagnosis goes further than the note does.
+2. **It is scoped to 2013+.** The surrounding code runs `%crspmerge(start=01JAN2013…)` —
+   the XML era. It was never validated on the text era, which is exactly where our
+   violations live.
+3. **A 50% cap would mask this defect, not remove it.** Capping the 719M AAPL row leaves a
+   fabricated 50% holding standing. This is precisely the clipping behaviour that makes
+   the defect invisible in vendor panels — WRDS's own pipeline clips at 50% per manager.
+   **Do not read a clipped series as a clean one.**
+
+WRDS scale estimate for their screen: "about 300 cases per quarter … out of 1.4 million
+holding records" (~0.02%). Our text-era incidence is far higher, consistent with the
+defect being our parser's rather than Thomson's.
+
+⚠️ I could not search the WRDS site for a *dedicated* note on this topic — the browser
+session's WRDS authentication expired mid-task (`/documents/` now returns the login page).
+The above is from the May 2017 note already retrieved. If a dedicated note exists, it has
+not been ruled out.
+
+→ Detector: `detect_implied_price_outlier` — flags rows whose implied price
+(`value × 1000 / shares`) is outside a plausible band. It catches this defect at row level
+rather than waiting for the aggregate to breach 100%, and also catches the inverse
+`value`-unit error (cik 93751 reports 9.78M shares against `value = 202,656,145`, an
+implied $20.7M per share).
 
 ## The S12 alternative: `crsp.holdings` (verified on the WRDS grid)
 

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -688,33 +688,81 @@ coverage cost showing honestly and small against the gain.
 
 #### The benign explanation was tested and does NOT hold
 
-The natural reading of a 1.057 median is that the remainder is ordinary noise —
-rdate-vs-shrout timing (#4a) and dual-class per-class numerators (#4c). **Both were tested
-against the clean population and neither survives as an explanation.**
+Dual-class (#4c) and rdate-vs-shrout timing (#4a) were both tested against the clean
+population. Neither survives:
 
 | | residual violators | clean (control) | enrichment |
 |---|---|---|---|
-| permco carries >1 common-stock permno (dual-class) | 8.24% | 5.48% | 1.5× |
-| \|Δshrout\| > 2% between rdate and rdate+2m (filing) | 12.46% | 9.77% | 1.3× |
-| median \|Δshrout\| | 0.129% | 0.046% | — |
+| permco carries >1 common-stock permno | 8.24% | 5.48% | 1.5× |
+| \|Δshrout\| > 2% between rdate and rdate+2m | 12.46% | 9.77% | 1.3× |
 | **explained by either** | **19.3%** | **14.5%** | **1.3×** |
 
-Both enrichments are small — compare the 21× that identified the cusip6 fallback. Against
-a 14.5% clean baseline, the two mechanisms account for roughly **5 excess percentage
-points** of the residual. **80.7% of residual violators (3.02% of the whole panel) show
-neither.**
+80.7% of residual violators show neither. **The severity test settles it:** if these
+mechanisms drove the violations, the cells they explain would be *more* severe. They are
+not — median ratio 1.069 where explained versus 1.054 where not. That is not a weak
+signal, it is the absence of one.
 
-The clincher: if these mechanisms drove the violations, cells they explain should be the
-extreme ones. They are not — median ratio 1.069 where explained versus 1.054 where not.
-The two populations are indistinguishable in severity.
+#### RESOLVED — the residual is short interest, and it is not a defect
 
-So D9 stays **PARTIAL**, and now for a stronger reason than "unconfirmed": a third
-numerator defect, not yet identified, sits behind roughly **3% of cells** at a median
-ratio near 1.05. Do not write the residual up as timing or dual-class noise — that has
-been checked and it isn't.
+**WRDS documents this directly.** Support article *"Institutional Ownership Exceeding
+100%"* (`/pages/support/support-articles/lseg/institutional-holdings-s34/`) gives four
+causes, and the first is not a data error at all:
 
-The panel is usable at this level with the caveat documented; the excess is small and
-non-extreme. But it is a defect, not an artifact of the denominator.
+> "Special cases with high levels of institutional ownership and high short interest
+> ratios around calendar quarter ends. 13F filings report only stock holdings and do not
+> report short positions."
+
+A lent share is reported twice — the lender still reports it, and so does the buyer who
+bought it from the short seller. Aggregate 13F ownership above 100% is the *correct*
+result for a heavily shorted stock, not an artifact.
+
+Tested against Compustat `sec_shortint` linked to permno via CCM:
+
+| | residual violators | clean (control) |
+|---|---|---|
+| median short interest / TSO | **12.44%** | 1.57% |
+| short interest > 5% | **82.9%** | 22.8% |
+| short interest > 10% | **60.5%** | 9.5% |
+
+And the dose-response is monotone, which is the strongest form of the evidence:
+
+| short interest / TSO | violation rate |
+|---|---|
+| 0–2% | 0.51% |
+| 2–5% | 2.16% |
+| 5–10% | 6.99% |
+| **>10%** | **22.95%** |
+
+A 45× spread in violation rate across the short-interest gradient, and
+`corr(excess over 100%, short interest) = 0.355` among violators.
+
+**The row-level test rules out a second parse pathology, in the opposite direction.**
+Violating cells are *less* concentrated than clean ones — median top-filer mass share
+12.33% vs 18.11%, `>50%` share in 5.3% vs 12.4%, median contributing filers 172 vs 85.
+The `value=0` defect was one row dominating a cell; this is the mirror image, excess
+spread thinly across *more* filers. That is what an economy-wide lending effect looks
+like and what a parse bug does not.
+
+**Do not repair this.** Clipping the ratio at 100% destroys real information — it is
+precisely the vendor clipping that hid the `value=0` defect (D9 above) and it would now
+also erase a genuine signal. 13F cannot capture shorts, so the excess is irreducible.
+Document it, and when a bounded ratio is required, cap explicitly and record that
+high-short-interest names are being truncated.
+
+The remaining WRDS causes map cleanly onto findings already recorded here: shared
+investment discretion double-counting (cause 2 — see the control test above, which shows
+the `other_manager` flag cannot isolate it even though the phenomenon is real), incorrect
+vendor shares outstanding (cause 3 — already handled, we use CRSP), and mis-applied
+adjustment factors joined at `fdate` (cause 4 — this is D1).
+
+**D9 status: the numerator defects are fixed (`value=0`, cusip6 fallback); the ~3%
+residual is explained and is not a defect.** What remains is a documentation obligation,
+not a repair.
+
+⚠️ One nuance worth preserving: the control test shows the `other_manager` flag has no
+discriminating power (99.9% vs 98.9%), which means it cannot be *used* as a fix. It does
+not prove shared-discretion double-counting never occurs — WRDS says it does. The two
+statements are compatible and the distinction matters.
 
 → Detector: `detect_fallback_join_contamination` — flags cells drawing an outsized share
 of their value from a degraded/fallback join path. The 16.5%-vs-0.8% split above is

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -477,7 +477,7 @@ collapsed to 0.9% after the fix). Note the *level* of the null rate is not the s
 ~54% is correct and expected, because 13F legitimately holds ADRs and closed-end funds
 with no CRSP common-stock match. The **spread across buckets** is the signal.
 
-### D9. Held shares exceeding shares outstanding — DIAGNOSED (EDGAR 13F parser)
+### D9. Held shares exceeding shares outstanding — PARTIAL (two causes; one fixed, one open)
 
 Surfaced by `detect_impossible_ratio` on the rebuilt EDGAR panel: **7.0% of non-zero
 observations exceed 100% ownership, 2.9% exceed 120%**, concentrated in the pre-XML
@@ -589,6 +589,107 @@ not been ruled out.
 rather than waiting for the aggregate to breach 100%, and also catches the inverse
 `value`-unit error (cik 93751 reports 9.78M shares against `value = 202,656,145`, an
 implied $20.7M per share).
+
+#### Status: PARTIAL — the `value=0` fix is real but explains only the extreme tail
+
+Validated independently against Thomson (a different pipeline, so it can distinguish
+"removed fabricated mass" from "removed real holdings"):
+
+| | no filter | with filter |
+|---|---|---|
+| impossible ratio | 6.111% | 5.205% |
+| Pearson vs Thomson | 0.4291 | **0.5843** |
+| Spearman vs Thomson | 0.9097 | 0.9116 |
+| median ratio | 0.9830 | 0.9823 |
+
+Outlier-sensitive Pearson rises 36% while the robust median moves 0.0007 — the signature
+of deleting fabricated tail mass. Deleting *real* holdings would have moved the median and
+left Pearson flat. Landed in mirror as `b69ca18` (PR #3), gated behind `--d9-threshold` /
+`--no-d9-filter`.
+
+**But the residual is era-agnostic, which a text-parser cause cannot explain:**
+
+| era | violators | of total | rate |
+|---|---|---|---|
+| text (<2013) | 9,528 | 180,555 | 5.28% |
+| xml (≥2013) | 9,501 | 185,062 | 5.13% |
+
+Median residual ratio 1.145; 40.7% above 120%, 8.2% above 200%.
+
+#### Residual cause 1 — sub-advisor double-counting: RULED OUT, including post-2013
+
+The text-era result does not transfer, so the test was re-run restricted to `rdate ≥ 2013`,
+where `other_manager` *is* populated. **It fails on the control.**
+
+| | violators | clean (control) |
+|---|---|---|
+| any `other_manager` populated | **99.9%** | **98.9%** |
+
+There is no discrimination — essentially every cell in both groups has it populated.
+Excluding those rows "fixes" 86.9% of violators, but removes **48.5% of mass from clean
+cells** and halves their median ratio (0.636 → 0.297). `SOLE`-only is the same story:
+87.6% fixed, 41.0% of clean mass destroyed.
+
+This is the identical trap as the text era, one layer up: a rule that looks like an 87%
+fix is deleting half the panel. **The clean-cell control is what exposes it** — the
+violator-only number alone would have shipped this.
+
+#### Residual cause 2 — cusip6 fallback collapsing securities onto one permno: CONFIRMED
+
+`load_13f_holdings` matches `cusip8 → ncusip`, then falls back to **`cusip6`** (issuer
+level) for unmatched rows. That fallback attributes *any* security of the issuer —
+another share class, preferred, warrants, units — to one common-stock `permno`, while the
+denominator is that one permno's shares outstanding.
+
+| | violators | clean | enrichment |
+|---|---|---|---|
+| >1 distinct `cusip8` → one permno | **55.6%** | 18.8% | 3.0× |
+| used cusip6 fallback | **53.7%** | 13.8% | 3.9× |
+| share of cell's `io` from fallback (xml) | **16.5%** | 0.8% | **21×** |
+| share of cell's `io` from fallback (text) | **20.9%** | 1.8% | 12× |
+
+Within violators, multi-cusip8 cells run a higher median ratio than single-cusip8 cells
+(1.191 vs 1.047). The text era is even more enriched (64.1% vs 17.8%).
+
+**Policy comparison, measured panel-wide:**
+
+| policy | panel violation rate | violators fixed | clean mass removed |
+|---|---|---|---|
+| A: keep all fallback (current) | 6.18% | — | — |
+| **B: drop all cusip6 fallback** | **3.74%** | **39.5%** | 1.67% |
+| C: drop only *ambiguous* fallback (cusip6 → >1 permno) | 5.97% | 3.5% | 0.07% |
+
+**C is the surgical fix and it does not work.** The failure is not map ambiguity — it is
+that a cusip6 match pulls in a genuinely different security even when the issuer has
+exactly one permno. Only B moves the needle.
+
+B is a real trade, not a free win: the 1.67% of clean mass it removes is holdings the
+fallback recovered *correctly*. Coverage versus correctness — which is why it belongs
+behind a flag, like the D9 filter itself.
+
+Proposed for `mirror scripts/build_inst_own.py` — **proposed, not landed; mirror PR #3 is
+Edwin's**:
+
+```python
+# F9: the cusip6 fallback is issuer-level, so it attributes other share classes,
+# preferreds and warrants to one common-stock permno while the denominator stays
+# single-class. Gate it. Restricting to unambiguous cusip6 does NOT help (3.5% of
+# violators vs 39.5% for dropping it outright) — the bad matches are to different
+# securities, not to ambiguous permnos.
+if not use_cusip6_fallback:          # default off; --cusip6-fallback to restore
+    h = matched8
+```
+
+**Residual after B: 3.74% of cells, median ratio 1.057** — down from 1.115, and now
+marginal rather than extreme. That remainder is consistent with the benign causes already
+documented in §Common Gotchas #4: rdate-vs-shrout timing around splits and issuance
+(#4a), and genuine dual-class per-class numerators (#4c). D9 stays **PARTIAL** until that
+is confirmed rather than assumed.
+
+→ Detector: `detect_fallback_join_contamination` — flags cells drawing an outsized share
+of their value from a degraded/fallback join path. The 16.5%-vs-0.8% split above is
+exactly what it keys on, and it generalises to any pipeline with a primary and a
+looser secondary match.
 
 ## The S12 alternative: `crsp.holdings` (verified on the WRDS grid)
 

--- a/skills/wrds/references/tfn-ownership.md
+++ b/skills/wrds/references/tfn-ownership.md
@@ -680,11 +680,41 @@ if not use_cusip6_fallback:          # default off; --cusip6-fallback to restore
     h = matched8
 ```
 
-**Residual after B: 3.74% of cells, median ratio 1.057** — down from 1.115, and now
-marginal rather than extreme. That remainder is consistent with the benign causes already
-documented in §Common Gotchas #4: rdate-vs-shrout timing around splits and issuance
-(#4a), and genuine dual-class per-class numerators (#4c). D9 stays **PARTIAL** until that
-is confirmed rather than assumed.
+**Residual after B: 3.74% of cells, median ratio 1.057** (3.016% in mirror's own
+pipeline, which landed policy B as `15b598c`, default-on with `--cusip6-fallback` to
+restore). Validated against Thomson: impossible rate 5.205% → 3.016%, **both** correlations
+up (Pearson 0.5843 → 0.5999, Spearman 0.9116 → 0.9127), median slipping only 0.3pp — the
+coverage cost showing honestly and small against the gain.
+
+#### The benign explanation was tested and does NOT hold
+
+The natural reading of a 1.057 median is that the remainder is ordinary noise —
+rdate-vs-shrout timing (#4a) and dual-class per-class numerators (#4c). **Both were tested
+against the clean population and neither survives as an explanation.**
+
+| | residual violators | clean (control) | enrichment |
+|---|---|---|---|
+| permco carries >1 common-stock permno (dual-class) | 8.24% | 5.48% | 1.5× |
+| \|Δshrout\| > 2% between rdate and rdate+2m (filing) | 12.46% | 9.77% | 1.3× |
+| median \|Δshrout\| | 0.129% | 0.046% | — |
+| **explained by either** | **19.3%** | **14.5%** | **1.3×** |
+
+Both enrichments are small — compare the 21× that identified the cusip6 fallback. Against
+a 14.5% clean baseline, the two mechanisms account for roughly **5 excess percentage
+points** of the residual. **80.7% of residual violators (3.02% of the whole panel) show
+neither.**
+
+The clincher: if these mechanisms drove the violations, cells they explain should be the
+extreme ones. They are not — median ratio 1.069 where explained versus 1.054 where not.
+The two populations are indistinguishable in severity.
+
+So D9 stays **PARTIAL**, and now for a stronger reason than "unconfirmed": a third
+numerator defect, not yet identified, sits behind roughly **3% of cells** at a median
+ratio near 1.05. Do not write the residual up as timing or dual-class noise — that has
+been checked and it isn't.
+
+The panel is usable at this level with the caveat documented; the excess is small and
+non-extreme. But it is a defect, not an artifact of the denominator.
 
 → Detector: `detect_fallback_join_contamination` — flags cells drawing an outsized share
 of their value from a degraded/fallback join path. The 16.5%-vs-0.8% split above is

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -45,6 +45,7 @@ __all__ = [
     "detect_duplicate_grain",
     "detect_unresolved_overlap",
     "detect_implied_price_outlier",
+    "detect_fallback_join_contamination",
     "detect_calendar_bucket_gap",
     "detect_join_gap_clustering",
     "detect_impossible_ratio",
@@ -1117,6 +1118,85 @@ def detect_implied_price_outlier(
                     "value": value,
                     "too_low": implied < min_price,
                 },
+            )
+        )
+    return findings
+
+
+def detect_fallback_join_contamination(
+    records: Sequence[dict],
+    *,
+    total_col: str = "io_total",
+    fallback_col: str = "io_fallback",
+    entity_col: str = "permno",
+    period_col: str = "rdate",
+    max_fallback_share: float = 0.05,
+    control_col: str | None = None,
+) -> list[Finding]:
+    """Cells drawing an outsized share of their value from a degraded join path.
+
+    Pipelines that fail a primary key match often retry on a looser one -- cusip8 falling
+    back to cusip6, exact name falling back to fuzzy. The fallback recovers real rows, so
+    it looks like pure gain, and the rows it recovers WRONGLY are invisible: they arrive as
+    ordinary values in the same column.
+
+    Reference case: `cusip8 -> ncusip` falling back to issuer-level `cusip6` attributes
+    other share classes, preferreds and warrants to one common-stock permno while the
+    denominator stays single-class. Cells breaching 100% ownership drew **16.5%** of their
+    value from the fallback against **0.8%** for clean cells -- a 21x enrichment, and a far
+    sharper discriminator than the join's overall usage rate (53.7% vs 13.8%).
+
+    That gap is the point: *whether* a cell used the fallback separates weakly, *how much
+    it leans on it* separates strongly. Key on the mass, not the flag.
+
+    Restricting a fallback to unambiguous keys is the tempting surgical fix and is usually
+    the wrong one -- measured here it recovered 3.5% of violators against 39.5% for
+    dropping the fallback outright, because the bad matches are to genuinely different
+    securities, not to ambiguous identifiers.
+
+    Pass `control_col` (a bool marking known-good cells) to have the finding report the
+    contamination gap against that control rather than an absolute threshold alone.
+    """
+    findings: list[Finding] = []
+    control_shares: list[float] = []
+    if control_col is not None:
+        for rec in records:
+            if not rec.get(control_col):
+                continue
+            total = rec.get(total_col)
+            if total:
+                control_shares.append(float(rec.get(fallback_col) or 0.0) / float(total))
+    control_mean = (
+        sum(control_shares) / len(control_shares) if control_shares else None
+    )
+
+    for rec in records:
+        total = rec.get(total_col)
+        if not total:
+            continue
+        share = float(rec.get(fallback_col) or 0.0) / float(total)
+        if share <= max_fallback_share:
+            continue
+        detail = (
+            f"{share:.1%} of {total_col} comes from the fallback join path "
+            f"(threshold {max_fallback_share:.0%})"
+        )
+        metrics: dict[str, Any] = {
+            "fallback_share": share,
+            "total": total,
+            "fallback": rec.get(fallback_col),
+        }
+        if control_mean is not None:
+            metrics["control_mean_share"] = control_mean
+            metrics["enrichment"] = (share / control_mean) if control_mean else None
+            detail += f" vs {control_mean:.1%} in the control population"
+        findings.append(
+            Finding(
+                kind="fallback_join_contamination",
+                entity=rec.get(entity_col),
+                period=rec.get(period_col),
+                detail=detail,
+                metrics=metrics,
             )
         )
     return findings

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -1001,22 +1001,49 @@ def detect_impossible_ratio(
     max_ratio: float = 1.0,
     tolerance: float = 0.02,
 ) -> list[Finding]:
-    """Held shares exceed shares outstanding -- an arithmetic impossibility, not an outlier.
+    """Held shares exceed shares outstanding. A TRIAGE signal, not a verdict.
 
-    Institutions cannot own 239% of a company. When they appear to, the shares are being
-    double-counted or mis-scaled, and no amount of winsorizing makes the number mean
-    something.
+    READ THIS BEFORE ACTING ON A FINDING. The name is a historical artifact and it
+    overstates the case: above 100% is not automatically impossible, and roughly a third
+    of what this detector flags on a raw 13F panel is CORRECT.
 
-    This is the check that survives a source swap. Vendor panels often clip the ratio at
-    100% so the defect is invisible in them; a panel built from raw filings does not clip,
-    so the violations are visible and countable. On the rebuilt mirror 13F panel this
-    fires on 7.0% of non-zero observations (2.9% above 120%), concentrated in the
-    pre-XML text-parse era -- e.g. AAPL 2003-09-30 with 4.90e10 shares held against
-    2.05e10 outstanding, bracketed by quarters at a sane 45% and 60%.
+    Form 13F reports LONG positions only and has no short side, so a lent share is
+    reported twice -- once by the lender, who still carries it, and once by whoever
+    bought it from the short seller. For a heavily shorted stock, summed 13F ownership
+    above 100% is the arithmetically right answer, and WRDS's own support article
+    ("Institutional Ownership Exceeding 100%", S34 knowledge base) leads with exactly
+    this cause. Measured against Compustat `sec_shortint` via CCM, the violation rate
+    rises 0.51% -> 2.16% -> 6.99% -> 22.95% across short-interest buckets of 0-2 / 2-5 /
+    5-10 / >10% of shares outstanding: a 45x dose-response.
+
+    So the finding list is a population to be SPLIT, not repaired:
+
+      real defects, worth fixing      parse failures (value = 0 with huge shares);
+                                      a fallback join mapping other share classes onto
+                                      the common permno
+      real economics, leave alone     securities lending
+
+    Two things separate them, and neither is the ratio itself:
+      - short interest. Join it if you have it; it is the direct test.
+      - CONCENTRATION. A parse failure is usually one row dominating one cell, so
+        top-filer mass share RISES. Lending is economy-wide, so it FALLS -- measured at
+        12.33% for lending-driven violators vs 18.11% for clean cells, with 172
+        contributing filers vs 85. Direction distinguishes them; magnitude does not.
+
+    DO NOT CLIP AT 100%. Capping destroys the short-lending information, and it is the
+    same clipping that hid the parse defect in vendor panels for years -- a clipped
+    series looks clean because the evidence has been deleted, not because it is.
+
+    CONSEQUENCE FOR VOTING WORK. A lent share carries no vote for the lender; the vote
+    passes to the borrower unless the loan is recalled before the record date. So the
+    double-count inflates OWNERSHIP but not VOTABLE SHARES. Anything using institutional
+    ownership as a voting weight overstates the block by roughly the lending rate, and
+    short interest is not random with respect to governance conflict -- borrowing spikes
+    around record dates specifically to acquire votes.
 
     `tolerance` allows a small band for genuine timing mismatch: holdings are reported at
     quarter-end while shares outstanding come from a monthly file, so a real 100.5% is
-    a stale denominator rather than a defect.
+    a stale denominator rather than either story above.
     """
     findings: list[Finding] = []
     limit = max_ratio * (1.0 + tolerance)
@@ -1034,7 +1061,8 @@ def detect_impossible_ratio(
                     period=_as_date(rec[period_col]) if rec.get(period_col) else None,
                     detail=(
                         f"{numerator_col} / {denominator_col} = {ratio:.1%}, above the "
-                        f"{max_ratio:.0%} bound -- shares double-counted or mis-scaled"
+                        f"{max_ratio:.0%} bound -- triage against short interest and "
+                        f"filer concentration before treating it as a defect"
                     ),
                     metrics={
                         "ratio": ratio,

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -48,6 +48,7 @@ __all__ = [
     "detect_fallback_join_contamination",
     "detect_calendar_bucket_gap",
     "detect_join_gap_clustering",
+    "detect_join_coverage_tail",
     "detect_impossible_ratio",
     "COMMON_SPLIT_FACTORS",
 ]
@@ -986,6 +987,85 @@ def detect_join_gap_clustering(
                 "worst_month": hi_month,
                 "best_month": lo_month,
                 "null_rate_by_month": dict(sorted(rates.items())),
+            },
+        )
+    ]
+
+
+def detect_join_coverage_tail(
+    records: Sequence[dict],
+    *,
+    period_col: str = "rdate",
+    joined_col: str = "tso",
+    null_threshold: float = 0.99,
+    min_periods: int = 2,
+) -> list[Finding]:
+    """A joined column goes (near-)entirely null for a contiguous TAIL of periods.
+
+    The signature of a reference table that FROZE while the fact table kept going.
+    Vendors retire products without retiring the tables: the old one simply stops
+    receiving rows, every join against it silently falls back to null or a default, and
+    the fact table looks complete because its own row counts never move.
+
+    Grounded in a real incident. `crsp.msf` is frozen at 2024-12-31 while the 13F panel
+    ran to 2025Q4, so all four 2025 quarters carried `tso = NULL` and an ownership ratio
+    of exactly 0 for 100% of their rows -- 43,000 permno-quarters of silently missing
+    ownership. The fix was to splice `crsp.msf_v2`, which continues.
+
+    NEITHER of the obvious guards catches this, which is why it is its own detector:
+      - a "months present" assertion passes, because [3, 6, 9, 12] all still exist.
+        Only the RANGE is short.
+      - `detect_join_gap_clustering` passes, because it keys on spread ACROSS calendar
+        buckets and a tail truncation fails all four buckets EQUALLY. Zero spread.
+
+    Deliberately requires an EARLIER period below the threshold. A column that is null
+    everywhere is a different defect -- a reference table that was never joined at all --
+    and reporting it here would bury the one this detector is for.
+    """
+    by_period: dict[_dt.date, list[int]] = {}
+    for rec in records:
+        value = rec.get(period_col)
+        if value is None:
+            continue
+        bucket = by_period.setdefault(_as_date(value), [0, 0])
+        bucket[1] += 1
+        if rec.get(joined_col) is None:
+            bucket[0] += 1
+
+    periods = sorted(by_period)
+    if len(periods) < min_periods + 1:
+        return []
+    rates = {p: by_period[p][0] / by_period[p][1] for p in periods if by_period[p][1]}
+
+    tail: list[_dt.date] = []
+    for p in reversed(periods):
+        if rates.get(p, 0.0) >= null_threshold:
+            tail.append(p)
+        else:
+            break
+    tail.reverse()
+
+    # No tail, too short, or the whole panel is null (a different defect entirely).
+    if len(tail) < min_periods or len(tail) == len(periods):
+        return []
+
+    healthy = [p for p in periods if p not in set(tail)]
+    return [
+        Finding(
+            kind="join_coverage_tail",
+            entity=joined_col,
+            period=tail[0],
+            detail=(
+                f"{joined_col} is null for >={null_threshold:.0%} of rows in the last "
+                f"{len(tail)} periods ({tail[0]} onward) but only "
+                f"{rates[healthy[-1]]:.1%} in {healthy[-1]} -- the reference table "
+                f"looks frozen while the fact table kept going"
+            ),
+            metrics={
+                "tail_periods": len(tail),
+                "tail_start": tail[0],
+                "last_healthy_period": healthy[-1],
+                "last_healthy_null_rate": rates[healthy[-1]],
             },
         )
     ]

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -44,6 +44,9 @@ __all__ = [
     "detect_bridge_rate_regression",
     "detect_duplicate_grain",
     "detect_unresolved_overlap",
+    "detect_calendar_bucket_gap",
+    "detect_join_gap_clustering",
+    "detect_impossible_ratio",
     "COMMON_SPLIT_FACTORS",
 ]
 
@@ -821,6 +824,223 @@ def detect_unresolved_overlap(
             by_period.setdefault(_as_date(rec[period_col]), []).append(rec)
         for period in sorted(by_period):
             _emit(period, by_period[period])
+    return findings
+
+
+def detect_calendar_bucket_gap(
+    records: Sequence[dict],
+    *,
+    period_col: str = "rdate",
+    expected_months: Sequence[int] = (3, 6, 9, 12),
+    thin_share: float = 0.5,
+) -> list[Finding]:
+    """A periodic panel missing an entire calendar bucket (e.g. no June, no September).
+
+    THE ROOT-CAUSE DETECTOR. Every other detector in this module catches a *symptom*
+    downstream of a broken source table; this one catches the source table itself, and
+    it is cheap enough to run on every reference panel at build time.
+
+    Grounded in a real incident (mirror `build_inst_own.py`, 2026-07). polars'
+    `dt.month()` returns Int8, so the common idiom
+
+        dt.year() * 10000 + dt.month() * 100 + dt.day()
+
+    overflows for every month >= 2 (2 * 100 = 200 > 127) and wraps NEGATIVE, silently.
+    February 2020 became 20199973 and March became 20200075 instead of 20200229 /
+    20200331. A quarter-snap then read those as "month 99" and "month 0" and bucketed
+    them into Q4-of-the-prior-year and Q1, so the CRSP reference panel held ONLY March
+    and December quarter-ends -- 193,335 rows where 370,630 were correct.
+
+    Nothing raised. The output was a full-looking table of plausible eight-digit
+    integers. Downstream, every June and September holdings quarter missed the join,
+    fell back to an unadjusted split factor and a null denominator, and produced an
+    ownership ratio of exactly 0 for 49% of the panel. That surfaced as a 4.5x seasonal
+    swing with a flat owner count -- which reads as a *vendor* defect, and was attributed
+    to one for weeks before being traced back here.
+
+    The lesson generalizes past polars: any date arithmetic on a narrow integer type can
+    silently produce a valid-looking key. Assert the buckets, do not eyeball the head.
+
+    `thin_share` also catches the softer version -- a bucket present but far smaller than
+    its peers, which is a partial join failure rather than a total one.
+    """
+    findings: list[Finding] = []
+    counts: dict[int, int] = {m: 0 for m in expected_months}
+    unexpected: dict[int, int] = {}
+    for rec in records:
+        value = rec.get(period_col)
+        if value is None:
+            continue
+        month = _as_date(value).month
+        if month in counts:
+            counts[month] += 1
+        else:
+            unexpected[month] = unexpected.get(month, 0) + 1
+
+    present = {m: n for m, n in counts.items() if n > 0}
+    for month in expected_months:
+        if counts[month] == 0:
+            findings.append(
+                Finding(
+                    kind="calendar_bucket_gap",
+                    entity=period_col,
+                    period=month,
+                    detail=(
+                        f"no rows in calendar month {month}; expected months "
+                        f"{list(expected_months)}. A whole bucket is missing, so every "
+                        f"downstream join keyed on it silently falls back to a default"
+                    ),
+                    metrics={"month": month, "rows": 0, "present_months": sorted(present)},
+                )
+            )
+
+    if present:
+        mean_present = sum(present.values()) / len(present)
+        for month, n in sorted(present.items()):
+            if n < mean_present * thin_share:
+                findings.append(
+                    Finding(
+                        kind="calendar_bucket_thin",
+                        entity=period_col,
+                        period=month,
+                        detail=(
+                            f"month {month} has {n:,} rows against a {mean_present:,.0f} "
+                            f"average across present months -- partial join failure"
+                        ),
+                        metrics={"month": month, "rows": n, "mean_rows": mean_present},
+                    )
+                )
+
+    for month, n in sorted(unexpected.items()):
+        findings.append(
+            Finding(
+                kind="calendar_bucket_unexpected",
+                entity=period_col,
+                period=month,
+                detail=(
+                    f"{n:,} rows in month {month}, which is not in the expected set "
+                    f"{list(expected_months)} -- a corrupted date key can land anywhere"
+                ),
+                metrics={"month": month, "rows": n},
+            )
+        )
+    return findings
+
+
+def detect_join_gap_clustering(
+    records: Sequence[dict],
+    *,
+    period_col: str = "rdate",
+    joined_col: str = "tso",
+    max_spread: float = 0.25,
+) -> list[Finding]:
+    """A join whose failure rate is wildly uneven across calendar buckets.
+
+    A left join that misses is not an error -- 13F holds ADRs and closed-end funds that
+    legitimately have no CRSP common-stock match, so a flat ~54% null rate is expected
+    and fine. What is NOT fine is that rate differing by bucket: real non-matches do not
+    know what month it is.
+
+    On the broken mirror panel the null rate for `tso` was 1.00 in June and September
+    against 0.53 in March and December -- a spread of 0.47. After the fix it was 0.537 to
+    0.546, a spread of 0.009. The absolute level moved barely at all; the *spread* is the
+    signal, which is why this is a separate detector from a null-rate threshold.
+
+    Use this wherever a reference table is joined in: a silent default is much harder to
+    notice than a missing column, because the arithmetic downstream still succeeds.
+    """
+    by_month: dict[int, list[int]] = {}
+    for rec in records:
+        value = rec.get(period_col)
+        if value is None:
+            continue
+        month = _as_date(value).month
+        bucket = by_month.setdefault(month, [0, 0])
+        bucket[1] += 1
+        if rec.get(joined_col) is None:
+            bucket[0] += 1
+
+    rates = {m: miss / total for m, (miss, total) in by_month.items() if total}
+    if len(rates) < 2:
+        return []
+    lo_month, lo = min(rates.items(), key=lambda kv: kv[1])
+    hi_month, hi = max(rates.items(), key=lambda kv: kv[1])
+    if hi - lo < max_spread:
+        return []
+    return [
+        Finding(
+            kind="join_gap_clustering",
+            entity=joined_col,
+            period=hi_month,
+            detail=(
+                f"{joined_col} is null for {hi:.1%} of rows in month {hi_month} but only "
+                f"{lo:.1%} in month {lo_month} (spread {hi - lo:.1%}) -- the join is "
+                f"failing for a calendar subset, not for genuinely unmatched entities"
+            ),
+            metrics={
+                "max_null_rate": hi,
+                "min_null_rate": lo,
+                "spread": hi - lo,
+                "worst_month": hi_month,
+                "best_month": lo_month,
+                "null_rate_by_month": dict(sorted(rates.items())),
+            },
+        )
+    ]
+
+
+def detect_impossible_ratio(
+    records: Sequence[dict],
+    *,
+    entity_col: str = "permno",
+    period_col: str = "rdate",
+    numerator_col: str = "io_total",
+    denominator_col: str = "tso",
+    max_ratio: float = 1.0,
+    tolerance: float = 0.02,
+) -> list[Finding]:
+    """Held shares exceed shares outstanding -- an arithmetic impossibility, not an outlier.
+
+    Institutions cannot own 239% of a company. When they appear to, the shares are being
+    double-counted or mis-scaled, and no amount of winsorizing makes the number mean
+    something.
+
+    This is the check that survives a source swap. Vendor panels often clip the ratio at
+    100% so the defect is invisible in them; a panel built from raw filings does not clip,
+    so the violations are visible and countable. On the rebuilt mirror 13F panel this
+    fires on 7.0% of non-zero observations (2.9% above 120%), concentrated in the
+    pre-XML text-parse era -- e.g. AAPL 2003-09-30 with 4.90e10 shares held against
+    2.05e10 outstanding, bracketed by quarters at a sane 45% and 60%.
+
+    `tolerance` allows a small band for genuine timing mismatch: holdings are reported at
+    quarter-end while shares outstanding come from a monthly file, so a real 100.5% is
+    a stale denominator rather than a defect.
+    """
+    findings: list[Finding] = []
+    limit = max_ratio * (1.0 + tolerance)
+    for rec in records:
+        numer = rec.get(numerator_col)
+        denom = rec.get(denominator_col)
+        if numer is None or denom is None or denom <= 0:
+            continue
+        ratio = numer / denom
+        if ratio > limit:
+            findings.append(
+                Finding(
+                    kind="impossible_ratio",
+                    entity=rec.get(entity_col),
+                    period=_as_date(rec[period_col]) if rec.get(period_col) else None,
+                    detail=(
+                        f"{numerator_col} / {denominator_col} = {ratio:.1%}, above the "
+                        f"{max_ratio:.0%} bound -- shares double-counted or mis-scaled"
+                    ),
+                    metrics={
+                        "ratio": ratio,
+                        "numerator": numer,
+                        "denominator": denom,
+                    },
+                )
+            )
     return findings
 
 

--- a/skills/wrds/scripts/ownership_dq.py
+++ b/skills/wrds/scripts/ownership_dq.py
@@ -44,6 +44,7 @@ __all__ = [
     "detect_bridge_rate_regression",
     "detect_duplicate_grain",
     "detect_unresolved_overlap",
+    "detect_implied_price_outlier",
     "detect_calendar_bucket_gap",
     "detect_join_gap_clustering",
     "detect_impossible_ratio",
@@ -1041,6 +1042,83 @@ def detect_impossible_ratio(
                     },
                 )
             )
+    return findings
+
+
+def detect_implied_price_outlier(
+    records: Sequence[dict],
+    *,
+    value_col: str = "value",
+    shares_col: str = "shares",
+    value_scale: float = 1000.0,
+    min_price: float = 0.01,
+    max_price: float = 10_000.0,
+    min_shares: int = 100_000,
+    id_cols: Sequence[str] = ("cik", "cusip8", "period_of_report"),
+) -> list[Finding]:
+    """Rows whose reported value and share count cannot both be true.
+
+    A 13F row carries two numbers describing one position, so they cross-check each other:
+    `value x value_scale / shares` is an implied price, and a position whose implied price
+    is impossible is a parse failure regardless of how reasonable either field looks alone.
+
+    This catches the D9 defect at ROW level rather than waiting for the aggregate to breach
+    100% of shares outstanding -- which matters, because by then the bad row is pooled with
+    hundreds of good ones and the only available remedy is a cap that leaves the fabrication
+    standing. Reference case: one row reporting 719,257,141 shares of AAPL with `value = 0`
+    drove that firm-quarter to 239% ownership; the next-largest holder reported 19.8M.
+
+    `min_shares` keeps the check off legitimately tiny positions. A holding genuinely worth
+    under $1,000 rounds to `value = 0` in $1000s, and there are 2.8M such rows carrying
+    almost no share mass -- dropping them all costs 33x the rows for no additional benefit.
+    Requiring a large share count isolates the 86,509 rows that carry 13.88% of the mass.
+
+    Also catches the inverse: `value` reported in dollars rather than thousands shows up as
+    an absurdly HIGH implied price (9.78M shares against `value = 202,656,145` implies
+    $20,720 per share against an actual 2003 AAPL price near $10).
+
+    ⚠️ **The high side is weaker than the low side, and the default reflects that.** A
+    constant ceiling cannot separate a units error from a genuinely expensive security --
+    BRK.A trades near $700,000 and will flag at any threshold that catches a 1000x error.
+    Treat high-side hits as "check this", not "this is wrong", and raise `max_price` or
+    exclude known high-priced issues when sweeping a broad cross-section. The low side has
+    no such ambiguity: no security has a price below a cent and a hundred-thousand-share
+    position at zero value.
+    """
+    findings: list[Finding] = []
+    for rec in records:
+        value, shares = rec.get(value_col), rec.get(shares_col)
+        if value is None or shares is None or shares <= 0:
+            continue
+        if shares < min_shares:
+            continue
+        implied = (float(value) * value_scale) / float(shares)
+        if min_price <= implied <= max_price:
+            continue
+        ident = {c: rec.get(c) for c in id_cols if c in rec}
+        findings.append(
+            Finding(
+                kind="implied_price_outlier",
+                entity=ident or None,
+                period=rec.get("period_of_report"),
+                detail=(
+                    f"{shares:,.0f} shares against {value_col}={value:,} implies "
+                    f"{implied:,.4g} per share -- "
+                    + (
+                        "zero/near-zero value with a large position is a parse failure"
+                        if implied < min_price
+                        else "implausibly high; check whether value is in dollars "
+                        "rather than thousands"
+                    )
+                ),
+                metrics={
+                    "implied_price": implied,
+                    "shares": shares,
+                    "value": value,
+                    "too_low": implied < min_price,
+                },
+            )
+        )
     return findings
 
 

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -848,5 +848,61 @@ check("handles zero-total cells without dividing by zero",
       dq.detect_fallback_join_contamination(
           [{"permno": 1, "rdate": dt.date(2015, 6, 30), "io_total": 0, "io_fallback": 5}]) == [])
 
+
+# ---------------------------------------------------------------------------
+# F7  A reference table that FROZE while the fact table kept going.
+#     crsp.msf stops at 2024-12-31; the 13F panel ran to 2025Q4, so all four
+#     2025 quarters carried tso = NULL and ior = 0 for 100% of rows -- 43,000
+#     permno-quarters. Neither the months assertion nor join_gap_clustering
+#     catches it, which is why this is its own detector.
+# ---------------------------------------------------------------------------
+print("\nF7: frozen-reference-table detector")
+
+_qs = quarters(2022, 16)                      # 2022Q1 .. 2025Q4
+frozen = []
+for q in _qs:
+    dead = q >= dt.date(2025, 1, 1)           # reference table froze at 2024-12-31
+    for i in range(40):
+        frozen.append({
+            "permno": 1000 + i,
+            "rdate": q,
+            # ~50% null before the freeze: 13F legitimately holds ADRs and
+            # closed-end funds with no CRSP common-stock match.
+            "tso": None if (dead or i % 2) else 1e9,
+        })
+hits = dq.detect_join_coverage_tail(frozen)
+check("F7 fires on a reference table frozen mid-panel", len(hits) == 1, f"got {len(hits)}")
+check(
+    "F7 identifies the correct freeze point",
+    hits and hits[0].metrics["tail_start"] == dt.date(2025, 3, 31),
+    hits[0].metrics["tail_start"] if hits else "",
+)
+check("F7 counts the dead tail", hits and hits[0].metrics["tail_periods"] == 4)
+
+healthy = [
+    {"permno": 1000 + i, "rdate": q, "tso": None if i % 2 else 1e9}
+    for q in _qs
+    for i in range(40)
+]
+check("F7 silent when the null rate is steady to the end", dq.detect_join_coverage_tail(healthy) == [])
+
+# A column null EVERYWHERE is a different defect (never joined at all) and
+# reporting it here would bury the one this detector exists for.
+never = [{"permno": 1, "rdate": q, "tso": None} for q in _qs]
+check("F7 silent when the column is null in every period", dq.detect_join_coverage_tail(never) == [])
+
+# A single dead quarter at the end is more likely a not-yet-loaded period than
+# a frozen source; min_periods guards against crying wolf on it.
+one_dead = [
+    {"permno": 1000 + i, "rdate": q,
+     "tso": None if (q == _qs[-1] or i % 2) else 1e9}
+    for q in _qs for i in range(40)
+]
+check("F7 respects min_periods on a single trailing gap", dq.detect_join_coverage_tail(one_dead) == [])
+check(
+    "F7 flags that same single gap when min_periods=1",
+    len(dq.detect_join_coverage_tail(one_dead, min_periods=1)) == 1,
+)
+
 print(f"\n{P} passed, {F} failed")
 sys.exit(1 if F else 0)

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -749,5 +749,61 @@ check(
     == [],
 )
 
+# ===========================================================================
+# D9. Implied-price outlier -- the row-level catch for >100% ownership
+# ===========================================================================
+print("\nD9: implied-price outlier detector")
+
+# The actual AAPL 2003-09-30 row that drove that firm-quarter to 239%.
+aapl_bad = {"cik": "728100", "cusip8": "03783310", "period_of_report": "20030930",
+            "shares": 719_257_141, "value": 0}
+# ...and a normal row from the same quarter.
+aapl_ok = {"cik": "315066", "cusip8": "03783310", "period_of_report": "20030930",
+           "shares": 19_798_710, "value": 408_447}
+hits = dq.detect_implied_price_outlier([aapl_bad, aapl_ok])
+check("catches the zero-value mega-position", len(hits) == 1, f"got {len(hits)}")
+check("flags it as too-low, i.e. a parse failure", hits and hits[0].metrics["too_low"])
+check("leaves the legitimate holding alone", hits and hits[0].metrics["shares"] == 719_257_141)
+
+# A sub-$1,000 holding legitimately rounds to value=0. Dropping these costs 33x the
+# rows for no extra mass, so the detector must NOT fire on them.
+check(
+    "silent on legitimately tiny value=0 holdings",
+    dq.detect_implied_price_outlier(
+        [{"shares": 479, "value": 0, "cik": "x", "period_of_report": "20030930"}]
+    )
+    == [],
+)
+check(
+    "min_shares is what separates the two -- lower it and the tiny row does flag",
+    len(
+        dq.detect_implied_price_outlier(
+            [{"shares": 479, "value": 0, "cik": "x", "period_of_report": "20030930"}],
+            min_shares=100,
+        )
+    )
+    == 1,
+)
+# The inverse defect: value reported in dollars, not thousands.
+dollars = dq.detect_implied_price_outlier(
+    [{"cik": "93751", "cusip8": "03783310", "period_of_report": "20030930",
+      "shares": 9_780_702, "value": 202_656_145}]
+)
+check("catches value-in-dollars as an implausibly high price", len(dollars) == 1)
+check("labels the high case distinctly", dollars and dollars[0].metrics["too_low"] is False)
+check(
+    "says to check the value units",
+    dollars and "dollars" in dollars[0].detail,
+)
+# A normal panel produces nothing.
+check(
+    "silent on a plausible cross-section",
+    dq.detect_implied_price_outlier(
+        [{"shares": 1_000_000 + i, "value": 20_000 + i, "cik": str(i),
+          "period_of_report": "20200630"} for i in range(50)]
+    )
+    == [],
+)
+
 print(f"\n{P} passed, {F} failed")
 sys.exit(1 if F else 0)

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -805,5 +805,48 @@ check(
     == [],
 )
 
+# ===========================================================================
+# D9 residual. Fallback-join contamination
+# ===========================================================================
+print("\nD9: fallback-join contamination detector")
+
+# Measured xml-era split: violating cells draw 16.5% of io from the cusip6 fallback,
+# clean cells 0.8%.
+cells = (
+    [{"permno": 100 + i, "rdate": dt.date(2015, 6, 30), "io_total": 1e9,
+      "io_fallback": 1.65e8, "clean": False} for i in range(20)]
+    + [{"permno": 200 + i, "rdate": dt.date(2015, 6, 30), "io_total": 1e9,
+        "io_fallback": 8e6, "clean": True} for i in range(200)]
+)
+fb = dq.detect_fallback_join_contamination(cells, control_col="clean")
+check("flags only the contaminated cells", len(fb) == 20, f"got {len(fb)}")
+check(
+    "measures the enrichment against the control (~21x)",
+    fb and 18.0 <= fb[0].metrics["enrichment"] <= 24.0,
+    f"{fb[0].metrics.get('enrichment')}" if fb else "",
+)
+check("reports the control mean in the detail", fb and "control population" in fb[0].detail)
+check(
+    "silent when the fallback is used lightly everywhere",
+    dq.detect_fallback_join_contamination(
+        [{"permno": i, "rdate": dt.date(2015, 6, 30), "io_total": 1e9, "io_fallback": 8e6}
+         for i in range(50)]
+    )
+    == [],
+)
+# Usage rate alone is the weak signal -- 53.7% vs 13.8% -- so a detector keyed on the
+# flag rather than the mass would separate far worse. Same cells, tiny fallback mass.
+check(
+    "keys on mass, not on whether the fallback was merely used",
+    dq.detect_fallback_join_contamination(
+        [{"permno": i, "rdate": dt.date(2015, 6, 30), "io_total": 1e9,
+          "io_fallback": 1e6, "used_fallback": True} for i in range(50)]
+    )
+    == [],
+)
+check("handles zero-total cells without dividing by zero",
+      dq.detect_fallback_join_contamination(
+          [{"permno": 1, "rdate": dt.date(2015, 6, 30), "io_total": 0, "io_fallback": 5}]) == [])
+
 print(f"\n{P} passed, {F} failed")
 sys.exit(1 if F else 0)

--- a/tests/ownership_dq_test.py
+++ b/tests/ownership_dq_test.py
@@ -643,5 +643,111 @@ check(
     == 1,
 )
 
+
+# ---------------------------------------------------------------------------
+# F6  A reference panel silently missing whole calendar buckets, and the
+#     symptoms it produces downstream.
+#
+#     Measured, not synthesized: mirror's CRSP reference panel held only March
+#     and December quarter-ends (193,335 rows where 370,630 were correct)
+#     because `dt.year()*10000 + dt.month()*100 + dt.day()` overflows polars'
+#     Int8 month. Feb 2020 became 20199973, March became 20200075. Nothing
+#     raised. Downstream, ior was exactly 0 for 49% of the panel.
+#
+#     Validated against the real artifacts before being written down here:
+#       calendar_bucket_gap  stale CRSP 2 findings -> fixed 0
+#       join_gap_clustering  broken panel 1 (47.5% spread) -> fixed 0
+#       impossible_ratio     2.8% of the rebuilt panel (a separate, open defect)
+# ---------------------------------------------------------------------------
+
+_quarters = ["03-31", "06-30", "09-30", "12-31"]
+full_panel = [
+    {"permno": 1, "rdate": f"20{y:02d}-{q}", "tso": 1e9, "io_total": 5e8}
+    for y in range(10, 20)
+    for q in _quarters
+]
+mar_dec_only = [r for r in full_panel if r["rdate"][5:7] in ("03", "12")]
+
+check(
+    "F6 calendar_bucket_gap fires on a March/December-only reference panel",
+    {f.metrics["month"] for f in dq.detect_calendar_bucket_gap(mar_dec_only)} == {6, 9},
+)
+check(
+    "F6 calendar_bucket_gap is silent on a complete quarterly panel",
+    dq.detect_calendar_bucket_gap(full_panel) == [],
+)
+# One lonely June against ten of every other quarter: the bucket exists, so
+# calendar_bucket_gap must not fire, but it is far below its peers -- a partial
+# join failure rather than a total one.
+one_thin_june = [r for r in full_panel if r["rdate"][5:7] != "06"] + [full_panel[1]]
+_thin = dq.detect_calendar_bucket_gap(one_thin_june)
+check(
+    "F6 calendar_bucket_gap flags a bucket that is present but far too thin",
+    [f.kind for f in _thin] == ["calendar_bucket_thin"]
+    and _thin[0].metrics["month"] == 6,
+)
+check(
+    "F6 calendar_bucket_gap reports a month outside the expected set",
+    any(
+        f.kind == "calendar_bucket_unexpected"
+        for f in dq.detect_calendar_bucket_gap(
+            full_panel + [{"permno": 1, "rdate": "2015-07-31", "tso": 1e9}]
+        )
+    ),
+)
+
+# A join that fails for a calendar subset vs one that fails uniformly. The
+# uniform case MUST stay silent: 13F legitimately holds ADRs and closed-end
+# funds with no CRSP match, so a flat ~54% null rate is correct behaviour.
+joined_by_month = [
+    {"permno": i, "rdate": f"2015-{q}", "tso": None if q[:2] in ("06", "09") else 1e9}
+    for q in _quarters
+    for i in range(50)
+]
+joined_uniform = [
+    {"permno": i, "rdate": f"2015-{q}", "tso": None if i % 2 else 1e9}
+    for q in _quarters
+    for i in range(50)
+]
+check(
+    "F6 join_gap_clustering fires when null rate is bucketed by calendar month",
+    len(dq.detect_join_gap_clustering(joined_by_month)) == 1,
+)
+check(
+    "F6 join_gap_clustering stays silent on a uniformly high null rate",
+    dq.detect_join_gap_clustering(joined_uniform) == [],
+)
+check(
+    "F6 join_gap_clustering needs at least two buckets to compare",
+    dq.detect_join_gap_clustering(
+        [{"permno": 1, "rdate": "2015-03-31", "tso": None}]
+    )
+    == [],
+)
+
+check(
+    "F6 impossible_ratio fires when held shares exceed shares outstanding",
+    [f.metrics["ratio"] for f in dq.detect_impossible_ratio(
+        [{"permno": 14593, "rdate": "2003-09-30", "io_total": 4.90e10, "tso": 2.05e10}]
+    )][0] > 2.0,
+)
+check(
+    "F6 impossible_ratio tolerates a marginally stale denominator",
+    dq.detect_impossible_ratio(
+        [{"permno": 1, "rdate": "2015-03-31", "io_total": 1.005e9, "tso": 1e9}]
+    )
+    == [],
+)
+check(
+    "F6 impossible_ratio ignores a zero or missing denominator",
+    dq.detect_impossible_ratio(
+        [
+            {"permno": 1, "rdate": "2015-03-31", "io_total": 1e9, "tso": 0},
+            {"permno": 2, "rdate": "2015-03-31", "io_total": 1e9, "tso": None},
+        ]
+    )
+    == [],
+)
+
 print(f"\n{P} passed, {F} failed")
 sys.exit(1 if F else 0)


### PR DESCRIPTION
Stacked on #76 (base is its branch, not `main`). Merge #76 first.

## Why

#76 built detectors for defects that WRDS documents. This adds the class that **no vendor note will ever cover: your own code producing a defect that looks exactly like theirs.**

polars' `dt.month()` returns **Int8**, so the ubiquitous date-key idiom

```python
pl.col("date").dt.year() * 10000 + pl.col("date").dt.month() * 100 + pl.col("date").dt.day()
```

overflows for every month ≥ 2 (`2 * 100 = 200 > 127`) and wraps **negative**. Only January survives:

| date | produced | correct |
|---|---|---|
| 2020-01-31 | 20200131 | ✓ |
| 2020-02-29 | 20199973 | 20200229 |
| 2020-03-31 | 20200075 | 20200331 |

A quarter-snap read those as "month 99" and "month 0". The CRSP reference panel ended up holding **only March and December** — 193,335 rows where 370,630 were correct. **Nothing raised.** Every Jun/Sep holdings quarter then missed the join, fell back to `cfacshr = 1` and a null denominator, and produced `ior = 0` for **49% of the panel**, while Mar/Dec carried 4× and 28× split factors.

On AAPL that is quarter means of `1.41e10 / 3.11e9 / 3.31e9 / 1.41e10` with `numowners` flat at ~2,200 — because owner counts don't depend on `cfacshr`, so only the shares moved. That is precisely the **D1 (Thomson split mis-adjustment) signature**, and it was attributed to Thomson for weeks.

## Validated on real artifacts, not fixtures

Every detector was run against the actual broken and fixed panels, both directions, *before* being written down:

| detector | target | broken | fixed |
|---|---|---|---|
| `detect_calendar_bucket_gap` | CRSP **reference table** | 2 (months 6, 9) | 0 |
| `detect_join_gap_clustering` | output panel | 1 (47.5% spread) | 0 |
| `detect_flat_owner_share_swing` (existing) | output panel | 22 | 6 |
| `detect_seasonal_alternation` (existing) | output panel | 1 | 0 |
| `detect_impossible_ratio` | output panel | — | 2.8% of rows |

Two things that finding taught, both encoded:

- **`calendar_bucket_gap` belongs on the reference table, not the output.** Pointed at the output panel it finds nothing — the holdings side always had four quarters. The corruption was upstream. It is the only detector here that catches a root cause instead of a symptom.
- **For `join_gap_clustering`, the null-rate *level* is not the signal.** ~54% null is *correct*: 13F legitimately holds ADRs and closed-end funds with no CRSP common-stock match. The **spread across calendar buckets** is the signal — 47.5% broken, 0.9% fixed, with the level barely moving.

## A second, still-open defect

`detect_impossible_ratio` surfaced something the rebuild did not cause: **7.0% of non-zero observations exceed 100% ownership** (2.9% above 120%), concentrated in the pre-XML `parse_mode="text"` era. AAPL 2003-09-30 shows 4.90e10 shares held against 2.05e10 outstanding — 239% — bracketed by quarters at a sane 45% and 60%.

The aggregation sums `shares` within `(cik, cusip8, rdate)`, so duplicates *inside* an accession inflate rather than dedupe. `investment_discretion` and `other_manager` exist precisely to prevent sub-advisor/parent double-counting and the build ignores both. Filed as **D9**, not fixed here.

Worth knowing: **vendor panels often clip this ratio at 100%, so the defect is invisible in them.** Don't read the clip as cleanliness.

## Contents

- 3 detectors in `skills/wrds/scripts/ownership_dq.py` (stdlib only) — 11 new assertions, **79 passed, 0 failed**
- **D8** (the overflow, with the correct cast — and the note that `dt.quarter()` is Int8 too, which caught the comparison script written to check this very bug) and **D9** in `references/tfn-ownership.md`
- `SKILL.md` updated: run `detect_calendar_bucket_gap` on every reference/dimension table at build time

Run: `uv run python3 tests/ownership_dq_test.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193ue9M5okF31PoPetXXBmL