### PR TITLE
fix(npx-ownership-panel): port the 2014 comma-shift repair into the linking suite

### DIFF
--- a/skills/npx-ownership-panel/scripts/npx_linking/build_sec_series_master.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_sec_series_master.py
@@ -184,6 +184,49 @@ def clean_str(s: pd.Series) -> pd.Series:
     return out.mask(out.str.upper().isin(NULL_SENTINELS))
 
 
+def repair_comma_shift(df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    """Undo the one-field right-shift caused by an unquoted comma in `series_name`.
+
+    The 2014 vintage is not fully quoted, so a series name containing a comma --
+    "Jefferies, TR/J CRB Global Commodity Equity Index Fund", "ALPS, JPMorgan ETF
+    Efficiente 5 TR Index Portfolio" -- is emitted as TWO fields, and every column
+    from `class_id` rightward lands one position too far right.
+
+    Without this the rows are not corrupted, they are DELETED: the
+    `class_id.startswith("C")` filter in read_year drops them silently, because the
+    shifted `class_id` holds the tail of a fund name rather than a C-number. Silent
+    deletion is the worse failure of the two -- the row count still looks plausible
+    and nothing in the output says anything is missing.
+
+    Detection is self-checking rather than positional: repair only where `class_id`
+    fails the C-number format AND `class_name` matches it. A row with a genuinely
+    absent class -- a closed-end fund carrying a series but no class -- has nothing
+    in the next column and is correctly left alone.
+
+    Measured: 4 of 40,532 rows in 2014, 0 in every other vintage. Small, but two of
+    the four are index/commodity funds, which is exactly what this table is used to
+    classify.
+    """
+    cid, cname = df["class_id"].astype("string"), df["class_name"].astype("string")
+    is_c = lambda x: x.str.match(r"^C\d{6,}$", na=False)  # noqa: E731
+    shifted = ~is_c(cid) & is_c(cname)
+    n = int(shifted.sum())
+    if not n:
+        return df, 0
+
+    tail = CANONICAL_COLUMNS[CANONICAL_COLUMNS.index("class_id"):]
+    fixed = df.copy()
+    fixed.loc[shifted, "series_name"] = (
+        df.loc[shifted, "series_name"].astype("string").str.rstrip()
+        + ", "
+        + df.loc[shifted, "class_id"].astype("string").str.strip()
+    )
+    for src, dst in zip(tail[1:], tail[:-1]):
+        fixed.loc[shifted, dst] = df.loc[shifted, src]
+    fixed.loc[shifted, tail[-1]] = pd.NA
+    return fixed, n
+
+
 def read_year(path: Path, year: int) -> pd.DataFrame:
     """Read one annual CSV into the canonical schema, adding `file_year`."""
     skiprows = find_header_row(path)
@@ -209,6 +252,12 @@ def read_year(path: Path, year: int) -> pd.DataFrame:
 
     for col in CANONICAL_COLUMNS:
         df[col] = clean_str(df[col])
+
+    # Repair the unquoted-comma field shift BEFORE the format filters below --
+    # those filters would otherwise delete the affected rows without a word.
+    df, n_shift = repair_comma_shift(df)
+    if n_shift:
+        print(f"  [{year}] repaired {n_shift} comma-shifted row(s)")
 
     # 2012 puts a row of dashes under the header; drop it and any id-less rows.
     df = df[df["series_id"].notna() & df["class_id"].notna()]


### PR DESCRIPTION
The linking suite is duplicated between mirror (`scripts/linking/`) and this skill (`scripts/npx_linking/`), and the two have **diverged in both directions** — neither is a superset, so this ports one function rather than copying a file.

| | mirror has | skill has |
|---|---|---|
| `build_sec_series_master.py` | `repair_comma_shift` | env-overridable paths (`NPX_LINK_ROOT`/`SEC_SERIES_RAW`/`SEC_SERIES_OUT`) vs mirror's hardcoded `parents[2]` |

Copying mirror's file wholesale would have fixed the defect and broken portability. So the repair is ported in, keeping the skill's paths.

**The defect:** the 2014 vintage isn't fully quoted, so a comma in a series name shifts every field after it. The rows weren't corrupted — they were **silently deleted** by `read_year`'s `class_id.startswith("C")` filter. Verified through the skill's own reader: **40,528 → 40,532 rows**, 4 repaired, 0 other vintages. Both recovered funds (`S000026188` Jefferies TR/J CRB, `S000044734` ALPS JPMorgan ETF Efficiente ×3 classes) are index/commodity funds — what this table classifies.

## Still open, deliberately

`build_npx_crsp_link.py` shares **zero function names** between the two copies. That's not drift, it's a reimplementation: the skill flattens into one file (`tier_seriesid`/`tier_sec_ticker`/`tier_sec_name`/`fuzzy_link`) what mirror splits across `pipeline.py`, `matching.py` and the `_gap`/`_gap2`/`_ticker` modules. Both emit the same tier labels, so it's the same ladder organised differently — but whether they produce identical output is untested, and mirror's produced the frozen baseline `8c0ddbfe`. **Picking one needs a comparison run, not a guess.**