### PR TITLE
feat(skills): crsp-v2 skill for CRSP CIZ format (v5.79.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.86.0"
+    "version": "5.87.0"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.86.0",
+      "version": "5.87.0",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.86.0",
+  "version": "5.87.0",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/crsp-v2/SKILL.md
+++ b/skills/crsp-v2/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: crsp-v2
+version: 1.0
+description: Use when "CRSP CIZ", "CRSP v2", "CRSP flat file format 2.0", "crsp.dsf_v2 / msf_v2", "StkDlySecurityData", "StkMthSecurityData", "StkSecurityInfoHist", "stocknames_v2", "DlyRet / MthRet / DlyPrc / MthPrc", "SHRCD or EXCHCD equivalent in new CRSP", "SIZ to CIZ migration", "CRSP data after 2024", "CRSP delisting returns", "CRSP cumulative adjustment factors", "CRSP index INDNO / INDFAM", or any CRSP stock/index query where the legacy SIZ column names no longer exist.
+user-invocable: false
+---
+
+## Contents
+
+- [Format Enforcement](#format-enforcement)
+- [Universe Enforcement](#universe-enforcement)
+- [Return Enforcement](#return-enforcement)
+- [What Changed at a Glance](#what-changed-at-a-glance)
+- [Table Map](#table-map)
+- [Canonical Queries](#canonical-queries)
+- [Additional Resources](#additional-resources)
+
+## Format Enforcement
+
+### IRON LAW: NO LEGACY SIZ TABLE FOR ANY DATA AFTER 2024-12-31
+
+<EXTREMELY-IMPORTANT>
+CRSP's legacy Stock & Indexes Flat File Format 1.0 (SIZ) was **discontinued after the
+December 2024 data release**. The legacy tables still exist on WRDS and still answer
+queries — they just stop.
+
+Verified on WRDS PostgreSQL (2026-07-26):
+
+| Table | Format | `max(date)` |
+|-------|--------|-------------|
+| `crsp.dsf` | legacy SIZ | **2024-12-31** |
+| `crsp.stkdlysecurityprimarydata` | CIZ | **2025-12-31** |
+| `crsp.stkmthsecuritydata` | CIZ | **2025-12-31** |
+
+- `SELECT ... FROM crsp.dsf WHERE date >= '2025-01-01'` → **WRONG. Returns zero rows, silently.**
+- `SELECT ... FROM crsp.msf WHERE date >= '2025-01-01'` → **WRONG. Same silent truncation.**
+- `SELECT ... FROM crsp.stkdlysecurityprimarydata` → **CORRECT.**
+
+A legacy query does not error when it runs off the end of the data. It returns a
+short panel, the regression runs, and the sample period is quietly wrong.
+</EXTREMELY-IMPORTANT>
+
+**Handing back a silently truncated panel is not helpful — it is worse than an error,
+because the user ships it.** You reach for `crsp.dsf` because the legacy names are in
+your weights and in every paper you have read. The weights are stale. Confirm the
+format before writing the first `SELECT`.
+
+### Red Flags — STOP Immediately If You're About To:
+
+- **Write `crsp.dsf`, `crsp.msf`, `crsp.dse`, `crsp.dsedelist`, or `crsp.stocknames`** → STOP. Legacy SIZ, frozen at 2024-12-31. Use the CIZ table (`references/tables.md`).
+- **Write `WHERE shrcd IN (10,11)`** → STOP. `shrcd` does not exist in CIZ. Five columns replace it (below).
+- **Write `WHERE exchcd IN (1,2,3)`** → STOP. `exchcd` does not exist in CIZ. Use `primaryexch`.
+- **Write `abs(prc)` or `WHERE prc > 0`** → STOP. CIZ prices are always positive. Use `dlyprcflg`.
+- **Add a delisting return to `dlyret`/`mthret`** → STOP. CIZ already embeds it. You are double-counting.
+- **Assume `mthret` reproduces legacy `ret`** → STOP. Different methodology (compounded daily). See `references/known-differences.md`.
+- **Guess what a flag value means** → STOP. `references/flags.md` has all 774 values; `crsp.metaflaginfo` is live.
+
+### Format Facts
+
+- The CIZ format shipped in July 2022 and became the only updated format in February 2025 (December 2024 data was the last SIZ release). Both formats sit in the **same** `crsp` schema in Postgres and the same `crsp` library in SAS — the schema name does not tell you which format you are in. The table name does.
+- WRDS-built convenience tables keep their legacy names with a `_v2` suffix: `crsp.dsf_v2`, `crsp.msf_v2`, `crsp.stocknames_v2`. CRSP-built tables use the new CIZ names (`crsp.stkdlysecuritydata`). Both are CIZ; the `_v2` ones are pre-joined and wider.
+- On the WRDS Cloud filesystem, SIZ stays at `/wrds/crsp/sasdata/a_stock` and CIZ is at `/wrds/crsp/sasdata/a_stock_v2`.
+- Column names carry their frequency as a prefix: `Dly`, `Mth`, `Qtr`, `Ann`. There is no frequency-agnostic `ret` or `prc` in CIZ — `DlyRet` and `MthRet` are different columns in different tables, not the same column read from two files.
+- The `62` suffix (`crsp.stkdlysecuritydata62`) is the 1962-start subset product; the `_ind` suffix (`crsp.stkindmembership_ind`) is the full Index database. Stock-only products carry just 4 index series; `crsp.indseriesinfohdr_ind` carries 274.
+
+## Universe Enforcement
+
+### IRON LAW: NO CIZ COMMON-STOCK SAMPLE WITHOUT ALL FIVE COLUMNS
+
+<EXTREMELY-IMPORTANT>
+Legacy `SHRCD IN (10, 11)` was unpacked into **five** CIZ columns across two tables.
+No single column reproduces it.
+
+```sql
+sharetype       = 'NS'                 -- No Special Share Type
+AND securitytype    = 'EQTY'
+AND securitysubtype = 'COM'
+AND usincflg        = 'Y'
+AND issuertype      IN ('ACOR', 'CORP')
+```
+
+- `WHERE sharetype = 'COM'` → **WRONG. Returns 0 rows.** `COM` lives at the *SecuritySubType* level; `ShareType` is never `'COM'` in CIZ. CRSP support confirmed this in writing.
+- `WHERE securitysubtype = 'COM'` alone → **WRONG.** Picks up non-US-incorporated firms, ADRs (`sharetype='AD'`), and REITs (`issuertype='REIT'`) that legacy `SHRCD` excluded.
+- All five, ANDed → **CORRECT.**
+</EXTREMELY-IMPORTANT>
+
+**A universe that silently differs from `SHRCD IN (10,11)` breaks comparability with
+every prior paper in the literature — that is an anti-helpful result dressed as a
+working query.** The one-column version is faster to type and returns plausible row
+counts, which is exactly why it survives review.
+
+Verified distribution in `crsp.stksecurityinfohist` (2026-07-26): `EQTY/COM/NS/CORP/Y`
+= 90,515 rows and `EQTY/COM/NS/ACOR/Y` = 21,682 rows are the two `SHRCD 10/11` cells;
+`EQTY/COM/AD/CORP/N` (6,279 ADR rows) and `EQTY/COM/NS/REIT/Y` (2,347 REIT rows) are
+what the sloppy filter lets in.
+
+### Exchange Facts
+
+- `EXCHCD` is gone. `primaryexch` is a single letter: `N` (NYSE), `A` (NYSE American), `Q` (NASDAQ), `R` (NYSE ARCA), `B` (BATS), `I` (IEX), `C` (Consolidated), `X` (Unknown), `N/A`.
+- `EXCHCD IN (1,2,3)` maps to `primaryexch IN ('N','A','Q')` — but `primaryexch` alone also carries the halted and suspended records that legacy `EXCHCD` split into `-2` and `-1`. To reproduce legacy `EXCHCD IN (1,2,3)` exactly, add `conditionaltype = 'RW' AND tradingstatusflg = 'A'`.
+- Legacy `EXCHCD = -2` (halted) → `tradingstatusflg = 'H'`. Legacy `EXCHCD = -1` (suspended) → `tradingstatusflg = 'S'`.
+- The universe columns live on the **history** table (`stksecurityinfohist`, one row per attribute-change interval), not only the header. Filtering on `stksecurityinfohdr` applies today's classification to the whole 1925–2025 panel and back-fills survivorship into the sample.
+
+### CUSIP Facts
+
+- CIZ **inverted the CUSIP naming**. `CUSIP` is now the *historical* CUSIP (legacy `NCUSIP`); `HdrCUSIP` is the *header/most-recent* CUSIP (legacy `CUSIP`).
+- Code ported from SIZ that joins on `cusip` therefore changes meaning silently — it starts joining on the historical value. For a point-in-time match to Compustat/IBES this is usually what you wanted; for a header match it is a bug.
+
+## Return Enforcement
+
+### IRON LAW: NEVER ADD A DELISTING RETURN TO A CIZ RETURN
+
+<EXTREMELY-IMPORTANT>
+In SIZ, delisting returns lived only in `crsp.dsedelist`/`msedelist` and every
+researcher hand-merged them in. **CIZ embeds the delisting return directly in the
+daily and monthly return series.**
+
+Verified for PERMNO 10002 (delisted 2013-02-15):
+
+| dlycaldt | dlyprc | dlyprcflg | dlyret | dlydelflg |
+|----------|--------|-----------|--------|-----------|
+| 2013-02-14 | 2.92 | `TR` | -0.010170 | `N` |
+| 2013-02-15 | 2.98 | `TR` | 0.020548 | `N` |
+| 2013-02-19 | 0.00 | `DA` | **0.010906** | `Y` |
+
+The 2013-02-19 row *is* the delisting return. `crsp.stkdelists` still exists, but it is
+for the delisting *reason* and *event* detail — not for patching the return series.
+
+- `coalesce(dlyret,0) + coalesce(dlret,0)` → **WRONG. Double-counts.**
+- `(1+dlyret)*(1+dlret)-1` → **WRONG. Same double-count, compounded.**
+- Use `dlyret` as-is → **CORRECT.**
+</EXTREMELY-IMPORTANT>
+
+**Silently inflating delisting-month returns reintroduces exactly the survivorship
+artifact the merge was supposed to fix.** The old merge is muscle memory and the
+result looks normal — the bias only shows up in the delisting tail, which is where
+the identification usually lives.
+
+### Return Facts
+
+- `MthRet` is a **compound of daily returns within the month**, with dividends reinvested on the ex-date. Legacy `RET` was a month-end-to-month-end holding period return with dividends reinvested at month-end. These are different estimators, not a renaming. WRDS found 90 stock-months differing by >100% and 3,479 differing by >5%.
+- The same change applies to delisting returns (`DelRet`), where the divergence can be larger.
+- `DLRETX` (delisting return without dividends) **does not exist** in CIZ. There is no substitute.
+- `DlyRetMissFlg` and `DlyRetDurFlg` explain missing and multi-period returns. `DlyRetDurFlg = 'D1'` is the ordinary adjacent-trading-day case; `P1`–`P9` mean the return spans 2–10 trading periods; `MR` means missing. Filtering on this flag replaces the old ad-hoc "drop returns after a gap" heuristics.
+- `DlyPrc` is always positive. The bid-ask-average case that legacy encoded as a negative price is now `DlyPrcFlg = 'BA'`; a real closing trade is `'TR'`; a delisting amount is `'DA'`. Never call `abs()`.
+
+## What Changed at a Glance
+
+| Concept | Legacy SIZ | CIZ (v2) |
+|---------|-----------|----------|
+| Daily price | `prc` (negative = bid/ask avg) | `dlyprc` (always positive) + `dlyprcflg` |
+| Daily return | `ret` | `dlyret` (delisting return included) |
+| Monthly return | `ret` from `msf` | `mthret` (compounded daily) |
+| Common stock | `shrcd IN (10,11)` | 5 columns (see above) |
+| Exchange | `exchcd IN (1,2,3)` | `primaryexch IN ('N','A','Q')` |
+| Historical CUSIP | `ncusip` | `cusip` |
+| Header CUSIP | `cusip` | `hdrcusip` |
+| Delisting code | `dlstcd` (3-digit) | `delactiontype`, `delstatustype`, `delreasontype`, `delpaymenttype` |
+| Distribution code | `distcd` (4-digit) | `distype`, `disfreqtype`, `dispaymenttype`, `disdetailtype`, `distaxtype`, `disorigcurtype`, `disordinaryflg` |
+| Adjustment factors | `cfacpr`, `cfacshr` in `dsf` | `crsp.stkdlycumulativeadjfactor` (separate table) |
+| Market index | `vwretd` in `dsf` | `indno=1000200` in `crsp.inddlyseriesdata` |
+| Issuer attributes | mixed into `stocknames` | `crsp.stkissuerinfohdr` / `stkissuerinfohist` (PERMCO-keyed) |
+
+## Table Map
+
+Most-used CIZ tables. Full catalog with verified columns: `references/tables.md`.
+
+| Table | Grain | Use for |
+|-------|-------|---------|
+| `crsp.stkdlysecurityprimarydata` | permno × day, 12 cols | Daily returns/prices/cap — **default daily table**, ~7 GB |
+| `crsp.stkdlysecuritydata` | permno × day, 32 cols | Adds bid/ask, high/low, open, prev-price, dividend amounts — ~20 GB |
+| `crsp.stkmthsecuritydata` | permno × month, 37 cols | Monthly aggregates + identifiers |
+| `crsp.stkqtrsecuritydata` / `stkannsecuritydata` | permno × qtr / year | Pre-aggregated panels; check `qtrcompflg`/`anncompflg` |
+| `crsp.stksecurityinfohist` | permno × interval | **Universe filters, historical CUSIP/ticker** |
+| `crsp.stksecurityinfohdr` | permno | Current/header attributes only |
+| `crsp.stkissuerinfohdr` / `stkissuerinfohist` | permco | Issuer-level SIC/NAICS/ICB, non-duplicated issuer counts |
+| `crsp.stkshares` | permno × interval | Shares outstanding history |
+| `crsp.stkdistributions` | permno × exdt × seq | Dividends, splits, factors |
+| `crsp.stkdelists` | permno | Delisting reason/status detail (**not** for returns) |
+| `crsp.stkdlycumulativeadjfactor` | permno × day | `dlycumfacpr`, `dlycumfacshr`, `dlyshrout` |
+| `crsp.inddlyseriesdata` / `indmthseriesdata` | indno × period | Index returns and levels |
+| `crsp.stkindmembership_ind` | permno × indno | Index constituents (S&P 500 = `indno 1000500`) |
+| `crsp.dsf_v2` / `msf_v2` / `stocknames_v2` | WRDS-built | Pre-joined convenience tables (identifiers + data + `shrout` + factors) |
+| `crsp.metafileinfo`, `metaiteminfo`, `metaflaginfo`, `metasiztociz` | metadata | Self-documenting schema — query these instead of guessing |
+
+## Canonical Queries
+
+All queries below were executed against WRDS PostgreSQL on 2026-07-26. Full set with
+output: `references/queries.md`.
+
+**Common-stock daily panel** (the `SHRCD 10/11` + `EXCHCD 1/2/3` equivalent):
+
+```sql
+SELECT d.permno, d.dlycaldt, d.dlyprc, d.dlyret, d.dlycap, d.dlyvol
+FROM crsp.stkdlysecurityprimarydata d
+JOIN crsp.stksecurityinfohist h
+  ON h.permno = d.permno
+ AND d.dlycaldt BETWEEN h.secinfostartdt AND h.secinfoenddt
+WHERE d.dlycaldt BETWEEN %(start)s AND %(end)s
+  AND h.sharetype = 'NS' AND h.securitytype = 'EQTY' AND h.securitysubtype = 'COM'
+  AND h.usincflg = 'Y' AND h.issuertype IN ('ACOR','CORP')
+  AND h.primaryexch IN ('N','A','Q')
+  AND h.conditionaltype = 'RW' AND h.tradingstatusflg = 'A';
+```
+
+The `BETWEEN secinfostartdt AND secinfoenddt` join is mandatory — it is what makes the
+classification point-in-time. Dropping it applies the security's final classification
+to its entire history.
+
+**Market capitalization** — do not compute it. `dlycap` (and `mthcap`) is CRSP's own
+capitalization in **$ thousands**, already on the row. `dlyprc * shrout` reintroduces
+the precision and rounding differences CRSP documented.
+
+**Market index return** — join on `indno`, do not look for `vwretd`:
+
+```sql
+SELECT m.permno, m.mthcaldt, m.mthret, i.mthtotret AS vwretd, i.mthprcret AS vwretx
+FROM crsp.stkmthsecuritydata m
+JOIN crsp.indmthseriesdata i ON i.mthcaldt = m.mthcaldt AND i.indno = 1000200;
+```
+
+`1000200` = CRSP NYSE/NYSEMKT/Nasdaq/Arca Value-Weighted (`vwretd`/`vwretx`),
+`1000201` = Equal-Weighted (`ewretd`/`ewretx`), `1000502` = S&P 500 Composite
+(`sprtrn` = `dlyprcret`/`mthprcret`).
+
+**Compustat merge** — the CCM link is **unchanged** by CIZ. `crsp.ccmxpf_lnkhist` is
+still keyed on `lpermno`, so existing CCM code ports as-is once the CRSP side is CIZ.
+
+## Additional Resources
+
+- **`references/tables.md`** — full CIZ table catalog, verified column lists, grain and key columns
+- **`references/siz-to-ciz.md`** — column-by-column crosswalk from every legacy SIZ file
+- **`references/flags.md`** — all 774 flag values across 62 flag types, dumped from `crsp.metaflaginfo`
+- **`references/known-differences.md`** — WRDS/CRSP-documented value discrepancies and the monthly-return methodology change
+- **`references/queries.md`** — verified query recipes (universe, delisting, factors, indexes, CCM, MSE-style rebuilds)
+- **`references/indexes.md`** — INDNO/INDFAM conventions, the +400 monthly rule, S&P 500 series, decile statistics
+- **`examples/ciz_panel.py`** — end-to-end Python pull of a CIZ common-stock panel
+- **`skills/wrds/SKILL.md`** — connection, `.pgpass`, WRDS Cloud/SGE rules (this skill assumes them)
+- CRSP source PDFs (WRDS login required): [User Guide](https://wrds-www.wharton.upenn.edu/documents/1996/CRSP_US_Stock__Indexes_Database_Guide_Flat_File_Format_2.0.pdf), [Cross-Reference Guide](https://wrds-www.wharton.upenn.edu/documents/1942/CRSP_Cross_Reference_Guide_1.0_to_2.0.pdf), [Metadata Guide](https://wrds-www.wharton.upenn.edu/documents/1941/CRSP_Metadata_Guide_Flat_File_Format_2.0.pdf), [Executive Summary](https://wrds-www.wharton.upenn.edu/documents/1943/Executive_Summary_File_Format_1.0_SIZ_to_File_Format_2.0_CIZ.pdf)
+- WRDS transition pages: [Announcement](https://wrds-www.wharton.upenn.edu/pages/data-announcements/changes-to-crsp-data/), [Transition FAQ](https://wrds-www.wharton.upenn.edu/pages/support/manuals-and-overviews/crsp/stocks-and-indices/crsp-ciz-faq/), [Index Overview](https://wrds-www.wharton.upenn.edu/pages/support/manuals-and-overviews/crsp/stocks-and-indices/siz-to-ciz-wrds-overview-of-index/), [Recreate MSE Tables](https://wrds-www.wharton.upenn.edu/pages/support/manuals-and-overviews/crsp/stocks-and-indices/recreate-legacy-mse-style-tables/)

--- a/skills/crsp-v2/SKILL.md
+++ b/skills/crsp-v2/SKILL.md
@@ -57,11 +57,11 @@ format before writing the first `SELECT`.
 
 ### Format Facts
 
-- The CIZ format shipped in July 2022 and became the only updated format in February 2025 (December 2024 data was the last SIZ release). Both formats sit in the **same** `crsp` schema in Postgres and the same `crsp` library in SAS — the schema name does not tell you which format you are in. The table name does.
-- WRDS-built convenience tables keep their legacy names with a `_v2` suffix: `crsp.dsf_v2`, `crsp.msf_v2`, `crsp.stocknames_v2`. CRSP-built tables use the new CIZ names (`crsp.stkdlysecuritydata`). Both are CIZ; the `_v2` ones are pre-joined and wider.
+- The CIZ format shipped in July 2022 and became the only updated format in February 2025 (December 2024 data was the last SIZ release). Both formats sit in the **same** `crsp` schema in Postgres and the same `crsp` library in SAS — the schema name does not tell you which format you are in. The table name does. Reporting "I queried the `crsp` schema, so this is v2 data" is an unverified claim presented as fact.
+- WRDS-built convenience tables keep their legacy names with a `_v2` suffix: `crsp.dsf_v2`, `crsp.msf_v2`, `crsp.stocknames_v2`. CRSP-built tables use the new CIZ names (`crsp.stkdlysecuritydata`). Both are CIZ; the `_v2` ones are pre-joined and wider. Treating the absence of a `_v2` suffix as evidence a table is legacy sends you back to the frozen data.
 - On the WRDS Cloud filesystem, SIZ stays at `/wrds/crsp/sasdata/a_stock` and CIZ is at `/wrds/crsp/sasdata/a_stock_v2`.
 - Column names carry their frequency as a prefix: `Dly`, `Mth`, `Qtr`, `Ann`. There is no frequency-agnostic `ret` or `prc` in CIZ — `DlyRet` and `MthRet` are different columns in different tables, not the same column read from two files.
-- The `62` suffix (`crsp.stkdlysecuritydata62`) is the 1962-start subset product; the `_ind` suffix (`crsp.stkindmembership_ind`) is the full Index database. Stock-only products carry just 4 index series; `crsp.indseriesinfohdr_ind` carries 274.
+- The `62` suffix (`crsp.stkdlysecuritydata62`) is the 1962-start subset product; the `_ind` suffix (`crsp.stkindmembership_ind`) is the full Index database. Stock-only products carry just 4 index series; `crsp.indseriesinfohdr_ind` carries 274. Querying the wrong one returns zero rows rather than an error, so "that index isn't in CRSP" is usually the wrong suffix, not a missing index.
 
 ## Universe Enforcement
 
@@ -235,6 +235,6 @@ still keyed on `lpermno`, so existing CCM code ports as-is once the CRSP side is
 - **`references/queries.md`** — verified query recipes (universe, delisting, factors, indexes, CCM, MSE-style rebuilds)
 - **`references/indexes.md`** — INDNO/INDFAM conventions, the +400 monthly rule, S&P 500 series, decile statistics
 - **`examples/ciz_panel.py`** — end-to-end Python pull of a CIZ common-stock panel
-- **`skills/wrds/SKILL.md`** — connection, `.pgpass`, WRDS Cloud/SGE rules (this skill assumes them)
+- **`${CLAUDE_SKILL_DIR}/../../skills/wrds/SKILL.md`** — connection, `.pgpass`, WRDS Cloud/SGE rules (this skill assumes them)
 - CRSP source PDFs (WRDS login required): [User Guide](https://wrds-www.wharton.upenn.edu/documents/1996/CRSP_US_Stock__Indexes_Database_Guide_Flat_File_Format_2.0.pdf), [Cross-Reference Guide](https://wrds-www.wharton.upenn.edu/documents/1942/CRSP_Cross_Reference_Guide_1.0_to_2.0.pdf), [Metadata Guide](https://wrds-www.wharton.upenn.edu/documents/1941/CRSP_Metadata_Guide_Flat_File_Format_2.0.pdf), [Executive Summary](https://wrds-www.wharton.upenn.edu/documents/1943/Executive_Summary_File_Format_1.0_SIZ_to_File_Format_2.0_CIZ.pdf)
 - WRDS transition pages: [Announcement](https://wrds-www.wharton.upenn.edu/pages/data-announcements/changes-to-crsp-data/), [Transition FAQ](https://wrds-www.wharton.upenn.edu/pages/support/manuals-and-overviews/crsp/stocks-and-indices/crsp-ciz-faq/), [Index Overview](https://wrds-www.wharton.upenn.edu/pages/support/manuals-and-overviews/crsp/stocks-and-indices/siz-to-ciz-wrds-overview-of-index/), [Recreate MSE Tables](https://wrds-www.wharton.upenn.edu/pages/support/manuals-and-overviews/crsp/stocks-and-indices/recreate-legacy-mse-style-tables/)

--- a/skills/crsp-v2/examples/ciz_panel.py
+++ b/skills/crsp-v2/examples/ciz_panel.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Pull a CRSP CIZ (v2) common-stock panel from WRDS PostgreSQL.
+
+Demonstrates the four things that most often go wrong when porting SIZ code:
+
+  1. Legacy tables (crsp.dsf / crsp.msf) stop at 2024-12-31 -- use CIZ tables.
+  2. SHRCD IN (10, 11) needs FIVE CIZ columns, not one.
+  3. The delisting return is already inside dlyret / mthret -- never add DelRet.
+  4. There is no vwretd column; market returns come from an INDNO join.
+
+Credentials come from ~/.pgpass (chmod 600):
+
+    wrds-pgdata.wharton.upenn.edu:9737:wrds:USERNAME:PASSWORD
+
+Set PGUSER (or pass --user) to that USERNAME -- libpq matches ~/.pgpass on the
+user too, so it fails if your OS username differs from your WRDS one.
+
+The value-weighted return this prints will NOT equal CRSP's VWRETD: this sample is
+common stock only, while INDNO 1000200 spans a broader eligible universe with CRSP's
+own weighting rules. Use the index series when you want the benchmark itself.
+
+Verified against WRDS 2026-07-26:
+    --start 2025-11-01 --end 2025-12-31 --freq monthly -> 7,373 rows / 3,703 permnos
+    --start 2025-12-01 --end 2025-12-05 --freq daily   -> 18,347 rows / 3,674 permnos
+
+Usage:
+    python ciz_panel.py --start 2024-01-01 --end 2025-12-31 --freq monthly
+    python ciz_panel.py --start 2025-01-02 --end 2025-01-31 --freq daily
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+
+import pandas as pd
+import psycopg2
+
+HOST = "wrds-pgdata.wharton.upenn.edu"
+PORT = 9737
+DATABASE = "wrds"
+
+# SHRCD IN (10, 11) + EXCHCD IN (1, 2, 3). All five share/issuer columns are
+# required: ShareType is never 'COM' in CIZ -- 'COM' lives at SecuritySubType.
+def common_stock(alias: str) -> str:
+    a = f"{alias}." if alias else ""
+    return f"""
+      {a}sharetype       = 'NS'
+  AND {a}securitytype    = 'EQTY'
+  AND {a}securitysubtype = 'COM'
+  AND {a}usincflg        = 'Y'
+  AND {a}issuertype      IN ('ACOR', 'CORP')
+  AND {a}primaryexch     IN ('N', 'A', 'Q')
+"""
+
+# CRSP NYSE/NYSEMKT/Nasdaq/Arca Value-Weighted Market Index -- the CIZ home of
+# legacy VWRETD (TotRet) and VWRETX (PrcRet).
+VWRETD_INDNO = 1000200
+
+# stkmthsecuritydata carries the universe columns as of MthPrcDt, so the monthly
+# panel needs no join to stksecurityinfohist.
+MONTHLY_SQL = f"""
+SELECT m.permno,
+       m.mthcaldt,
+       m.mthprc,
+       m.mthprcflg,
+       m.mthret,                 -- delisting return already included
+       m.mthretx,
+       m.mthcap,                 -- $ thousands, CRSP's own figure
+       m.mthprevcap,             -- prior-period cap: the VW weight, no LAG() needed
+       m.mthvol,
+       m.mthcompflg,             -- completeness of the underlying daily data
+       m.ticker,
+       m.issuernm,
+       i.mthtotret AS vwretd,
+       i.mthprcret AS vwretx
+FROM crsp.stkmthsecuritydata m
+JOIN crsp.indmthseriesdata i
+  ON i.mthcaldt = m.mthcaldt
+ AND i.indno    = %(indno)s
+WHERE m.mthcaldt BETWEEN %(start)s AND %(end)s
+  AND {common_stock("m")}
+ORDER BY m.permno, m.mthcaldt
+"""
+
+# The daily files have no identifier columns, so the universe filter comes from
+# stksecurityinfohist. The BETWEEN join is what makes it point-in-time -- without
+# it you apply today's classification to the whole history.
+#
+# Uses stkdlysecuritydata (32 cols) rather than stkdlysecurityprimarydata (12 cols)
+# only because DlyPrevCap lives in the wider file. Drop DlyPrevCap and switch to
+# the primary file if you do not need value weights -- same rows, ~1/3 the bytes.
+DAILY_SQL = f"""
+SELECT d.permno,
+       d.dlycaldt,
+       d.dlyprc,
+       d.dlyprcflg,              -- 'TR' trade, 'BA' bid-ask avg, 'DA' delisting
+       d.dlyret,                 -- delisting return already included
+       d.dlyretx,
+       d.dlycap,
+       d.dlyprevcap,             -- prior-period cap: the VW weight, no LAG() needed
+       d.dlyvol,
+       d.dlydelflg,
+       h.ticker,
+       h.issuernm,
+       i.dlytotret AS vwretd,
+       i.dlyprcret AS vwretx
+FROM crsp.stkdlysecuritydata d
+JOIN crsp.stksecurityinfohist h
+  ON h.permno = d.permno
+ AND d.dlycaldt BETWEEN h.secinfostartdt AND h.secinfoenddt
+JOIN crsp.inddlyseriesdata i
+  ON i.dlycaldt = d.dlycaldt
+ AND i.indno    = %(indno)s
+WHERE d.dlycaldt BETWEEN %(start)s AND %(end)s
+  AND h.conditionaltype  = 'RW'
+  AND h.tradingstatusflg = 'A'
+  AND {common_stock("h")}
+ORDER BY d.permno, d.dlycaldt
+"""
+
+
+def pull(freq: str, start: str, end: str, user: str | None = None) -> pd.DataFrame:
+    """Run the panel query. `user` must be the WRDS username, not the OS one --
+    libpq matches ~/.pgpass on (host, port, db, user), so leaving it unset makes
+    the lookup fail with 'no password supplied' whenever they differ."""
+    sql = MONTHLY_SQL if freq == "monthly" else DAILY_SQL
+    params = {"start": start, "end": end, "indno": VWRETD_INDNO}
+    user = user or os.environ.get("PGUSER") or getpass.getuser()
+    with psycopg2.connect(
+        host=HOST, port=PORT, database=DATABASE, user=user, sslmode="require"
+    ) as conn:
+        return pd.read_sql(sql, conn, params=params)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--start", required=True, help="YYYY-MM-DD")
+    ap.add_argument("--end", required=True, help="YYYY-MM-DD")
+    ap.add_argument("--freq", choices=["daily", "monthly"], default="monthly")
+    ap.add_argument("--user", help="WRDS username (default: $PGUSER)")
+    ap.add_argument("--out", help="optional parquet output path")
+    args = ap.parse_args()
+
+    df = pull(args.freq, args.start, args.end, args.user)
+
+    ret = "mthret" if args.freq == "monthly" else "dlyret"
+    date = "mthcaldt" if args.freq == "monthly" else "dlycaldt"
+
+    print(f"rows={len(df):,}  permnos={df.permno.nunique():,}")
+    print(f"dates {df[date].min()} .. {df[date].max()}")
+    print(f"mean {ret}: {df[ret].astype(float).mean():.6f}")
+
+    # Value-weighted portfolio return. Weight on the PREVIOUS period's cap --
+    # weighting by the contemporaneous cap builds this period's return into its
+    # own weight and biases the portfolio return upward.
+    cap = "mthprevcap" if args.freq == "monthly" else "dlyprevcap"
+    g = df.dropna(subset=[ret, cap]).astype({ret: float, cap: float})
+    vw = g.groupby(date).apply(
+        lambda x: (x[ret] * x[cap]).sum() / x[cap].sum(), include_groups=False
+    )
+    print("\nvalue-weighted return, first 5 periods:")
+    print(vw.head())
+
+    if args.out:
+        df.to_parquet(args.out, index=False)
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/crsp-v2/references/flags.md
+++ b/skills/crsp-v2/references/flags.md
@@ -1,0 +1,1168 @@
+# CIZ Flag Dictionary
+
+Every flag value below was dumped from `crsp.metaflaginfo` on the WRDS PostgreSQL
+server (2026-07-26). This file is a snapshot for offline reading — **the live table
+is authoritative**:
+
+```sql
+SELECT flagvalue, flagdesc, flagdef FROM crsp.metaflaginfo WHERE flagtype = 'PC' ORDER BY 1;
+SELECT flagtype, flagtypedesc FROM crsp.metaflagtype ORDER BY 1;
+```
+
+CIZ replaced SIZ's packed numeric codes (`SHRCD`, `EXCHCD`, `DISTCD`, `DLSTCD`) with
+alphanumeric flag columns. `MetaItemInfo.itemflagtype` tells you which flag type a
+given column uses; that type is the key into this dictionary.
+
+Flag types are listed alphabetically by type code.
+
+## Flag type index
+
+| Type | Description |
+|------|-------------|
+| `AD` | Distribution Detail Type |
+| `AF` | Aggregate Factor to Adjust Shares Flag |
+| `AG` | Aggregate Date Flag |
+| `AR` | Aggregate Return Flag |
+| `AS` | Amount Source Type |
+| `AT` | Distribution Type |
+| `AV` | Aggregate Volume Flag |
+| `CB` | ICB Industry Type |
+| `CD` | Delisting Corporate Action Type |
+| `CF` | Aggregate Completeness Flag |
+| `CG` | Aggregate Completeness Sub-Flag |
+| `CI` | Distribution Impact |
+| `CL` | Item Class |
+| `CP` | Capitalization Flag |
+| `CS` | Delist Completion Status Type |
+| `CT` | Conditional Type |
+| `CU` | Distribution Original Currency Type |
+| `CY` | Item Category |
+| `DE` | Aggregate Delisting Flag |
+| `DR` | Delisting Reason Type |
+| `EC` | Primary Exchange |
+| `ED` | Date Status Flag |
+| `EG` | Exchange Group |
+| `ET` | Exchange Tier |
+| `FD` | Flag Type and Item Flag Type |
+| `FI` | File Category |
+| `FK` | File Key Type |
+| `FO` | Portfolio Order |
+| `FR` | File Row Frequency |
+| `FT` | Distribution Frequency Type |
+| `I1` | Issuer Status |
+| `I8` | Index Count and Value Availability Type |
+| `IB` | Index Breakpoint Formation Type |
+| `IF` | Index Family Type |
+| `IJ` | Statistic Breakpoint Type |
+| `IT` | Issuer Type |
+| `IW` | Index Weighting Type |
+| `MF` | Constituent Membership Flag |
+| `MS` | Statistic Flag |
+| `MT` | SIZ to CIZ Mapping Type |
+| `MU` | Siz to CIZ Mapping Sub-Type |
+| `PC` | Price Flag - Multiple - See Definition |
+| `PF` | Calendar Period Flag |
+| `PM` | Distribution Payment Method Type |
+| `PP` | Frequency Type |
+| `PT` | Delisting Payment Summary Type |
+| `RD` | Daily Return Duration Flag |
+| `RM` | Return Missing Flag - Daily and Delisting |
+| `S2` | Security Sub-Type |
+| `S3` | Security Type |
+| `S4` | Share Type |
+| `SD` | Share Change Source Type |
+| `SH` | Share Class |
+| `SY` | Statistic Assignment Type |
+| `TG` | Index Frequency |
+| `TS` | Trading Status |
+| `TX` | Distribution Tax Status Type |
+| `UC` | UES Industry Type |
+| `UD` | Underlying Data for Index Family |
+| `UT` | Universe Type |
+| `YN` | Yes No Flag |
+| `YX` | Yes No Unavailable Flag |
+
+## `AD` — Distribution Detail Type
+
+| Value | Description |
+|-------|-------------|
+| `CAPG` | Capital Gains |
+| `CDIV` | Cash Dividend |
+| `CDM` | Cash Dividend - Missing Terms |
+| `CDPSR` | Cash Dividend - Proceeds from Sale of Rights |
+| `CPBLST` | Cash Payment - Buyback - Limited Self Tender |
+| `CPEX` | Cash Payment - Exchange |
+| `CPEXCSH` | Cash Payment - Exchange - Cash |
+| `CPFL` | Cash Payment - Final Liquidation |
+| `CPM` | Cash Payment - Merger |
+| `CPPL` | Cash Payment - Partial Liquidation |
+| `CPRCSH` | Cash Payment - Reorganization - Cash |
+| `CPSCM` | Cash Payment - Shares Changed Merger |
+| `CPSCMO` | Cash Payment - Shares Changed Merger Other |
+| `CPSIL` | Cash Payment - Step in Liquidation |
+| `CPSOA` | Cash Payment - Sale of Assets |
+| `ICLA` | Issuer Change - Liquidation Announcement |
+| `ICSAA` | Issuer Change - Sale of Assets Announcement |
+| `ROC` | Return of Capital |
+| `RPSR` | ROC - Proceeds from Sale of Rights |
+| `SDIV` | Special Dividends |
+| `SDROC` | Special Dividends - ROC |
+| `SECBLST` | Security Payment - Buyback - Limited Self Tender |
+| `SECDO` | Security Payment - Distribution Offer |
+| `SECDW` | Security Change - Declared Worthless |
+| `SECEX` | Security Payment - Exchange |
+| `SECFL` | Security Payment - Final Liquidation |
+| `SECMRG` | Security Payment - Merger |
+| `SECMWM` | Security Payment - Merger with Missing Terms |
+| `SECNOD` | Security Payment - Non-Ordinary Distribution |
+| `SECPL` | Security Payment - Partial Liquidation |
+| `SECPMT` | Security Payment |
+| `SECRD` | Security Payment - Rights Distribution |
+| `SECRSD` | Security Payment - Reorg Stock Distribution |
+| `SECSDN` | Security Payment - Stock Dividend New |
+| `SECSDO` | Security Payment - Stock Dividend Other |
+| `SECSIM` | Security Payment - Step in Merger - TBR |
+| `SECSO` | Security Payment - Spin-Off |
+| `SECSTL` | Security Payment - Step in Total Liquidation |
+| `SECUM` | Security Payment - Unknown Merger |
+| `STKDIV` | Forward or Reverse Split - Stock Dividend |
+| `STKSPL` | Forward or Reverse Split - Stock Split |
+| `TSCC` | TSO Observation - Shares Changed Conversion |
+| `TSCM` | TSO Observation - Shares Changed Merger |
+| `TSCMO` | TSO Observation - Shares Changed Merger Other |
+| `TSCU` | TSO Observation - Shares Changed Unknown |
+| `TSOF` | TSO Observation - Secondary Offer |
+| `ULIQ` | Unknown Liquidation |
+| `UMRGR` | Unknown Merger |
+| `URTSD` | Unknown Rights Distribution |
+
+## `AF` — Aggregate Factor to Adjust Shares Flag
+
+| Value | Description |
+|-------|-------------|
+| `B` | Both |
+| `N` | None |
+| `O` | Other |
+| `S` | Stock Split |
+
+## `AG` — Aggregate Date Flag
+
+| Value | Description |
+|-------|-------------|
+| `ED` | End Date |
+| `LA` | Last Available |
+| `MI` | Missing/Not Tracked |
+| `NS` | New Security |
+| `NT` | Not Tracked |
+| `PE` | Period-End |
+
+## `AR` — Aggregate Return Flag
+
+| Value | Description |
+|-------|-------------|
+| `CR` | Compounded Return |
+| `DE` | Compounded Return - Delists |
+| `GP` | Gap Between Prices is too Large |
+| `IP` | Compounded Return - Incomplete Period |
+| `MP` | Compounded Return - Missing Prices(s) |
+| `NS` | New Security |
+| `NT` | Not Tracked |
+
+## `AS` — Amount Source Type
+
+| Value | Description |
+|-------|-------------|
+| `CF` | Non-Transferable - Calculated |
+| `CV` | Calculated but Transferable |
+| `FM` | Fair Market Value |
+| `MK` | Market Value |
+| `MP` | Market Value - Price Provided |
+| `N/A` | Not Applicable |
+| `NF` | Non-Transferable - Fair Market |
+| `UN` | Unknown |
+| `UT` | Unknown Transferable |
+| `UV` | Non-Transferable - Unknown |
+
+## `AT` — Distribution Type
+
+| Value | Description |
+|-------|-------------|
+| `CD` | Cash Dividend |
+| `CG` | Capital Gains |
+| `CP` | Cash Payment |
+| `FRS` | Forward or Reverse Split |
+| `IN` | Issuer Notification |
+| `N/A` | Not Applicable |
+| `ROC` | Return of Capital |
+| `SD` | Special Dividends |
+| `SP` | Security Payment |
+| `TSOO` | Total Shares Outstanding Observation |
+
+## `AV` — Aggregate Volume Flag
+
+| Value | Description |
+|-------|-------------|
+| `CV` | Complete Volume |
+| `DE` | Delisting |
+| `GP` | Gap during period |
+| `IP` | Incomplete Period |
+| `MI` | Missing/Not Tracked |
+| `MV` | Missing Volume |
+| `NS` | New Security |
+
+## `CB` — ICB Industry Type
+
+| Value | Description |
+|-------|-------------|
+| `BASMAT` | Basic Materials |
+| `CONDIS` | Consumer Discretionary |
+| `CONSTAP` | Consumer Staples |
+| `ENERGY` | Energy |
+| `FINL` | Financials |
+| `HEALTH` | Health Care |
+| `INDL` | Industrials |
+| `NOAVAIL` | Not Available |
+| `REIT` | Real Estate Investment Trusts |
+| `TECH` | Technology |
+| `TELECOM` | Telecommunications |
+| `UTIL` | Utilities |
+
+## `CD` — Delisting Corporate Action Type
+
+| Value | Description |
+|-------|-------------|
+| `GDR` | Dropped |
+| `GEX` | Exchange |
+| `GLI` | Liquidation |
+| `LOS` | Lost Source |
+| `MER` | Merger |
+| `N/A` | Not Applicable |
+
+## `CF` — Aggregate Completeness Flag
+
+| Value | Description |
+|-------|-------------|
+| `G` | Green |
+| `R` | Red |
+| `Y` | Yellow |
+
+## `CG` — Aggregate Completeness Sub-Flag
+
+| Value | Description |
+|-------|-------------|
+| `G1` | Green-1 |
+| `G2` | Green-2 |
+| `G3` | Green-3 |
+| `R1` | Red-1 |
+| `R2` | Red-2 |
+| `R3` | Red-3 |
+| `Y1` | Yellow-1 |
+| `Y2` | Yellow-2 |
+| `Y3` | Yellow-3 |
+
+## `CI` — Distribution Impact
+
+| Value | Description |
+|-------|-------------|
+| `C1` | One Ordinary Cash Dividend |
+| `C2` | Two Ordinary Cash Dividends |
+| `CS` | One Cash Dividend & One Stock Split |
+| `D1` | One Delisting Action |
+| `D2` | Two Delisting Actions |
+| `F1` | One Share Factor - Non-Split |
+| `M2` | Two Corporate Actions |
+| `MU` | Multiple Corporate Actions |
+| `N1` | One Non-Ordinary |
+| `NA` | Not Applicable |
+| `NO` | No Corporate Actions |
+| `O1` | One 'Other' Action |
+| `P1` | One Price Factor - Non-Split |
+| `S1` | One Stock Split/Dividend |
+| `S2` | Two Stock Splits/Dividends |
+| `T1` | One (Tender) Offer Action |
+
+## `CL` — Item Class
+
+| Value | Description |
+|-------|-------------|
+| `CodeSICCD` | SIC - Standard Industrial Classification Code |
+| `DateAnnual` | Annual Year-End Date |
+| `DateDaily` | Daily Calendar Date |
+| `DateDaily14` | Daily Calendar Date - 14 days |
+| `DateDaily180` | Daily Calendar Date - 180 days |
+| `DateDlyEnd` | Daily Calendar End Date |
+| `DateDlyStart` | Daily Calendar Start Date |
+| `DateDlyWNull` | Daily Calendar Date With Null |
+| `DateMonth` | Month-End Date |
+| `DateQuarter` | Quarter-End Date |
+| `DateTrade` | Daily Trading Date |
+| `DateTrdEnd` | Daily Trading End Date |
+| `DateTrdStart` | Daily Trading Start Date |
+| `DescVar-255` | Description field - 255 characters wide |
+| `DescVar-50` | Description field - 50 characters wide |
+| `FlagFix-1` | Flag that is exactly 1 character |
+| `FlagFix-2` | Flag that is exactly 2 characters |
+| `FlagFix-3` | Flag that is exactly 3 characters |
+| `FlagFix-4` | Flag that is exactly 4 characters |
+| `FlagFix-5` | Flag that is exactly 5 characters |
+| `FlagFix-8` | Flag that is exactly 8 characters |
+| `FlagVar-1` | Flag that can be up to 1 character |
+| `FlagVar-16` | Flag that can be up to 16 characters |
+| `FlagVar-20` | Flag that can be up to 20 characters |
+| `FlagVar-3` | Flag that can be up to 3 characters |
+| `FlagVar-4` | Flag that can be up to 4 characters |
+| `FlagVar-5` | Flag that can be up to 5 characters |
+| `FlagVar-6` | Flag that can be up to 6 characters |
+| `FlagVar-7` | Flag that can be up to 7 characters |
+| `IdCNUM` | CNUM - CUSIP Bureau Issuer - Exactly 6 characters |
+| `IdCUSIP` | CUSIP Bureau Security - Exactly 8 characters wide |
+| `IdCUSIP9` | CUSIP Bureau Security with Check Digit - width 9 |
+| `IdFileName` | CRSP File Name |
+| `IdFlagValue` | CRSP Flag Value |
+| `IdItemName` | CRSP Item Name |
+| `IdNAICS` | NAICS - North Amer Industry Classification System |
+| `IdnumCompno` | NASDAQ Compno |
+| `IdnumIssueno` | NASDAQ Issuno |
+| `IdR` | R code for the data type |
+| `IdSAS` | SAS code for the data type |
+| `IdSASForm` | SAS code for the data format |
+| `IdSQL` | SQL code for the data type |
+| `IdTicker` | Ticker - up to 5 upper case letters |
+| `IdTradingSymbol` | Trading Symbol - up to 7 upper case letters |
+| `KeyColCov` | Column Coverage Key |
+| `KeyColumn` | Column Key |
+| `KeyFile` | File Key |
+| `KeyFlag` | Flag Key |
+| `KeyFlagCov` | Flag Coverage Key |
+| `KeyFlagType` | Flag Type Key |
+| `KeyINDFAM` | INDFAM |
+| `KeyINDNO` | INDNO |
+| `KeyItem` | Item Key |
+| `KeyPERMCO` | PERMCO |
+| `KeyPERMNO` | PERMNO |
+| `KeySIZtoCIZ` | SIZ to CIZ Key |
+| `Name100` | Name Field 100 |
+| `Name50` | Name Field 50 |
+| `Name60` | Name Field 60 |
+| `Name80` | Name Field 80 |
+| `Num1to10` | Number from 1 to 10 |
+| `Num1to4` | Number from 1 to 4 |
+| `Num1to7` | Number from 1 to 7 |
+| `NumCnt100` | Count from 0 to 100 |
+| `NumCnt100K` | Count from 0 to 100,000 |
+| `NumCnt10K` | Count from 0 to 10,000 |
+| `NumCnt1B` | Count from 0 to 1,000,000,000 |
+| `NumCnt1K` | Count from 0 to 1,000 |
+| `NumCnt1M` | Count from 0 to 1,000,000 |
+| `NumCnt20` | Count from 0 to 20 |
+| `NumCnt200` | Count from 0 to 200 |
+| `NumCnt350` | Count from 0 to 350 |
+| `PctShares` | Shares Percentage |
+| `PerAny` | Period Value - Any Frequency |
+| `PerDay` | Daily Period Value - YYYYMMDD |
+| `PerMonth` | Monthly Period Value - YYYYMM |
+| `PerQuarter` | Quarterly Period Value - YYYYQ |
+| `PerYear` | Annual (Yearly) Period Value - YYYY |
+| `QtyShares` | Quantity Shares |
+| `QtyVolume` | Quantity Volume |
+| `RatioCount` | Ratio of Counts |
+| `RatioFactor` | Calculation Factors |
+| `RatioIncRet` | Income Return |
+| `RatioReturn` | Return |
+| `ValBaseLvl` | Base Index Level |
+| `ValCap` | Security or Issuer Capitalization |
+| `ValDivAmt` | Distribution or Dividend Amount |
+| `ValLevel` | Index Level |
+| `ValMktVal` | Market Value for an Index |
+| `ValPrc` | Security Price |
+| `ValPrcVol` | Security Price times Volume |
+| `ValSecStat` | Security Statistics |
+
+## `CP` — Capitalization Flag
+
+| Value | Description |
+|-------|-------------|
+| `AD` | ADR |
+| `BP` | Basis Price Capitalization |
+| `DE` | Delisted |
+| `MP` | Missing Price |
+| `MS` | Missing Shares |
+| `NA` | Not Applicable |
+| `NT` | Not Tracked |
+| `PB` | Prior Basis Price Capitalization |
+
+## `CS` — Delist Completion Status Type
+
+| Value | Description |
+|-------|-------------|
+| `FPAY` | Final Payment |
+| `N/A` | Not Applicable |
+| `NDC` | No Distributions, Closed |
+| `NDP` | No Distributions, Pending |
+| `NFC` | No Final, Closed |
+| `NFP` | No Final, Pending |
+| `NVP` | No Value, Pending |
+| `UNAV` | Unavailable |
+| `VCL` | Valued, Closed |
+
+## `CT` — Conditional Type
+
+| Value | Description |
+|-------|-------------|
+| `N/A` | Not Applicable |
+| `NT` | Not Tracked |
+| `NW` | Non-Leading When Issued |
+| `RW` | Regular Way |
+| `WI` | When Issued |
+
+## `CU` — Distribution Original Currency Type
+
+| Value | Description |
+|-------|-------------|
+| `N/A` | Not Applicable |
+| `NUS` | Non-US |
+| `USD` | United States dollar |
+
+## `CY` — Item Category
+
+| Value | Description |
+|-------|-------------|
+| `CODE` | Integer Code |
+| `DATE` | Date Field |
+| `DESCRIPTION` | Wide Character Description Field |
+| `FLAG` | Character Flag Field |
+| `ID` | Character Identifier Field |
+| `IDNUM` | Numeric Identifier Field |
+| `KEY` | Integer Field used as a Unique Key |
+| `NAME` | Medium width character field |
+| `NUMBER` | Integer value < 2,000,000,000 |
+| `PERIOD` | Integer field used for a Calendar Period |
+| `QUANTITY` | Integer with values that can exceed 2,000,000 |
+| `RATIO` | Calculated floating point number |
+| `VALUE` | Field with a wide range of numeric values |
+
+## `DE` — Aggregate Delisting Flag
+
+| Value | Description |
+|-------|-------------|
+| `A` | Amount - Return Included |
+| `G` | Gap - Return Excluded |
+| `M` | Missing- Return Excluded |
+| `N` | Not Applicable |
+| `P` | Price- Return Included |
+| `V` | Value Partial - Return Included |
+
+## `DR` — Delisting Reason Type
+
+| Value | Description |
+|-------|-------------|
+| `BKPY` | Bankruptcy |
+| `CORQ` | Company Request |
+| `DEEX` | Denied Exception |
+| `DELQ` | Delinquent |
+| `DERE` | Deregistration |
+| `EQRQ` | Equity Requirements |
+| `FARG` | Failure to Register |
+| `FDCV` | Fund Conversion |
+| `FING` | Financial Guidelines |
+| `INSC` | Insufficient Capital |
+| `INSF` | Insufficient Float |
+| `LP` | Low Price |
+| `MTMK` | Market Makers |
+| `MVB` | Moved to Boston |
+| `MVCHI` | Moved to Chicago |
+| `MVMF` | Moved to Mutual Fund |
+| `MVMO` | Moved to Montreal |
+| `MVNM` | Moved to NYSE MKT |
+| `MVOT` | Moved to OTC |
+| `MVPAC` | Moved to Pacific |
+| `MVPH` | Moved to Philadelphia |
+| `MVTO` | Moved to Toronto |
+| `N/A` | Not Applicable |
+| `NACT` | Not Applicable - Active |
+| `OFFRE` | Offer Rescinded |
+| `PUBI` | Public Interest |
+| `SERQ` | SEC Required |
+| `SHLD` | Shareholders |
+| `UNAV` | Unavailable |
+| `UNL` | Unlisted |
+| `VIO` | Violation |
+
+## `EC` — Primary Exchange
+
+| Value | Description |
+|-------|-------------|
+| `A` | NYSE American |
+| `B` | BATS |
+| `I` | IEX |
+| `N` | NYSE |
+| `Q` | NASDAQ |
+| `R` | NYSE ARCA |
+| `X` | Unknown |
+
+## `ED` — Date Status Flag
+
+| Value | Description |
+|-------|-------------|
+| `CLMB` | Columbus Day |
+| `COOL` | Special Event |
+| `DDEF` | Special Event |
+| `EAST` | Easter Saturday |
+| `ELEC` | Election Day |
+| `EMBH` | Special Event |
+| `GFRI` | Good Friday |
+| `GHBF` | Special Event |
+| `GLOR` | Special Event |
+| `GRFF` | Special Event |
+| `JFKA` | Special Event |
+| `JUL4` | Independence Day |
+| `LABR` | Labor Day |
+| `LBJF` | Special Event |
+| `LINC` | Lincoln's Birthday |
+| `LNBG` | Special Event |
+| `MLKD` | Martin Luther King's Day |
+| `MLKM` | Special Event |
+| `MMRL` | Memorial Day |
+| `MNTN` | Close for Maintenance |
+| `MOON` | Special Event |
+| `N/A` | Not Applicable |
+| `NAVY` | Special Event |
+| `NEWY` | New Years Day |
+| `NIXF` | Special Event |
+| `NYBO` | Special Event |
+| `PRES` | Presidents Day |
+| `RGNF` | Special Event |
+| `SATC` | Special Event |
+| `SEP11` | Special Event |
+| `SNDY` | Special Event |
+| `SNOW` | Special Event |
+| `TNKG` | Thanksgiving |
+| `TRDF` | Full Day Trading |
+| `TRDH` | Partial Day Trading |
+| `TRDS` | Saturday Trading |
+| `TRUF` | Special Event |
+| `VETR` | Veterans Day |
+| `VJDY` | Special Event |
+| `WASH` | Washington's birthday |
+| `WKND` | Weekend |
+| `XMAS` | Christmas |
+
+## `EG` — Exchange Group
+
+| Value | Description |
+|-------|-------------|
+| `A` | NYSE Market Only |
+| `ALL` | All - No Exchange restriction is done |
+| `N` | NSYE Only |
+| `N/A` | Not Applicable |
+| `NA` | NYSE-NYSE Market |
+| `NANMS` | NYSE-NYSE Market-NMS-Global-GlobalSelect |
+| `NAQ` | NYSE-NYSE Market-NASDAQ |
+| `NAQR` | NYSE-NYSE Market-NASDAQ-ARCA |
+| `Q` | NASDAQ Only |
+| `R` | ARCA Only |
+
+## `ET` — Exchange Tier
+
+| Value | Description |
+|-------|-------------|
+| `G` | Global Market after 20060701 (formerly NMS) |
+| `N/A` | Not Applicable |
+| `NMS` | The NASDAQ National Market |
+| `Q` | Global Select Market after 20060701 (new subset) |
+| `S` | Capital Market after 20060701 (formerly SmallCap) |
+| `SC` | NASDAQ Small Cap Market on or after 19920615 |
+| `SC1` | The NASDAQ Small Cap Market before 19920615 |
+
+## `FD` — Flag Type and Item Flag Type
+
+| Value | Description |
+|-------|-------------|
+| `AD` | Action Component Detail Type Code |
+| `AF` | Aggregate Share Factor Type Code |
+| `AG` | Aggregate Date Type Code |
+| `AR` | Aggregate Return Type Code |
+| `AT` | Action Component Type Code |
+| `AV` | Aggregate Volume Type Code |
+| `CB` | ICB Industry Type Code |
+| `CC` | Common Class Type Code |
+| `CD` | Corporate Action Type Code |
+| `CF` | Calendar Period Type Code |
+| `CI` | Corporate Action Impact Type Code |
+| `CL` | Item Class Type Code |
+| `CP` | Capitalization Type Code |
+| `CS` | Completion Status Type Code |
+| `CT` | Conditional Type Code |
+| `CU` | Currency Code |
+| `CY` | Item Category Type Code |
+| `DR` | Delist Reason Type Code |
+| `EC` | Exchange Code |
+| `ED` | Exchange Date Status Code |
+| `EG` | Exchange Group Code |
+| `ET` | Exchange Tier Code |
+| `FD` | Flag Type Type Code |
+| `FI` | File Category Type Code |
+| `FK` | File Key Type Type Code |
+| `FO` | Fractile Order Code |
+| `FR` | File Row Frequency Type Code |
+| `FT` | Frequency Type Code |
+| `I1` | Issuer Status Type Code |
+| `I8` | Index Count Value Type Code |
+| `IB` | Index Break Point Formation Type Code |
+| `IF` | Index Family Type Code |
+| `IJ` | Index Breakpoint Statistic Code |
+| `IT` | Issuer Type Code |
+| `IW` | Index Weighting Type Code |
+| `MF` | Membership Type Code |
+| `MS` | Missing Statistic Code |
+| `MT` | SIZ Mapping Type Code |
+| `MU` | SIZ Mapping Sub-Type Code |
+| `PC` | Price Type Code |
+| `PM` | Payment Method Type Code |
+| `PP` | Periodic Processing Frequency Code |
+| `PT` | Payment Summary Type Code |
+| `RD` | Return Duration Type Code |
+| `RM` | Return Missing Type Code |
+| `S2` | Security Sub Type Code |
+| `S3` | Security Type Code |
+| `S4` | Share Type Code |
+| `SD` | Share Change Source Type Code |
+| `SY` | Assignment Statistic Used Type Code |
+| `TG` | Time Grain Type Code |
+| `TS` | Trading Status Type Code |
+| `TX` | Tax Status Code |
+| `UT` | Universe Type Code |
+| `YN` | Yes or No Type Code |
+| `YX` | Yes, No, or Not Available X Type Code |
+
+## `FI` — File Category
+
+| Value | Description |
+|-------|-------------|
+| `ASSOCIATION` | Rows provide association between two keys |
+| `EVENT` | Event - Non-Regular and Dated Events |
+| `IDENTIFIER` | Identifiers and Descriptive Characteristics |
+| `METADATA` | Metadata Files |
+| `TIMESERIES` | Contains contiguous rows at a fixed frequency |
+
+## `FK` — File Key Type
+
+| Value | Description |
+|-------|-------------|
+| `AssocPerWithGap` | Association Periods with Gap Allowed |
+| `AssocRangeWithGap` | Association Ranges With Gap Allowed |
+| `Key` | Single Key Field |
+| `KeyDtNoGap` | Key Field with Date and No Gap (i.e. Timeseries) |
+| `KeyDtSeq` | Key Field with event date and sequence number |
+| `KeyPeriodNoGap` | Key Field with Period and No Gap (i.e. Timeseries) |
+| `KeyRangeNoGap` | Key Field with Range and No Gap |
+| `KeySeq` | Key Field combined with sequence field |
+| `KeySeqSeq` | Key Field combined with two sequence fields |
+| `KeySeqValue` | Key Field combined with sequence field and a value |
+| `KeyValue` | Key Field combined with a value |
+
+## `FO` — Portfolio Order
+
+| Value | Description |
+|-------|-------------|
+| `HIGH` | HIGH |
+| `LOW` | LOW |
+| `N/A` | Not Applicable |
+
+## `FR` — File Row Frequency
+
+| Value | Description |
+|-------|-------------|
+| `Annual` | Annual Period - YYYY or AnnCalDt |
+| `AssocAnnual` | Association Periods with Annual Data |
+| `AssocDateRange` | Association Periods with Data Ranges |
+| `AssocQuarterly` | Association Periods with Quarterly Data |
+| `Column` | Column - 1 row per column - file and item |
+| `ColumnSeq` | ColumnSeq - 1 row per column and sequence number |
+| `ColumnValue` | ColumnValue - 1 row per column per value |
+| `Daily` | Daily Period - YYYYMMDD or DlyCalDt |
+| `DateRange` | Date Range - Start and End |
+| `Monthly` | Monthly Period - YYYYMM or MthCalDt |
+| `Observation` | Observation - Event Date |
+| `PeriodFreq` | Period Frequency - 1 row per period per frequency |
+| `Quarterly` | Quarterly Period - YYYYQ or QtrCalDt |
+| `Single` | Single Row Per Entity |
+| `TypeValue` | Type Value - 1 Row per flag type and flag value |
+
+## `FT` — Distribution Frequency Type
+
+| Value | Description |
+|-------|-------------|
+| `A` | Annual |
+| `E` | Extra or Special |
+| `I` | Interim |
+| `M` | Monthly |
+| `N` | Non-Recurring |
+| `N/A` | Not Applicable |
+| `Q` | Quarterly |
+| `S` | Semi-Annual |
+| `U` | Unspecified |
+| `X` | Unknown |
+| `Y` | Year-End |
+
+## `I1` — Issuer Status
+
+| Value | Description |
+|-------|-------------|
+| `AC` | Active and Tracked |
+| `NT` | Not Tracked |
+
+## `I8` — Index Count and Value Availability Type
+
+| Value | Description |
+|-------|-------------|
+| `BOTH` | Both |
+| `N/A` | Not Applicable |
+| `USED` | Used |
+
+## `IB` — Index Breakpoint Formation Type
+
+| Value | Description |
+|-------|-------------|
+| `F` | Use forward statistics for breakpoints |
+| `L` | Largest stat in each fractile used as breakpoint |
+| `X` | Not Applicable |
+
+## `IF` — Index Family Type
+
+| Value | Description |
+|-------|-------------|
+| `C` | Combination (Union) of ICGs |
+| `E` | External (e.g. Treasury) |
+| `F` | Fractile (even count) |
+| `L` | Level-Based (External levels) |
+| `N` | No Operation/Change (same as superfamily) |
+| `R` | Recalc of external (S&P) |
+
+## `IJ` — Statistic Breakpoint Type
+
+| Value | Description |
+|-------|-------------|
+| `B` | Beta |
+| `IC` | Issuer Cap |
+| `IC2` | Issuer Cap - NYSE Break pointing |
+| `N/A` | Not Applicable |
+| `SC` | Security Cap |
+| `SCM` | Security Cap (Monthly) |
+| `SD` | Standard Deviation |
+| `TOB` | Trade Only Beta |
+
+## `IT` — Issuer Type
+
+| Value | Description |
+|-------|-------------|
+| `ACOR` | Assumed Corporation |
+| `CORP` | Corporation |
+| `REIT` | REIT |
+
+## `IW` — Index Weighting Type
+
+| Value | Description |
+|-------|-------------|
+| `EQ` | Equal |
+| `EV` | Equal/Value |
+| `MC` | Market-Cap |
+| `X` | Not Applicable |
+
+## `MF` — Constituent Membership Flag
+
+| Value | Description |
+|-------|-------------|
+| `NORM` | Normal Membership - 100% weight |
+
+## `MS` — Statistic Flag
+
+| Value | Description |
+|-------|-------------|
+| `CPNL` | Cur Proc Period - not active on last trading day |
+| `CPPP` | Cur Proc Per Active last trd day; part trd period |
+| `FWD` | Forward statistic value used |
+| `IVER` | Insufficient Valid and Eligible Returns |
+| `MSC` | Missing security capitalization |
+| `N/A` | Not Applicable |
+| `NMBR` | NonMember of Index Family during processing period |
+
+## `MT` — SIZ to CIZ Mapping Type
+
+| Value | Description |
+|-------|-------------|
+| `Closest` | Closest Match - non-exact |
+| `Combined` | SIZ columns combine to form a CIZ column |
+| `ConvChange` | Convention Change |
+| `DateToYYYY` | Date to YYYY |
+| `DateToYYYYMM` | Date to YYYYMM |
+| `DateToYYYYMMDD` | Date to YYYYMMDD |
+| `DateToYYYYQ` | Date to YYYYQ |
+| `Denormalized` | Denormalized (duplicated) Data |
+| `Documentation` | Columns from Documentation |
+| `Exact` | Exact Match |
+| `ManyToOne` | Many to One |
+| `Mapped` | Mapped from Integer to Flag |
+| `NameCleanup` | Name Column Cleanup |
+| `Normalized` | Normalized Data |
+| `OneToMany` | One to Many |
+| `OneToOne` | One to One |
+| `Reassign` | Reassignment Process |
+| `Recalc` | Recalculation Process |
+| `Split` | Split Code |
+| `SplitToOne` | Split Rows to One |
+| `Zero-ManyToMany` | Zero-Many to One |
+| `Zero-ManyToNormalize` | Zero-OneToNormalized |
+| `Zero-ManyToOne` | Zero-Many to Many |
+| `Zero-OneToMany` | Zero-One to Many |
+| `Zero-OneToOne` | Zero-OneToOne |
+
+## `MU` — Siz to CIZ Mapping Sub-Type
+
+| Value | Description |
+|-------|-------------|
+| `AddedIndDaily` | Additional Daily Index Rows |
+| `AddedIndHeader` | Additional Index Header Rows |
+| `AddedIndIssSecRB` | Additional Rebalancing Summary Rows |
+| `AddedIndMember` | Additional Index Membership Rows |
+| `AddedIndMonthly` | Additional Monthly Index Series Data Rows |
+| `AddedIndPortDaily` | Additional Index Portfolio Daily Assignment Rows |
+| `AddedIndPortMonthly` | Additional Index Portfolio Monthly Assignment Rows |
+| `AddedIndStatDaily` | Additional Index Portfolio Daily Statistics Rows |
+| `AddedIndStatMonthly` | Additional Index Portfolio Monthly Statistics Rows |
+| `BidAsk` | Bid Ask Convention Change |
+| `CAP` | Capitalization Change |
+| `CNUM6` | CNUM Issuer CUSIP |
+| `DailyPrev` | Daily Previous Convention |
+| `DateToYYYY` | Date to YYYY |
+| `DateToYYYYMM` | Date to YYYYMM |
+| `DateToYYYYMMwithJoin` | Date to YYYYMM with Join |
+| `DateToYYYYQ` | Date to YYYYQ |
+| `DelistCd` | Delisting Numeric Code to Mnemonic Fields |
+| `DelistConv` | Delisting Convention Changes |
+| `DelistConvDaily` | Delisting Convention Daily Changes |
+| `DelistConvDaily_Date` | Delisting Convention Daily Changes Date |
+| `DelistConvMonthly` | Delisting Convention Change Monthly |
+| `DelistConvSlicing` | Delisting Convention Slicing |
+| `DistCd` | Distribution Numeric Code to Mnemonic Fields |
+| `DistConversion` | Distribution Key Field Conversion |
+| `Exact` | Exact Match |
+| `ExactRows` | Exact Rows |
+| `Exchcd` | Exchange Numeric Code to Mnemonic Fields |
+| `IndexBreakStat` | Index Breakpoint Statistic Levels |
+| `IndexCount` | Index Counts Fields |
+| `IndexCountValue` | Index Count Value |
+| `IndexCountValuePT` | Index Count Value Pass-Through |
+| `IndexDescription` | Index Description Fields |
+| `IndexEligCnt` | Index Eligible Count |
+| `IndexEligCntPT` | Index Eligible Count Pass-Through |
+| `IndexInfo` | Index Information Split |
+| `IndexIssuerAllCnt` | Index Issuer All Count |
+| `IndexLevel` | Index Level Fields |
+| `IndexMinMaxId` | Index Minimum and Maximum ID Fields |
+| `IndexMinMaxStat` | Index Minimum and Maximum Statistic Fields |
+| `IndexRebalCnt` | Index Rebalance Summary Count |
+| `IndexReturn` | Index Return Fields |
+| `IndexValue` | Index Value Fields |
+| `MachinePrecision` | Machine Precision Limitations |
+| `MbrFlg` | Member Flag |
+| `Minus5Conv` | Minus 5 Convention |
+| `MthToAgg` | Monthly To Aggregate |
+| `MthToAggDateToYYYYMM` | Monthly To Aggregate with YYYYMM |
+| `MthToAggPrice` | Monthly To Aggregate Price |
+| `NDIToDly` | Nasdaq Information to Daily |
+| `NDIToInfoHIst` | Nasdaq Information to Security Info Hist |
+| `NMSIND` | NMS Indicator Convention |
+| `PassThrough` | Pass Through Index Values |
+| `PeriodEndToDaily` | Period End to Daily |
+| `PeriodEndToPeriodEnd` | Period End to Period End |
+| `Plus1Port` | Plus One Port for YYYY |
+| `Price` | Price Convention Change |
+| `Rename` | Rename of Item |
+| `RenameMinus5` | Minus 5 Convention |
+| `Rename/NextTrdDay` | Renamed Field and Next Trading Day Convention |
+| `Rename/PrevQtr` | Renamed Field and Previous Quarter |
+| `Rename/PrevYr` | Renamed Field and Previous Year |
+| `SAME` | Same Name |
+| `SECurityNm` | Security Name Convention |
+| `SECurityRet` | Security Return Changes |
+| `SFZ_HDR-PERMCO` | SFZ Header PERMCO convention |
+| `SFZ_INDHDR-INDFAM` | SFZ Index Header to Index Family |
+| `SFZ_INDHDR-INDNO` | SFZ Index Header to INDNO Characteristics |
+| `SFZ_NAM-PERMCO_DT` | SFZ Names to PERMCO and Date |
+| `SFZ_NAM-PERMNO_DT` | SFZ Names to PERMNO and Date |
+| `ShareConversion` | Share Conversion Changes |
+| `ShrCd` | Share Code Convention Change |
+| `ShrFlg` | Share Flag Convention Change |
+| `SICCD` | SICCD Convention Change |
+| `StatFlg` | Statistic Flag Convention Change |
+| `Ticker` | Ticker Convention Change |
+| `YYYYtoYYYYQ` | YYYYMM to YYYYQ |
+| `YYYYtoYYYYQPlus1Port` | YYYYMM to YYYYQ and Plus One Port |
+
+## `PC` — Price Flag - Multiple - See Definition
+
+| Value | Description |
+|-------|-------------|
+| `BA` | Bid Ask Average |
+| `DA` | Delisting Amount (no Delisting Price) |
+| `DM` | Delisting Price/Amount Missing |
+| `DP` | Delisting Price |
+| `GP` | Gap - more than 10 periods |
+| `MI` | Missing - Prior to BegDt |
+| `MP` | Missing Price |
+| `NA` | Not Applicable |
+| `NS` | New Security |
+| `NT` | Not Tracked |
+| `TR` | Closing Trade Price |
+
+## `PF` — Calendar Period Flag
+
+| Value | Description |
+|-------|-------------|
+| `COMPLETE` | Complete Period |
+| `FUTURE` | Future Period |
+| `PARTIAL` | Partial Period |
+| `START` | Start of CRSP Data |
+
+## `PM` — Distribution Payment Method Type
+
+| Value | Description |
+|-------|-------------|
+| `FX` | Foreign Currency |
+| `N/A` | Not Applicable |
+| `OP` | Other Property |
+| `OS` | Other Security |
+| `SS` | Same Security |
+| `UN` | Unspecified |
+| `UNIT` | Units Including Same Issue of Common Stock |
+| `USD` | USD |
+| `X` | Unknown |
+
+## `PP` — Frequency Type
+
+| Value | Description |
+|-------|-------------|
+| `A` | Annually |
+| `N/A` | Not Applicable |
+| `Q` | Quarterly |
+
+## `PT` — Delisting Payment Summary Type
+
+| Value | Description |
+|-------|-------------|
+| `CASH` | Cash |
+| `CNC` | Common and Non-Common |
+| `COP` | Cash and Other Property |
+| `CSHN` | Cash and Non-Common |
+| `CST` | Cash and Stock |
+| `CUS` | Cash and Untracked Stock |
+| `DW` | Declared Worthless |
+| `MAF` | Merger Attempt Failed |
+| `MMI` | Missing Information |
+| `MUT` | Mutual Funds |
+| `N/A` | Not Applicable |
+| `NCOM` | Non-Common |
+| `NCOP` | Non-Common and Other Property |
+| `OP` | Other Property |
+| `PRCF` | Price Final |
+| `SNC` | Stock and Non-Common |
+| `SOP` | Stock and Other Property |
+| `STK` | Stock |
+| `UMAP` | Unmapped |
+| `UNAV` | Unavailable |
+| `USNC` | Untracked Stock and Non-Common |
+| `USOP` | Untracked Stock and Other Property |
+| `USTK` | Untracked Stock |
+
+## `RD` — Daily Return Duration Flag
+
+| Value | Description |
+|-------|-------------|
+| `D1` | 1 Trading Day and 1 Calendar Day |
+| `D2` | 1 Trading Day and 2 Calendar Days |
+| `D3` | 1 Trading Day and 3 Calendar Days |
+| `D4` | 1 Trading Day and 4 Calendar Days |
+| `DD` | Other Daily Delisting Return Duration |
+| `DU` | 1 Trading Day & 5 or more Calendar Days |
+| `MR` | Missing Return |
+| `P1` | Multi-period 2 Trading Days or Months |
+| `P2` | Multi-period 3 Trading Days or Months |
+| `P3` | Multi-period 4 Trading Days or Months |
+| `P4` | Multi-period 5 Trading Days or Months |
+| `P5` | Multi-period 6 Trading Days or Months |
+| `P6` | Multi-period 7 Trading Days or Months |
+| `P7` | Multi-period 8 Trading Days or Months |
+| `P8` | Multi-period 9 Trading Days or Months |
+| `P9` | Multi-period 10 Trading Days or Months |
+
+## `RM` — Return Missing Flag - Daily and Delisting
+
+| Value | Description |
+|-------|-------------|
+| `DG` | Delisting Price GT 10 periods from delisting date |
+| `DM` | Delisting Price/Amount Missing |
+| `DP` | Delisting Pending |
+| `GP` | Gap Between Prices Too Large |
+| `MP` | Missing Price |
+| `MV` | Missing Corporate Action Value |
+| `NA` | Not Applicable |
+| `NS` | New Security |
+| `NT` | Not Tracked |
+| `RA` | Return after Not Tracked period |
+
+## `S2` — Security Sub-Type
+
+| Value | Description |
+|-------|-------------|
+| `ATR` | Americus Trust |
+| `CEF` | Closed End Fund |
+| `COM` | Common |
+| `ETF` | Exchange Traded Fund |
+| `ETV` | Exchange Traded Vehicle |
+| `UNK` | Unknown or Unspecified |
+
+## `S3` — Security Type
+
+| Value | Description |
+|-------|-------------|
+| `DERV` | Derivative |
+| `EQTY` | Equity |
+| `FUND` | Fund |
+| `N/A` | Not Applicable |
+
+## `S4` — Share Type
+
+| Value | Description |
+|-------|-------------|
+| `AD` | American Depositary Receipt |
+| `CE` | Certificate |
+| `N/A` | Not Applicable |
+| `NS` | No special share type specified |
+| `SB` | Shares of Beneficial Interest |
+| `UG` | Units General |
+
+## `SD` — Share Change Source Type
+
+| Value | Description |
+|-------|-------------|
+| `EVS` | Split/Dividend Event |
+| `NC` | Name Change |
+| `OBS` | Observation From Source |
+
+## `SH` — Share Class
+
+| Value | Description |
+|-------|-------------|
+| `1` | Class 1 |
+| `A` | Class A |
+| `B` | Class B |
+| `C` | Class C |
+| `D` | Class D |
+| `E` | Class E |
+| `G` | Class G |
+| `H` | Class H |
+| `L` | Class L |
+| `N` | Class N |
+| `NCS` | No Class Specified |
+| `P` | Class P |
+| `S` | Class S |
+| `T` | Class T |
+| `U` | Class U |
+| `V` | Class V |
+| `Z` | Class Z |
+
+## `SY` — Statistic Assignment Type
+
+| Value | Description |
+|-------|-------------|
+| `FWD` | Forward statistics can be used for assignments |
+
+## `TG` — Index Frequency
+
+| Value | Description |
+|-------|-------------|
+| `BTH` | Both |
+| `DLY` | Daily |
+| `MTH` | Monthly |
+
+## `TS` — Trading Status
+
+| Value | Description |
+|-------|-------------|
+| `A` | Active |
+| `D` | Delisted |
+| `H` | Halted |
+| `S` | Suspended |
+| `X` | Unknown or Unavailable |
+
+## `TX` — Distribution Tax Status Type
+
+| Value | Description |
+|-------|-------------|
+| `C` | Capital Gains |
+| `D` | Dividend |
+| `F` | Full |
+| `G` | Gain/Loss |
+| `N` | Non-Taxable |
+| `N/A` | Not Applicable |
+| `P` | Plan |
+| `R` | Return of Capital |
+| `T` | Tax Receipt |
+| `U` | Unspecified |
+| `X` | Unknown |
+
+## `UC` — UES Industry Type
+
+| Value | Description |
+|-------|-------------|
+| `CONDIS` | Consumer Discretionary |
+| `CONSTAP` | Consumer Staples |
+| `ENERGY` | Energy |
+| `FINL` | Financials |
+| `HEALTH` | Healthcare |
+| `INDL` | Industrials |
+| `MATL` | Materials |
+| `MEDCOMM` | Media & Communications |
+| `NOAVAIL` | Not Available |
+| `QUASGOV` | Quasi Government |
+| `REIT` | Real Estate & REITS |
+| `SOVRN` | Sovereign |
+| `TECH` | Technology |
+| `TRUST` | Trust |
+| `UTIL` | Utilities |
+
+## `UD` — Underlying Data for Index Family
+
+| Value | Description |
+|-------|-------------|
+| `MBR` | Security and membership  available |
+| `NONE` | No underlying data available |
+| `REB` | Sec, membership, weight, and rebal data available |
+| `SEC` | Only security data available |
+| `WGT` | Sec, mbr, weight data avail; rebal data not needed |
+
+## `UT` — Universe Type
+
+| Value | Description |
+|-------|-------------|
+| `CAP` | Cap-Based |
+| `HLU` | Historic (Legacy) Universe |
+| `N/A` | Not applicable-Security Information not Available |
+| `NORULE` | Security Information available-no Rule restriction |
+
+## `YN` — Yes No Flag
+
+| Value | Description |
+|-------|-------------|
+| `N` | No |
+| `Y` | Yes |
+
+## `YX` — Yes No Unavailable Flag
+
+| Value | Description |
+|-------|-------------|
+| `N` | No |
+| `X` | Unavailable |
+| `Y` | Yes |
+

--- a/skills/crsp-v2/references/indexes.md
+++ b/skills/crsp-v2/references/indexes.md
@@ -1,0 +1,196 @@
+# CIZ Indexes: INDNO, INDFAM, and Statistics
+
+In legacy SIZ, indexes were reached by name (`vwretd`, `CAP1`) and grouped informally
+(Stock File Indexes, Cap-Based Portfolios). In CIZ **every index is a number** (`INDNO`)
+belonging to a numbered **family** (`INDFAM`). Nothing is addressable by name any more.
+
+## Contents
+
+- [The `_ind` Suffix](#the-_ind-suffix)
+- [Family and Series Tables](#family-and-series-tables)
+- [The +400 Monthly Renumbering](#the-400-monthly-renumbering)
+- [INDNOs You Will Actually Use](#indnos-you-will-actually-use)
+- [The Three S&P 500 Series](#the-three-sp-500-series)
+- [Membership](#membership)
+- [Stock-Level Statistics and Deciles](#stock-level-statistics-and-deciles)
+- [Rebalancing and Breakpoints](#rebalancing-and-breakpoints)
+
+## The `_ind` Suffix
+
+Index tables appear in both the Stock and Index products under the same base name. The
+Index-database copies carry an `_ind` suffix and far more data.
+
+Verified 2026-07-26: `crsp.indseriesinfohdr` (stock product) has **4** series;
+`crsp.indseriesinfohdr_ind` (index product) has **274**.
+
+The 4 in the stock-only product are the ones CRSP passes through for convenience:
+
+| INDNO | INDFAM | Name | Freq | Range |
+|-------|--------|------|------|-------|
+| 1000200 | 1100200 | CRSP NYSE/NYSEMKT/Nasdaq/Arca Value-Weighted Market Index | BTH | 1925-12-31 → 2025-12-31 |
+| 1000201 | 1100200 | CRSP NYSE/NYSEMKT/Nasdaq/Arca Equal-Weighted Market Index | BTH | 1925-12-31 → 2025-12-31 |
+| 1000502 | 1100502 | S&P 500 Composite | BTH | 1962-07-02 → 2025-12-31 |
+| 1000503 | 1100503 | Nasdaq Composite | BTH | 1972-12-14 → 2025-12-31 |
+
+If a query against `crsp.indseriesinfohdr` returns nothing for the index you want, you
+need the `_ind` table and an Index-database subscription.
+
+Index values in the stock products are calculated on CRSP's legacy system and passed
+through, so they may not match precisely what you would get by recalculating from the
+CIZ files.
+
+## Family and Series Tables
+
+`crsp.indfamilyinfohdr_ind` — one row per family. Tells you the weighting scheme, the
+base level/date, the frequency, and the **INDNO range** of its members:
+
+```sql
+SELECT indfam, indfamnm, baselvl, basedt, weighttype, freqavail,
+       indfamsize, indfamfirstindno, indfamlastindno
+FROM crsp.indfamilyinfohdr_ind ORDER BY indfam;
+```
+
+`crsp.indseriesinfohdr_ind` — one row per index:
+
+```sql
+SELECT indno, indfam, indfamtype, indnm, indbegdt, indenddt,
+       baselvl, basedt, freqavail, weighttype, cntvaltype, portnum
+FROM crsp.indseriesinfohdr_ind WHERE indfam = 1100012 ORDER BY indno;
+```
+
+`freqavail`: `DLY` daily only, `MTH` monthly only, `BTH` both. `weighttype`: `EV` equal
+and value weighted, `MC` market-cap weighted, `X` not applicable (published series).
+Four columns that used to exist only in the PDF documentation — `IndFamilyType`,
+`FreqAvail`, `WeightType`, `CntValType` — are now data.
+
+Time series live in `crsp.inddlyseriesdata[_ind]` and `crsp.indmthseriesdata[_ind]`,
+keyed on `indno` + period.
+
+## The +400 Monthly Renumbering
+
+**The single most common CIZ index mistake.** In legacy SIZ, daily and monthly versions
+of an index shared an `INDNO`. In CIZ, CRSP renumbered the monthly series:
+
+> Monthly `INDFAM` and `INDNO` = daily value **+ 400**.
+
+Example — NYSE Market Capitalization Deciles:
+
+| | INDFAM | Members | Freq |
+|---|--------|---------|------|
+| Daily | 1100012 | 1000002 – 1000011 | `DLY` |
+| Monthly | 1100412 | 1000402 – 1000411 | `MTH` |
+
+So `SELECT * FROM crsp.indmthseriesdata_ind WHERE indno = 1000002` returns **zero rows**,
+silently — the monthly decile 1 series is `1000402`.
+
+Check `freqavail` before assuming a series exists at your frequency. Families with
+`freqavail = 'BTH'` (like the two CRSP market indexes and the S&P 500 composite) keep one
+INDNO across both frequencies; families with `DLY` and `MTH` variants are the ones that
+were split and renumbered.
+
+## INDNOs You Will Actually Use
+
+| INDNO | INDFAM | Index | Replaces |
+|-------|--------|-------|----------|
+| 1000000 | 1100000 | CRSP NYSE Value-Weighted Market Index | |
+| 1000001 | 1100000 | CRSP NYSE Equal-Weighted Market Index | |
+| 1000002 – 1000011 | 1100012 | NYSE Market Cap Deciles 1–10 (daily) | Cap-based portfolios |
+| 1000402 – 1000411 | 1100412 | NYSE Market Cap Deciles 1–10 (monthly) | same, monthly |
+| 1000102 – 1000111 | 1100112 | NYSE/NYSE American Beta Deciles 1–10 | Risk-based deciles |
+| 1000200 | 1100200 | CRSP NYSE/NYSEMKT/Nasdaq/Arca Value-Weighted | `VWRETD` (`DlyTotRet`), `VWRETX` (`DlyPrcRet`) |
+| 1000201 | 1100200 | CRSP NYSE/NYSEMKT/Nasdaq/Arca Equal-Weighted | `EWRETD`, `EWRETX` |
+| 1000500 | 1100500 | CRSP Value-Weighted Index of the S&P 500 Universe | **membership source** |
+| 1000502 | 1100502 | S&P 500 Composite (published) | `SPINDX`, `SPRTRN` (`DlyPrcRet`) |
+| 1000503 | 1100503 | Nasdaq Composite (published) | |
+| 1000510 | 1100510 | CRSP Value-Weighted Portfolios of the S&P 500 Universe | |
+| 1000700 | 1100700 | CRSP 30-Year Bond Returns (monthly only) | |
+
+CIZ also added the investable CRSP Market Indexes and the CRSP ISS ESG Indexes, which
+have no SIZ counterpart at all — they contribute the bulk of the extra rows in
+`IndDlySeriesData` and `StkIndMembership`.
+
+## The Three S&P 500 Series
+
+CRSP ships three distinct things that all say "S&P 500". Picking the wrong one is a
+silent methodology error.
+
+1. **`INDFAM 1100502` / `INDNO 1000502` — S&P 500 Composite.** The official published
+   index and its return. `weighttype = 'X'`. This is where `SPINDX` and `SPRTRN` come
+   from. **It has no membership rows** — `stkindmembership_ind` for `indno = 1000502`
+   returns 0.
+
+2. **`INDFAM 1100500` / `INDNO 1000500`, `1000501` — CRSP Index of the S&P 500
+   Universe.** CRSP's own value- and equal-weighted index computed over the S&P 500
+   constituent universe. **This is the membership source** (1,956 distinct PERMNOs).
+   Uses membership as of the **end of the current period**.
+
+3. **`INDFAM 1100510` / `INDNO 1000510`, `1000511` — CRSP Portfolio of the S&P 500
+   Universe.** Identical construction except it uses membership as of the end of the
+   **previous** period — i.e. a genuinely tradable portfolio. Use this one for anything
+   claiming implementability.
+
+## Membership
+
+```sql
+SELECT permno, indno, mbrstartdt, mbrenddt, mbrflg, indfam
+FROM crsp.stkindmembership_ind
+WHERE indno = 1000500;
+```
+
+Output shape (verified):
+
+```
+ permno |  indno  | mbrstartdt |  mbrenddt  | mbrflg | indfam
+--------+---------+------------+------------+--------+---------
+  10006 | 1000500 | 1957-03-01 | 1984-07-18 | NORM   | 1100500
+  10030 | 1000500 | 1957-03-01 | 1969-01-08 | NORM   | 1100500
+  10049 | 1000500 | 1925-12-31 | 1932-10-01 | NORM   | 1100500
+```
+
+Join point-in-time with `BETWEEN mbrstartdt AND mbrenddt`. `INDNO` is the right key;
+`INDFAM` is only for comparing against legacy `KEYSET`.
+
+`crsp.msp500list_v2` / `crsp.dsp500list_v2` are WRDS convenience copies filtered to
+`indno = 1000500`, in the same column shape.
+
+## Stock-Level Statistics and Deciles
+
+CRSP pre-computes per-security statistics (beta, standard deviation, capitalization) and
+the decile assignment that follows from them. In CIZ these live in
+`crsp.stkindsecuritystatistics_ind`, keyed by `permno, indfam, yyyy`.
+
+```sql
+SELECT permno, indfam, yyyy, secstattype, secstat, secstatflg,
+       secassignyyyy, secassignindno, secassignportnum
+FROM crsp.stkindsecuritystatistics_ind
+WHERE permno = 12490 AND indfam = 1100112;   -- IBM, beta deciles
+```
+
+Read it as: the statistic measured in year `yyyy` determines the portfolio assignment
+`secassignportnum` (and index `secassignindno`) for year `secassignyyyy`. IBM's 2022
+beta of 0.720082 (`secstattype = 'TOB'`) put it in decile 7 for 2023, i.e. index
+`1000108`.
+
+`crsp.stkindissuerstatistics_ind` is the issuer-level twin: keyed `permco, indfam, yyyyq`
+with `iss*` columns, quarterly rather than annual. It exists because issuer cap-based
+statistics used to be duplicated across every PERMNO of a PERMCO in SIZ; CIZ collapses
+them to one issuer row.
+
+## Rebalancing and Breakpoints
+
+`crsp.indsecrebalancesummary_ind` (annual, security-based: capitalization, standard
+deviation, beta indexes) and `crsp.indissrebalancesummary_ind` (quarterly, issuer
+cap-based) carry the decile breakpoints and the add/drop counts per rebalancing.
+
+```sql
+SELECT indno, yyyy, secassignstartdt, secassignenddt, secstattype,
+       seclowbreakpoint, sechighbreakpoint, secminstat, secmaxstat,
+       secminstatpermno, secmaxstatpermno,
+       secsecurityallcnt, secsecuritydropcnt, secsecurityaddcnt
+FROM crsp.indsecrebalancesummary_ind
+WHERE indfam = 1100012 AND yyyy = 2024 ORDER BY portnum;
+```
+
+`SecLowBreakpoint` / `SecHighBreakpoint` (and the `Iss*` equivalents) are new in CIZ —
+SIZ only gave you the min and max realised statistic, not the breakpoint itself. The
+add/drop/all counts are also new; legacy `RUSDCNT` has no direct equivalent.

--- a/skills/crsp-v2/references/known-differences.md
+++ b/skills/crsp-v2/references/known-differences.md
@@ -1,0 +1,182 @@
+# Known SIZ vs CIZ Value Differences
+
+WRDS compared every data item between the legacy SIZ and new CIZ formats. **The vast
+majority match exactly.** The discrepancies below are documented, investigated, and in
+most cases confirmed by CRSP as intentional convention changes — they are not bugs to
+work around, and they are not yours to "fix".
+
+Source: WRDS *SIZ to CIZ Transition FAQ — Stock*, WRDS *Recreate Legacy MSE Style
+Tables*, CRSP *Cross-Reference Guide* and *Executive Summary of Differences*.
+
+## Contents
+
+- [Monthly Returns — the big one](#monthly-returns--the-big-one)
+- [Delisting Prices and Amounts](#delisting-prices-and-amounts)
+- [Shares Outstanding](#shares-outstanding)
+- [Market Capitalization](#market-capitalization)
+- [SIC Code](#sic-code)
+- [Distribution Factor to Adjust Price](#distribution-factor-to-adjust-price)
+- [Distribution Dividend Amount Missingness](#distribution-dividend-amount-missingness)
+- [Monthly Volume](#monthly-volume)
+- [Row-Count Differences That Are Not Value Differences](#row-count-differences-that-are-not-value-differences)
+- [Duplicate Rows in WRDS Query Tables](#duplicate-rows-in-wrds-query-tables)
+
+## Monthly Returns — the big one
+
+`MthRet` and legacy `RET` (from `crsp.msf`) are **different estimators of different
+quantities**, not the same number under a new name.
+
+| | Legacy `RET` | CIZ `MthRet` |
+|---|---|---|
+| Basis | Month-end price to month-end price | Compound of daily returns within the month |
+| Dividend reinvestment | At month-end | On the ex-date |
+| Missing month-end price | Loses **two** consecutive months of returns | Unaffected |
+| Partial first month | Lost (new securities, all NASDAQ at 1972-12-14) | Captured |
+| Delisting proceeds | Assumed received at delisting payment date | Compounded through the daily series |
+
+Magnitude of the divergence, as measured by WRDS across the full panel:
+
+| Absolute return difference | Stock-months |
+|----------------------------|--------------|
+| > 100% | 90 |
+| > 50% | 355 |
+| > 5% | 3,479 |
+
+The largest cases are concentrated in (1) months with trading gaps, where the SIZ number
+is contaminated by stale prices, and (2) months with distributions, where the
+reinvestment-timing assumption bites. Example: PERMNO 15017, December 2017 —
+`MthRet = 111.79%` vs legacy `RET = 769.57%`, a difference of 6.58. `MthRetFlg = 'GP'`
+flags the gap.
+
+The same methodology change applies to **delisting returns** (`DelRet`), where CRSP
+warns the divergence can be larger still.
+
+**Implication for replication:** a paper whose monthly returns came from SIZ will not
+reproduce exactly on CIZ, and no amount of coding fixes that. Say so in the write-up
+rather than tuning the query until the numbers agree. WRDS published a separate note,
+*Comment on CRSP CIZ Monthly Return*, for the full analysis.
+
+Daily returns, by contrast, show negligible differences between the formats.
+
+## Delisting Prices and Amounts
+
+Two separate issues, often mistaken for one bug (~20,000 apparently mismatched records).
+
+**1. You are comparing the wrong column.** Legacy `SFZ_DEL.DLPRC` contains the price on
+`NEXTDT`. In CIZ, `DelDtPrc` is the price on the *delisting date* and `DelNextPrc` is the
+price on `DelNextDt`. `DLPRC` maps to **`DelNextPrc`**.
+
+**2. Convention change on the amount.** Legacy `DLAMT` contained either post-delisting
+distribution amounts *or* the `NEXTDT` price. CIZ `DelDivAmt` contains **only**
+post-delisting distribution amounts, and is zero when there are none — even when
+`DelNextPrc` is non-missing.
+
+## Shares Outstanding
+
+About 70 PERMNOs differ from legacy `SHROUT`, always by **exactly 1** (thousand shares).
+
+Cause: single-precision (32-bit) vs double-precision (64-bit) storage of `FacShr`,
+combined with rounding to the nearest integer. CRSP's worked example: a prior `ShrOut` of
+66,940 adjusted by `FACSHR = -0.9750` gives 66,940 × (1 − 0.9750) = 1673.5 → rounds to
+**1674** in CIZ. In the legacy single-precision system, −0.9750 was stored as
+−0.97500002384, giving 1673.4984 → rounds to **1673**.
+
+Separately, in the rebuilt `MseShares`-style comparison, 88 records show genuinely
+different `ShrOut` values (mean difference 1.23%, median 0.07%) — same rounding family.
+
+CRSP calls this known and accepted. It is not correctable and not material.
+
+## Market Capitalization
+
+50+ PERMNOs show `DlyCap ≠ legacy TCAP`. Three distinct causes, all accepted:
+
+1. **Share rounding propagation.** A one-thousand-share difference times the price gives
+   a cap difference equal to the price. PERMNO 88007 on 1994-09-29: `DlyCap = 22,224` vs
+   `TCAP = 22,212`, price $12.
+2. **Improved bid/ask-average precision** for quotes in 32nds and 64ths, multiplied by
+   large share counts.
+3. **Floating-point limits.** Caps range from 1.75 to ~3×10⁹; double precision carries
+   ~14 significant digits, so differences up to ~0.0001 are structural.
+
+This is one more reason to read `dlycap` off the row rather than computing
+`dlyprc × shrout` — your recomputation will not match CRSP's and the difference will
+look like a data error.
+
+## SIC Code
+
+100+ PERMNOs have `SICCD = 0` in `StkSecurityInfoHdr` where legacy `HSICCD` had a valid
+code.
+
+Definitional change: legacy `HSICCD` was "the last **non-zero** SICCD"; CIZ `SICCD` in
+the header is "the SICCD from the **last active name record**", zero or not. PERMNO 10859
+carried 5031 on the name record valid 1972-12-14 → 1973-05-03, but its final active name
+record (1973-05-04 → 1978-10-03) has SICCD 0, so the header shows 0.
+
+If you need the legacy behaviour, take the last non-zero `siccd` from
+`stksecurityinfohist` yourself — and note that you did.
+
+## Distribution Factor to Adjust Price
+
+Seven records where CIZ `DisFacPr = 0` and legacy `FACPR` was non-zero (e.g. PERMNO 40388
+on 1997-05-01: legacy 40.70%, CIZ 0.00%).
+
+Convention change: the price factor for spin-offs is the dividend amount divided by the
+ex-date price. For distributions **after delisting** the ex-date price is unknown, so CIZ
+sets `DisFacPr` to zero (no impact). CRSP indicated it will likely edit the seven legacy
+records to match.
+
+## Distribution Dividend Amount Missingness
+
+Legacy `divamt` was **never missing** — no amount meant 0. CIZ `DisDivAmt` is **NULL**
+for distribution types that have no cash amount.
+
+Concrete case: legacy `DISTCD = 5523` had `divamt = 0` throughout. The CIZ equivalent
+(`DisType = 'FRS'`, `DisPaymentType = 'SS'`, `DisDetailType = 'STKSPL'`) has
+`DisDivAmt` missing.
+
+Consequence: `SUM(disdivamt)`, `AVG(disdivamt)`, and any `WHERE disdivamt = 0` behave
+differently than the legacy code they were ported from. Use
+`coalesce(disdivamt, 0)` when you need legacy semantics.
+
+## Monthly Volume
+
+Large `MthVol` vs legacy `VOL` gaps for some securities — e.g. Citigroup (PERMNO 70519)
+in 2009-08, 2009-12, and 2010-12, and PERMNO 17854 in 2021-01.
+
+This one is **not** a CIZ change. CRSP corrected the monthly volume problem in SIZ
+several years ago; WRDS never loaded that SIZ correction. So the CIZ values are right and
+the WRDS-hosted SIZ values are the stale ones.
+
+Note also the unit change when comparing: legacy `VOL` is quoted in units of 100.
+
+## Row-Count Differences That Are Not Value Differences
+
+- **`StkDelists` has far fewer rows than `SFZ_DEL`.** Legacy carried a row for every
+  security, including active ones (`DLSTCD = 100`, `DLSTDT` artificially set to the most
+  recent period end). CIZ includes only genuinely delisted securities. PERMNO 14593
+  (Apple) has no `StkDelists` row. An inner join to `stkdelists` is now an implicit
+  "delisted only" filter.
+
+- **`StkSecurityInfoHist` has more rows than `msenames`.** Two causes: CIZ emits a
+  separate one-day record for the delisting event (`TradingStatusFlg = 'D'`), and it
+  splits intervals on `ExchangeTier` changes that SIZ ignored. PERMNO 10001: 14 CIZ rows
+  vs 10 legacy rows.
+
+- **`StkShares` splits intervals more finely than `mseshares`.** PERMNO 10001's single
+  legacy record 1986-06-30 → 1986-09-29 (`SHROUT = 985`) becomes two CIZ records
+  (1986-06-30 → 1986-09-01 with `ShrSource = 'OBS'`, and 1986-09-02 → 1986-09-29 with
+  `ShrSource = 'NC'`), both with `ShrOut = 985`. Comparing on exact date ranges produces
+  a *false* mismatch.
+
+## Duplicate Rows in WRDS Query Tables
+
+The WRDS-built Daily and Monthly Stock File queries (and `dsf_v2`/`msf_v2` lineage) join
+stock data to shares, distributions, and index data in one table. When a security has
+**more than one distribution in a period**, the join duplicates the stock row.
+
+Documented example: Apple, August 2020 — a cash dividend with ex-date 2020-08-07 and a
+4:1 split with ex-date 2020-08-31. The August 2020 monthly row appears twice.
+
+This behaviour existed in the legacy WRDS queries too. If duplicates matter, query
+`crsp.stkdlysecuritydata` / `crsp.stkmthsecuritydata` directly — they have no duplicates
+— and join `crsp.stkdistributions` yourself with an explicit aggregation.

--- a/skills/crsp-v2/references/queries.md
+++ b/skills/crsp-v2/references/queries.md
@@ -2,7 +2,7 @@
 
 Every query in this file was executed against `wrds-pgdata.wharton.upenn.edu:9737` on
 2026-07-26. Where output is shown, it is real output. Connection setup, `.pgpass`, and
-the WRDS Cloud / SGE rules live in `skills/wrds/SKILL.md`.
+the WRDS Cloud / SGE rules live in `${CLAUDE_SKILL_DIR}/../../skills/wrds/SKILL.md`.
 
 ## Contents
 
@@ -398,4 +398,4 @@ tables.
 - Filter on `dlycaldt`/`mthcaldt` ranges before joining. Push the universe predicate into
   the same `WHERE` clause rather than filtering in pandas after the pull.
 - Bulk pulls belong on the WRDS Cloud via `qsub`, never on the login node. See
-  `skills/wrds/SKILL.md`.
+  `${CLAUDE_SKILL_DIR}/../../skills/wrds/SKILL.md`.

--- a/skills/crsp-v2/references/queries.md
+++ b/skills/crsp-v2/references/queries.md
@@ -1,0 +1,401 @@
+# CIZ Query Recipes
+
+Every query in this file was executed against `wrds-pgdata.wharton.upenn.edu:9737` on
+2026-07-26. Where output is shown, it is real output. Connection setup, `.pgpass`, and
+the WRDS Cloud / SGE rules live in `skills/wrds/SKILL.md`.
+
+## Contents
+
+- [Universe: Common Stock](#universe-common-stock)
+- [Daily Panel](#daily-panel)
+- [Monthly Panel](#monthly-panel)
+- [Market Capitalization and Weights](#market-capitalization-and-weights)
+- [Delistings](#delistings)
+- [Cumulative Adjustment Factors](#cumulative-adjustment-factors)
+- [Distributions and Dividends](#distributions-and-dividends)
+- [Market and Benchmark Index Returns](#market-and-benchmark-index-returns)
+- [S&P 500 Membership](#sp-500-membership)
+- [Linking to Compustat (CCM)](#linking-to-compustat-ccm)
+- [Looking Up Flags and Columns](#looking-up-flags-and-columns)
+- [Rebuilding Legacy MSE-Style Tables](#rebuilding-legacy-mse-style-tables)
+- [Performance Notes](#performance-notes)
+
+## Universe: Common Stock
+
+The `SHRCD IN (10,11)` + `EXCHCD IN (1,2,3)` equivalent. All five share/issuer columns
+are required; see the Iron Law in `SKILL.md`.
+
+```sql
+SELECT permno, secinfostartdt, secinfoenddt, ticker, issuernm
+FROM crsp.stksecurityinfohist
+WHERE sharetype       = 'NS'
+  AND securitytype    = 'EQTY'
+  AND securitysubtype = 'COM'
+  AND usincflg        = 'Y'
+  AND issuertype      IN ('ACOR','CORP')
+  AND primaryexch     IN ('N','A','Q')
+  AND conditionaltype = 'RW'
+  AND tradingstatusflg = 'A';
+```
+
+Dropping `conditionaltype`/`tradingstatusflg` widens the sample to include halted
+(`tradingstatusflg='H'`, legacy `EXCHCD=-2`) and suspended (`'S'`, legacy `EXCHCD=-1`)
+records. That is sometimes what you want — decide, don't default.
+
+## Daily Panel
+
+Verified: returns 84,245 rows for January 2024.
+
+```sql
+SELECT d.permno, d.dlycaldt, d.dlyprc, d.dlyprcflg,
+       d.dlyret, d.dlyretx, d.dlycap, d.dlyvol
+FROM crsp.stkdlysecurityprimarydata d
+JOIN crsp.stksecurityinfohist h
+  ON  h.permno = d.permno
+ AND  d.dlycaldt BETWEEN h.secinfostartdt AND h.secinfoenddt
+WHERE d.dlycaldt BETWEEN %(start)s AND %(end)s
+  AND h.sharetype = 'NS' AND h.securitytype = 'EQTY' AND h.securitysubtype = 'COM'
+  AND h.usincflg = 'Y'   AND h.issuertype IN ('ACOR','CORP')
+  AND h.primaryexch IN ('N','A','Q')
+  AND h.conditionaltype = 'RW' AND h.tradingstatusflg = 'A';
+```
+
+The `BETWEEN secinfostartdt AND secinfoenddt` predicate is what makes the classification
+point-in-time. Without it you apply a security's final classification to its whole
+history and import survivorship into the sample.
+
+Single-table alternative — `crsp.dsf_v2` already carries the universe columns, `shrout`,
+and the cumulative factors, so no join is needed:
+
+```sql
+SELECT permno, dlycaldt, dlyprc, dlyret, dlycap, dlyvol, shrout, dlycumfacpr
+FROM crsp.dsf_v2
+WHERE dlycaldt BETWEEN %(start)s AND %(end)s
+  AND sharetype = 'NS' AND securitytype = 'EQTY' AND securitysubtype = 'COM'
+  AND usincflg = 'Y' AND issuertype IN ('ACOR','CORP')
+  AND primaryexch IN ('N','A','Q');
+```
+
+Use `crsp.stkdlysecuritydata` (32 columns) instead of the primary file only when you need
+quotes, OHLC, previous-period values, or the denormalized dividend amounts — it is ~3×
+the size.
+
+## Monthly Panel
+
+No join required: `stkmthsecuritydata` carries identifiers and the universe columns
+as of `mthprcdt`.
+
+```sql
+SELECT permno, mthcaldt, mthprc, mthret, mthretx, mthcap, mthvol,
+       ticker, issuernm, mthcompflg
+FROM crsp.stkmthsecuritydata
+WHERE mthcaldt BETWEEN %(start)s AND %(end)s
+  AND sharetype = 'NS' AND securitytype = 'EQTY' AND securitysubtype = 'COM'
+  AND usincflg = 'Y' AND issuertype IN ('ACOR','CORP')
+  AND primaryexch IN ('N','A','Q');
+```
+
+`mthcompflg` / `mthcompsubflg` report whether the underlying daily data was complete for
+the month. Same idea at quarterly (`qtrcompflg`) and annual (`anncompflg`) frequency —
+the annual file exists precisely so studies can avoid scanning the ~100M-row daily file.
+
+## Market Capitalization and Weights
+
+Read it, do not compute it. `dlycap` / `mthcap` are CRSP's own capitalization in
+**$ thousands**.
+
+For value-weighted portfolio returns, use the **previous** period's cap — already on the
+row, no `LAG()`:
+
+```sql
+SELECT dlycaldt,
+       sum(dlyprevcap * dlyret) / nullif(sum(dlyprevcap), 0) AS vw_ret,
+       avg(dlyret)                                           AS ew_ret,
+       count(*)                                              AS n
+FROM crsp.stkdlysecuritydata
+WHERE dlycaldt BETWEEN %(start)s AND %(end)s
+GROUP BY dlycaldt ORDER BY dlycaldt;
+```
+
+`dlyprevcap` respects trading gaps and delisting conventions in a way a self-join on the
+prior calendar day does not. `dlyprevprc` and `dlyprevdt` are the matching price and
+date.
+
+## Delistings
+
+**The delisting return is already in `dlyret`/`mthret`.** Verified for PERMNO 10002,
+delisted 2013-02-15:
+
+```sql
+SELECT permno, dlycaldt, dlyprc, dlyprcflg, dlyret, dlydelflg
+FROM crsp.stkdlysecurityprimarydata
+WHERE permno = 10002 AND dlycaldt BETWEEN '2013-02-14' AND '2013-02-20'
+ORDER BY dlycaldt;
+```
+
+```
+ permno |  dlycaldt  |  dlyprc  | dlyprcflg |  dlyret   | dlydelflg
+--------+------------+----------+-----------+-----------+-----------
+  10002 | 2013-02-14 | 2.920000 | TR        | -0.010170 | N
+  10002 | 2013-02-15 | 2.980000 | TR        |  0.020548 | N
+  10002 | 2013-02-19 | 0.000000 | DA        |  0.010906 | Y
+```
+
+The final row is the delisting return (`dlyprcflg = 'DA'`, `dlydelflg = 'Y'`). Do not
+merge `stkdelists` and add `delret`.
+
+Use `crsp.stkdelists` for the *reason*:
+
+```sql
+SELECT permno, delistingdt, delactiontype, delstatustype, delreasontype,
+       delpaymenttype, delpermno, delpermco, delnextdt, delnextprc, deldivamt
+FROM crsp.stkdelists
+WHERE delistingdt BETWEEN %(start)s AND %(end)s;
+```
+
+Only delisted securities appear here — an inner join is an implicit "delisted only"
+filter. Legacy `DLPRC` corresponds to `delnextprc`, **not** `deldtprc`.
+
+## Cumulative Adjustment Factors
+
+`CFACPR` / `CFACSHR` moved to their own tables. Verified for Apple's 4:1 split on
+2020-08-31:
+
+```sql
+SELECT permno, dlycaldt, dlyshrout, dlycumfacpr, dlycumfacshr
+FROM crsp.stkdlycumulativeadjfactor
+WHERE permno = 14593 AND dlycaldt BETWEEN '2020-08-28' AND '2020-09-02'
+ORDER BY dlycaldt;
+```
+
+```
+ permno |  dlycaldt  | dlyshrout |  dlycumfacpr   |  dlycumfacshr
+--------+------------+-----------+----------------+----------------
+  14593 | 2020-08-28 |   4275634 | 4.000000000000 | 4.000000000000
+  14593 | 2020-08-31 |  17102536 | 1.000000000000 | 1.000000000000
+```
+
+`crsp.stkmthcumulativeadjfactor` is the monthly twin. `crsp.dsf_v2` / `msf_v2` carry
+these columns inline, so joining is only needed against the CRSP-native tables.
+
+## Distributions and Dividends
+
+```sql
+SELECT permno, disexdt, disseqnbr, distype, disdetailtype, disfreqtype,
+       disordinaryflg, disdivamt, disfacpr, disfacshr, dispaydt
+FROM crsp.stkdistributions
+WHERE permno = %(permno)s ORDER BY disexdt, disseqnbr;
+```
+
+`disdivamt` is **NULL**, not 0, for splits and other non-cash distributions — use
+`coalesce(disdivamt, 0)` for legacy semantics. `disseqnbr` disambiguates same-ex-date
+events.
+
+For daily dividend amounts you usually do not need this table at all:
+`crsp.stkdlysecuritydata` carries `dlyorddivamt`, `dlynonorddivamt`, and `dlyfacprc`
+already denormalized onto the return row, plus `dlydistretflg` categorising what kind of
+distribution (if any) drove the day's return.
+
+Joining `stkdistributions` to a monthly panel duplicates rows when a security has two
+distributions in a month. Aggregate first:
+
+```sql
+SELECT permno, date_trunc('month', disexdt) AS mth,
+       sum(coalesce(disdivamt,0)) AS div_amt, count(*) AS n_dist
+FROM crsp.stkdistributions GROUP BY 1,2;
+```
+
+## Market and Benchmark Index Returns
+
+There is no `vwretd` column in CIZ. Join the index series table on `indno`.
+
+| Legacy variable | INDNO | Index name | CIZ column |
+|-----------------|-------|-----------|------------|
+| `VWRETD` | 1000200 | CRSP NYSE/NYSEMKT/Nasdaq/Arca Value-Weighted | `DlyTotRet` / `MthTotRet` |
+| `VWRETX` | 1000200 | same | `DlyPrcRet` / `MthPrcRet` |
+| `EWRETD` | 1000201 | CRSP NYSE/NYSEMKT/Nasdaq/Arca Equal-Weighted | `DlyTotRet` / `MthTotRet` |
+| `EWRETX` | 1000201 | same | `DlyPrcRet` / `MthPrcRet` |
+| `SPRTRN` | 1000502 | S&P 500 Composite | `DlyPrcRet` / `MthPrcRet` |
+
+Verified:
+
+```sql
+SELECT m.permno, m.mthcaldt, m.mthret, i.mthtotret AS vwretd, i.mthprcret AS vwretx
+FROM crsp.stkmthsecuritydata m
+JOIN crsp.indmthseriesdata i ON i.mthcaldt = m.mthcaldt AND i.indno = 1000200
+WHERE m.permno = 14593 AND m.mthcaldt >= '2025-09-01' ORDER BY m.mthcaldt;
+```
+
+```
+ permno |  mthcaldt  |  mthret   |  vwretd
+--------+------------+-----------+----------
+  14593 | 2025-09-30 |  0.096881 | 0.035626
+  14593 | 2025-10-31 |  0.061815 | 0.019284
+  14593 | 2025-11-28 |  0.032360 | 0.001997
+  14593 | 2025-12-31 | -0.025067 | 0.001297
+```
+
+Porting shortcut: `crsp.dsp500_v2` / `crsp.msp500_v2` keep the legacy column names
+(`vwretd, vwretx, ewretd, ewretx, spindx, sprtrn, totval, totcnt, usdval, usdcnt`).
+
+## S&P 500 Membership
+
+Membership lives under the **CRSP Index of the S&P 500 Universe** (`indno = 1000500`),
+not the published composite (`1000502`, which has no membership rows).
+
+```sql
+SELECT permno, mbrstartdt, mbrenddt, mbrflg
+FROM crsp.stkindmembership_ind
+WHERE indno = 1000500;
+```
+
+1,956 distinct PERMNOs as of 2026-07-26. `crsp.msp500list_v2` is the same content in the
+same shape, for code that expects the legacy table name.
+
+Point-in-time membership on a given date:
+
+```sql
+SELECT d.permno, d.dlycaldt, d.dlyret
+FROM crsp.stkdlysecurityprimarydata d
+JOIN crsp.stkindmembership_ind m
+  ON  m.permno = d.permno AND m.indno = 1000500
+ AND  d.dlycaldt BETWEEN m.mbrstartdt AND m.mbrenddt
+WHERE d.dlycaldt BETWEEN %(start)s AND %(end)s;
+```
+
+## Linking to Compustat (CCM)
+
+**Unchanged by CIZ.** The link table is still keyed on `lpermno`, so existing CCM code
+ports as-is once the CRSP side is CIZ. Verified for Apple:
+
+```sql
+SELECT l.gvkey, l.lpermno, l.linktype, l.linkprim, l.linkdt, l.linkenddt
+FROM crsp.ccmxpf_lnkhist l
+WHERE l.lpermno = 14593 AND l.linktype IN ('LU','LC') AND l.linkprim IN ('P','C');
+```
+
+```
+ gvkey  | lpermno | linktype | linkprim |   linkdt   | linkenddt
+--------+---------+----------+----------+------------+-----------
+ 001690 |   14593 | LU       | P        | 1980-12-12 |
+```
+
+Full merge:
+
+```sql
+SELECT c.gvkey, c.datadate, m.permno, m.mthcaldt, m.mthret, m.mthcap
+FROM comp.funda c
+JOIN crsp.ccmxpf_lnkhist l
+  ON  l.gvkey = c.gvkey
+ AND  l.linktype IN ('LU','LC') AND l.linkprim IN ('P','C')
+ AND  c.datadate BETWEEN l.linkdt AND coalesce(l.linkenddt, current_date)
+JOIN crsp.stkmthsecuritydata m
+  ON  m.permno = l.lpermno
+ AND  m.mthcaldt BETWEEN c.datadate AND c.datadate + interval '1 year'
+WHERE c.indfmt = 'INDL' AND c.datafmt = 'STD'
+  AND c.popsrc = 'D' AND c.consol = 'C';
+```
+
+WRDS also publishes a CIZ-specific sample program, *Merging CRSP and Compustat using CCM
+(CIZ format)*, on its CRSP sample-programs page.
+
+## Looking Up Flags and Columns
+
+Never guess a flag value. Two-step lookup — find the flag type for a column, then its
+values:
+
+```sql
+SELECT itemname, itemdesc, itemflagtype
+FROM crsp.metaiteminfo WHERE itemname = 'DlyPrcFlg';
+
+SELECT flagvalue, flagdesc, flagdef
+FROM crsp.metaflaginfo WHERE flagtype = 'PC' ORDER BY flagvalue;
+```
+
+Verified example — `flagtype = 'RD'` (Daily Return Duration Flag): `D1` = 1 trading day
+and 1 calendar day (the ordinary case), `D2`–`D4` = 1 trading day spanning 2–4 calendar
+days (weekends, holidays), `DU` = 1 trading day and ≥5 calendar days, `P1`–`P9` =
+multi-period returns spanning 2–10 trading periods, `MR` = missing return, `DD` = other
+daily delisting duration.
+
+Find the CIZ column for a legacy one:
+
+```sql
+SELECT sizitemname, cizfilename, cizitemname, cizitemdesc, sizcolmapseq
+FROM crsp.metasiztociz
+WHERE sizitemname = 'PRC' ORDER BY sizcolmapseq;
+```
+
+Check coverage before designing around a column:
+
+```sql
+SELECT itemname, colcountpct, colcountidpct, colmindt, colmaxdt
+FROM crsp.metacolumncoverage WHERE filename = 'StkDlySecurityData';
+```
+
+Trading-day calendar without deriving it:
+
+```sql
+SELECT caldt, tradingflg, holidayflg, weekendflg, datestatusflg
+FROM crsp.metaexchangecalendar
+WHERE caldt BETWEEN '2001-09-10' AND '2001-09-18' ORDER BY caldt;
+```
+
+## Rebuilding Legacy MSE-Style Tables
+
+WRDS does not host `msedelist`/`msedist`/`msenames`/`mseshares` in CIZ form — it
+publishes rebuild code instead. SQL translations of the WRDS SAS programs:
+
+**MSENames:**
+
+```sql
+SELECT permno, secinfostartdt AS namedt, secinfoenddt AS nameendt,
+       cusip AS ncusip, hdrcusip, ticker, issuernm AS comnam,
+       shareclass AS shrcls, tradingsymbol AS tsymbol,
+       primaryexch AS primexch, tradingstatusflg AS trdstat,
+       conditionaltype AS secstat, siccd, naics,
+       nasdcompno AS compno, nasdissuno AS issuno,
+       sharetype, securitytype, securitysubtype, usincflg, issuertype
+FROM crsp.stksecurityinfohist;
+```
+
+**MSEDelist:**
+
+```sql
+SELECT DISTINCT a.*, b.permco, b.primaryexch AS primexch, b.conditionaltype,
+       b.siccd, b.hdrcusip, b.cusip, b.nasdcompno AS compno, b.nasdissuno AS issuno
+FROM crsp.stkdelists a
+LEFT JOIN crsp.stksecurityinfohist b
+  ON  b.permno = a.permno
+ AND  a.delistingdt BETWEEN b.secinfostartdt AND b.secinfoenddt;
+```
+
+(rename `delistingdt→dlstdt`, `delpermno→nwperm`, `delpermco→nwcomp`,
+`delnextdt→nextdt`, `delamtdt→dlpdt`, `deldivamt→dlamt`)
+
+**MSEDist** — same shape against `crsp.stkdistributions` joined on
+`disexdt BETWEEN secinfostartdt AND secinfoenddt`, renaming `disdivamt→divamt`,
+`disfacpr→facpr`, `disfacshr→facshr`, `disdeclaredt→dclrdt`, `disexdt→exdt`,
+`disrecorddt→rcrddt`, `dispaydt→paydt`, `dispermno→acperm`, `dispermco→accomp`.
+
+**MSEShares** — `crsp.stkshares` joined the same way, renaming `shrstartdt→shrsdt`,
+`shrenddt→shrenddt`.
+
+Columns that **cannot** be rebuilt: `SHRCD`, `DISTCD`, `DLSTCD`, `EXCHCD`, `DLRETX`.
+WRDS explicitly declines to reverse-engineer the packed codes. See
+`known-differences.md` for the row-count differences you will see against the legacy
+tables.
+
+## Performance Notes
+
+- The January-2024 universe-joined daily query above ran in **1.9 s**. Index-series and
+  single-PERMNO lookups ran in 12–25 ms. Full-history daily pulls are a different
+  animal — `StkDlySecurityData` is ~20 GB / ~100M rows.
+- Prefer `stkdlysecurityprimarydata` (~7 GB, 12 columns) whenever the extra 20 columns
+  are unused. Same row count, under a quarter of the bytes.
+- Prefer the pre-aggregated `stkmth`/`stkqtr`/`stkannsecuritydata` files over aggregating
+  the daily file yourself — that is what the completeness flags are for.
+- Filter on `dlycaldt`/`mthcaldt` ranges before joining. Push the universe predicate into
+  the same `WHERE` clause rather than filtering in pandas after the pull.
+- Bulk pulls belong on the WRDS Cloud via `qsub`, never on the login node. See
+  `skills/wrds/SKILL.md`.

--- a/skills/crsp-v2/references/siz-to-ciz.md
+++ b/skills/crsp-v2/references/siz-to-ciz.md
@@ -1,0 +1,320 @@
+# SIZ → CIZ Column Crosswalk
+
+Transcribed from CRSP's *Cross-Reference Guide Legacy FIZ/SIZ to CIZ* (document last
+modified 2025-12-03) and reconciled against the live WRDS schema. Mappings are organised
+by **legacy** file, because that is the direction you port code in.
+
+The machine-readable version of this crosswalk is `crsp.metasiztociz` — query it when you
+need a column this file does not list:
+
+```sql
+SELECT sizitemname, cizfilename, cizitemname, cizitemdesc, sizcolmapseq
+FROM crsp.metasiztociz
+WHERE sizfilename = 'SFZ_DP_DLY'
+ORDER BY sizcolposition, sizcolmapseq;
+```
+
+## Contents
+
+- [File-Level Map](#file-level-map)
+- [SFZ_DP_DLY / SFZ_DS_DLY — Daily](#sfz_dp_dly--sfz_ds_dly--daily)
+- [SFZ_MTH and SFZ_AGG_MTH — Monthly](#sfz_mth-and-sfz_agg_mth--monthly)
+- [SFZ_AGG_QTR / SFZ_AGG_ANN — Quarterly and Annual](#sfz_agg_qtr--sfz_agg_ann--quarterly-and-annual)
+- [SFZ_HDR — Header](#sfz_hdr--header)
+- [SFZ_NAM — Name History](#sfz_nam--name-history)
+- [SFZ_NDI — NASDAQ Trading Info](#sfz_ndi--nasdaq-trading-info)
+- [SFZ_DEL / SFZ_MDEL — Delisting](#sfz_del--sfz_mdel--delisting)
+- [SFZ_DIS — Distributions](#sfz_dis--distributions)
+- [SFZ_SHR — Shares](#sfz_shr--shares)
+- [Index Files](#index-files)
+- [Columns With No CIZ Equivalent](#columns-with-no-ciz-equivalent)
+
+## File-Level Map
+
+| Legacy (SIZ/FIZ) | CIZ | Notes |
+|------------------|-----|-------|
+| `Sfz_dp_dly` | `StkDlyPrimarySecurityData` | Primary daily items |
+| `Sfz_ds_dly` | `StkDlySecurityData` | Superset of all daily items |
+| `Sfz_mth` | `StkMthSecurityData` | Return methodology changed |
+| `Sfz_agg_mth` | `StkMthSecurityData` | Adds `MthCompFlg`, `MthCompSubFlg` |
+| `Sfz_agg_qtr` | `StkQtrSecurityData` | Adds `QtrCompFlg`, `QtrCompSubFlg` |
+| `Sfz_agg_ann` | `StkAnnSecurityData` | Adds `AnnCompFlg`, `AnnCompSubFlg` |
+| `Sfz_hdr` | `StkSecurityInfoHdr` + `StkIssuerInfoHdr` | Split security/issuer |
+| `Sfz_nam` | `StkSecurityInfoHist` + `StkIssuerInfoHist` | Split security/issuer |
+| `Sfz_ndi` | `StkSecurityInfoHist` + `StkDlySecurityData` | `mmcnt` moved to daily |
+| `Sfz_del`, `Sfz_mdel` | `StkDelists` | Active securities no longer present |
+| `Sfz_dis` | `StkDistributions` | `DisSeqNbr` added to key |
+| `Sfz_shr` | `StkShares` | See also new `StkMthFloatShares` |
+| `Sfz_mbr` | `StkIndMembership` | `INDFAM` added |
+| `Sfz_dind` | `IndDlySeriesData` | Investable-index rows added |
+| `Sfz_mind` | `IndMthSeriesData` | |
+| `Sfz_indhdr` | `IndSeriesInfoHdr` + `IndFamilyInfoHdr` | |
+| `Sfz_portd` | `IndSecStatistics` | Annual security breakpoints |
+| `Sfz_portm` | `IndIssStatistics` | Quarterly issuer breakpoints |
+| `Sfz_rb` | `IndSecRebalSummary` + `IndIssRebalSummary` | Issuer caps split out |
+
+## SFZ_DP_DLY / SFZ_DS_DLY — Daily
+
+| Legacy | CIZ | Note |
+|--------|-----|------|
+| `kypermno` | `PERMNO` | |
+| `caldt` | `DlyCalDt` (also `YYYYMMDD`) | |
+| `prc` | `DlyPrc` + `DlyPrcFlg` | Always positive now |
+| `ret` | `DlyRet` | Delisting return included |
+| `retx` | `DlyRetx` | |
+| `tcap` | `DlyCap` + `DlyCapFlg` | $ thousands |
+| `vol` | `DlyVol` | |
+| `bidlo` | `DlyLow` (see also `DlyBid`) | Some values moved to `DlyBid` |
+| `askhi` | `DlyHigh` (see also `DlyAsk`) | Some values moved to `DlyAsk` |
+| `bid` | `DlyBid` | |
+| `ask` | `DlyAsk` | |
+| `numtrd` | `DlyNumTrd` | NASDAQ only, from 1982-11-01 |
+| `openprc` | `DlyOpen` | |
+| `cfacpr` | `DlyCumFacPr` | Moved to `StkDlyCumulativeAdjFactor` |
+| `cfacshr` | `DlyCumFacShr` | Moved to `StkDlyCumulativeAdjFactor` |
+
+New in CIZ with no SIZ predecessor: `DlyPrevPrc`, `DlyPrevPrcFlg`, `DlyPrevDt`,
+`DlyPrevCap`, `DlyPrevCapFlg`, `DlyRetI`, `DlyRetMissFlg`, `DlyRetDurFlg`,
+`DlyOrdDivAmt`, `DlyNonOrdDivAmt`, `DlyFacPrc`, `DlyDistRetFlg`, `DlyClose`,
+`DlyMMCnt`, `DlyPrcVol`, `DlyDelFlg`.
+
+## SFZ_MTH and SFZ_AGG_MTH — Monthly
+
+| Legacy | CIZ | Note |
+|--------|-----|------|
+| `mcaldt` | `MthCalDt` (also `YYYYMM`) | |
+| `mprc` / `mthprc` | `MthPrc` + `MthPrcFlg` | |
+| `mret` / `mthret` | `MthRet` | **Compounded daily — different estimator** |
+| `mretx` / `mthretx` | `MthRetx` | Same caveat |
+| `mtcap` / `mthcap` | `MthCap` | |
+| `mvol` / `mthvol` | `MthVol` | |
+| `maltprc` | `MthPrc` | Variation of the same concept |
+| `maltprcdt` | `MthPrcDt` + `MthDtFlg` | |
+| `mthprevprc` | `MthPrevPrc` (+ `MthPrevPrcFlg`) | |
+| `mthprevdt` | `MthPrevDt` (+ `MthPrevDtFlg`) | |
+| `mthprevcap` | `MthPrevCap` | |
+| `mthdiscnt` | `MthDisCnt` | |
+| `mthprcvol` | `MthPrcVol` | |
+| `mthfacshrflg` | `MthFacShrFlg` | |
+| `mthprcvolmisscnt` | `MthPrcVolMissCnt` | |
+| `mthdelflg` | `MthDelFlg` | |
+| `ncusip` | `CUSIP` | as of `MthPrcDt` |
+| `ticker` | `Ticker` | as of `MthPrcDt` |
+| `comnam` | `IssuerNm` | as of `MthPrcDt` |
+| `mbidlo`, `maskhi`, `mbid`, `mask`, `mspread` | **not present** | Derive from `StkDlySecurityData` (`DlyLow`, `DlyHigh`, `DlyBid`, `DlyAsk`, `DlyAsk - DlyBid`) |
+
+New: `MthCompFlg`, `MthCompSubFlg`.
+
+## SFZ_AGG_QTR / SFZ_AGG_ANN — Quarterly and Annual
+
+Identical structure to the monthly aggregate with the prefix swapped
+(`qtr*` / `ann*`) and the period key changed (`YYYYQ` / `YYYY`, `QtrCalDt` / `AnnCalDt`).
+Legacy `qcaldt` → `QtrCalDt`; legacy `acaldt` → `AnnCalDt`. New: `QtrCompFlg`/
+`QtrCompSubFlg` and `AnnCompFlg`/`AnnCompSubFlg`.
+
+## SFZ_HDR — Header
+
+| Legacy | CIZ | Table |
+|--------|-----|-------|
+| `kypermno` | `PERMNO` | security |
+| `cusip` | `HdrCUSIP` (see also `CNUM`) | security |
+| `cusip9` | `HdrCUSIP9` | security |
+| `htick` | `Ticker` | security |
+| `permco` | `PERMCO` | both |
+| `compno` | `NASDCompno` | both |
+| `issuno` | `NASDIssuno` | security |
+| `hexcd` | **not present** — see `PrimaryExch` + `ConditionalType` | security |
+| `hsiccd` | `SICCD` | both |
+| `begdt` | `SecurityBegDt` | security |
+| `enddt` | `SecurityEndDt` | security |
+| `hdlstcd` | `SecurityActiveFlg` + `DelActionType` + `DelStatusType` + `DelReasonType` + `DelPaymentType` | security |
+| `hcomnam` | `SecurityNm` / `IssuerNm` | security / both |
+| `htsymbol` | `TradingSymbol` | security |
+| `hsnaics` | `NAICS` | both |
+| `hshrcd` | `USIncFlg` + `IssuerType` + `SecurityType` + `SecuritySubType` + `ShareType` | security / both |
+| `hprimexch` | `PrimaryExch` | security |
+| `htrdstat` | `TradingStatusFlg` | security |
+| `hsecstat` | `ConditionalType` | security |
+
+New: `SecurityHdrFlg`, `ExchangeTier`, `SecInfoStartDt`, `SecInfoEndDt`, `ShareClass`,
+`ICBIndustry`, `UESIndustry`; issuer side adds `IssuerBegDt`, `IssuerEndDt`,
+`IssuerHdrFlg`, `CNUM`, `SecurityRangeCnt`, `SecurityTotalCnt`, `IssuerStatusType`.
+
+`HSICCD` was "last non-zero SICCD"; CIZ `SICCD` is the SICCD on the last active name
+record — so 100+ PERMNOs now show `SICCD = 0` where legacy showed a valid code.
+
+## SFZ_NAM — Name History
+
+| Legacy | CIZ |
+|--------|-----|
+| `namedt` | `SecInfoStartDt` |
+| `nameenddt` | `SecInfoEndDt` |
+| `ncusip` | **`CUSIP`** |
+| `ncusip9` | `CUSIP9` |
+| `ticker` | `Ticker` |
+| `comnam` | `IssuerNm` (see also `SecurityNm`) |
+| `shrcls` | `ShareClass` |
+| `shrcd` | `ShareType` + `SecurityType` + `SecuritySubType` + `USIncFlg` + `IssuerType` |
+| `exchcd` | **not present** — see `PrimaryExch` + `ConditionalType` |
+| `siccd` | `SICCD` |
+| `tsymbol` | `TradingSymbol` |
+| `snaics` | `NAICS` |
+| `primexch` | `PrimaryExch` |
+| `trdstat` | `TradingStatusFlg` |
+| `secstat` | `ConditionalType` |
+
+`secstat` values also changed representation: legacy `'R'` is CIZ `'RW'`. Renaming the
+column is not enough; the value comparison has to change too.
+
+## SFZ_NDI — NASDAQ Trading Info
+
+| Legacy | CIZ | Table |
+|--------|-----|-------|
+| `trtsdt` | `SecInfoStartDt` | `StkSecurityInfoHist` |
+| `trtsenddt` | `SecInfoEndDt` | `StkSecurityInfoHist` |
+| `nmsind` | `ExchangeTier` | `StkSecurityInfoHist` |
+| `mmcnt` | `DlyMMCnt` | `StkDlySecurityData` |
+| `nsdinx` | **not present** — closest are `SICCD`, `NAICS`, `ICBIndustry`, `UESIndustry` | |
+| `trtscd` | **not present** | |
+
+## SFZ_DEL / SFZ_MDEL — Delisting
+
+| Legacy | CIZ |
+|--------|-----|
+| `(m)dlstdt` | `DelistingDt` |
+| `(m)dlstcd` | `DelActionType` + `DelStatusType` + `DelReasonType` + `DelPaymentType` |
+| `(m)nwperm` | `DelPERMNO` |
+| `(m)nwcomp` | `DelPERMCO` |
+| `(m)nextdt` | `DelNextDt` |
+| `(m)dlprc` | **`DelNextPrc`** (not `DelDtPrc`) |
+| `(m)dlpdt` | `DelAmtDt` |
+| `(m)dlamt` | `DelDivAmt` (distributions after delisting only) |
+| `(m)dlret` | `DelRet` |
+| `(m)dlretx` | **not present** |
+
+New: `DelDtPrc`, `DelDtPrcFlg`, `DelNextPrcFlg`, `DelRetMissType`, `DelDisType`,
+`DelDlyDt`.
+
+## SFZ_DIS — Distributions
+
+| Legacy | CIZ |
+|--------|-----|
+| `distcd` | `DisType` + `DisFreqType` + `DisPaymentType` + `DisDetailType` + `DisTaxType` + `DisOrigCurType` (+ `DisOrdinaryFlg`) |
+| `divamt` | `DisDivAmt` |
+| `facpr` | `DisFacPr` |
+| `facshr` | `DisFacShr` |
+| `dclrdt` | `DisDeclareDt` |
+| `exdt` | `DisExDt` |
+| `rcrddt` | `DisRecordDt` |
+| `paydt` | `DisPayDt` |
+| `acperm` | `DisPERMNO` |
+| `accomp` | `DisPERMCO` |
+
+New: `DisSeqNbr` (part of the key), `DisAmountSourceType`.
+
+## SFZ_SHR — Shares
+
+| Legacy | CIZ |
+|--------|-----|
+| `shrsdt` | `ShrStartDt` |
+| `shrsenddt` | `ShrEndDt` |
+| `shrout` | `ShrOut` |
+| `shrflg` | `ShrSource` |
+
+New: `ShrFacType`, `ShrAdrFlg`.
+
+## Index Files
+
+### SFZ_DIND / SFZ_MIND → `IndDlySeriesData` / `IndMthSeriesData`
+
+| Legacy | CIZ (daily) | CIZ (monthly) |
+|--------|-------------|---------------|
+| `kyindno` | `INDNO` | `INDNO` |
+| `caldt` / `mcaldt` | `DlyCalDt` | `MthCalDt` |
+| `tret` / `mtret` | `DlyTotRet` | `MthTotRet` |
+| `tind` / `mtind` | `DlyTotInd` | `MthTotInd` |
+| `aret` / `maret` | `DlyPrcRet` | `MthPrcRet` |
+| `aind` / `maind` | `DlyPrcInd` | `MthPrcInd` |
+| `iret` / `miret` | `DlyIncRet` | `MthIncRet` |
+| `iind` / `miind` | `DlyIncInd` | `MthIncInd` |
+| `usdcnt` | `DlyUsdCnt` | `MthUsdCnt` |
+| `usdval` | `DlyUsdVal` | `MthUsdVal` |
+| `totcnt` | `DlyTotCnt` | `MthTotCnt` |
+| `totval` | `DlyTotVal` | `MthTotVal` |
+
+New: `DlyEligCnt`/`MthEligCnt`, `DlyWgtAmt`/`MthWgtAmt`.
+
+### SFZ_INDHDR → `IndSeriesInfoHdr` / `IndFamilyInfoHdr`
+
+| Legacy | CIZ |
+|--------|-----|
+| `kyindno` | `INDNO` |
+| `indname` | `IndNm` |
+| `indbegdt` | `IndBegDt` |
+| `indenddt` | `IndEndDt` |
+| `indfam` | `INDFAM` |
+| `portnum` | `PortNum` |
+| `baselvl` | `BaseLvl` |
+| `basedt` | `BaseDt` |
+| `calcrule` | `BreakPointStatType` |
+| `listrule` | `RuleGroup` |
+
+`AVAILABILITY`, `METHOD`, `REBALRULE`, `PUNIVERSE`, `UNIVERSE` were restructured into
+`AssignStatType`, `IndFamType`, `WeightType`, `BreakpointFreqType`, `PortOrder`,
+`BreakpointStatType`, `BreakpointINDFAM`, `UniverseType`, `ExchangeGroup`.
+
+### SFZ_MBR → `StkIndMembership`
+
+| Legacy | CIZ |
+|--------|-----|
+| `kypermno` | `PERMNO` |
+| `keyset` | `INDFAM` |
+| `mbrdt` | `MbrStartDt` |
+| `mbrenddt` | `MbrEndDt` |
+| `mbrflag` | `MbrFlg` |
+
+`INDNO` is the better join key for most purposes; use `INDFAM` only when comparing to
+legacy `KEYSET`.
+
+### SFZ_PORTD / SFZ_PORTM → `IndSecStatistics` / `IndIssStatistics`
+
+| Legacy | CIZ (security) | CIZ (issuer) |
+|--------|----------------|--------------|
+| `kypermno` | `PERMNO` | `PERMCO` |
+| `keyset` | `INDFAM` | `INDFAM` |
+| `annual` | `YYYY` + `SecAssignYYYY` | `YYYYQ` + `IssAssignYYYYQ` |
+| `(m)pportnum` | `SecAssignPortNum` | `IssAssignPortNum` |
+| `(m)pindno` | `SecAssignINDNO` | `IssAssignINDNO` |
+| `(m)pstat` | `SecStat` | `IssStat` |
+| `(m)ppflg` | `SecStatFlg` | `IssStatFlg` |
+
+The legacy `ANNUAL` field was overloaded (calculation year vs assignment year) and is
+now two columns. Issuer cap-based statistics that used to be duplicated across every
+PERMNO of a PERMCO are collapsed into one issuer row.
+
+### SFZ_RB → `IndSecRebalSummary` / `IndIssRebalSummary`
+
+| Legacy | CIZ (security) | CIZ (issuer) |
+|--------|----------------|--------------|
+| `kyindno` | `INDNO` | `INDNO` |
+| `rbbegdt` | `SecAssignStartDt` | `IssAssignStartDt` |
+| `rbenddt` | `SecAssignEndDt` | `IssAssignEndDt` |
+| `rusdcnt` | **not present** — see `SecIssuerAllCnt`, `SecSecurityAllCnt` | `IssIssuerAllCnt`, `IssSecurityAllCnt` |
+| `minid` | `SecMinStatPERMNO` | `IssMinStatPERMCO` |
+| `maxid` | `SecMaxStatPERMNO` | `IssMaxStatPERMCO` |
+| `minstat` | `SecMinStat` (+ `SecLowBreakpoint`) | `IssMinStat` |
+| `maxstat` | `SecMaxStat` (+ `SecHighBreakpoint`) | `IssMaxStat` |
+
+## Columns With No CIZ Equivalent
+
+Do not construct a substitute for these without saying so explicitly in the write-up:
+
+| Legacy column | Status |
+|---------------|--------|
+| `DLRETX` | Removed. No delisting return excluding dividends. |
+| `EXCHCD` / `HEXCD` | Removed. `PrimaryExch` + `ConditionalType` + `TradingStatusFlg` cover the same ground with different values. |
+| `TRTSCD` (NASDAQ status code) | Removed. |
+| `NSDINX` (NASDAQ index code) | Removed. Closest: `SICCD`, `NAICS`, `ICBIndustry`, `UESIndustry`. |
+| `MBIDLO`, `MASKHI`, `MBID`, `MASK`, `MSPREAD` | Removed from monthly. Derive from the daily file. |
+| `RUSDCNT` | Removed from rebalancing files. |
+| `SHRCD`, `DISTCD`, `DLSTCD` as single codes | Unpacked; not reconstructable in a way CRSP endorses, and WRDS explicitly declines to reverse-engineer them. |

--- a/skills/crsp-v2/references/siz-to-ciz.md
+++ b/skills/crsp-v2/references/siz-to-ciz.md
@@ -4,6 +4,11 @@ Transcribed from CRSP's *Cross-Reference Guide Legacy FIZ/SIZ to CIZ* (document 
 modified 2025-12-03) and reconciled against the live WRDS schema. Mappings are organised
 by **legacy** file, because that is the direction you port code in.
 
+**One CRSP naming trap before you start:** the Cross-Reference Guide PDF spells the daily
+primary file *both* `StkDlyPrimarySecurityData` and `StkDlySecurityPrimaryData`. Only the
+second exists — the table is `crsp.stkdlysecurityprimarydata`. Transcribing the PDF's first
+spelling yields `relation does not exist`.
+
 The machine-readable version of this crosswalk is `crsp.metasiztociz` — query it when you
 need a column this file does not list:
 
@@ -33,7 +38,7 @@ ORDER BY sizcolposition, sizcolmapseq;
 
 | Legacy (SIZ/FIZ) | CIZ | Notes |
 |------------------|-----|-------|
-| `Sfz_dp_dly` | `StkDlyPrimarySecurityData` | Primary daily items |
+| `Sfz_dp_dly` | `StkDlySecurityPrimaryData` | Primary daily items |
 | `Sfz_ds_dly` | `StkDlySecurityData` | Superset of all daily items |
 | `Sfz_mth` | `StkMthSecurityData` | Return methodology changed |
 | `Sfz_agg_mth` | `StkMthSecurityData` | Adds `MthCompFlg`, `MthCompSubFlg` |

--- a/skills/crsp-v2/references/tables.md
+++ b/skills/crsp-v2/references/tables.md
@@ -1,0 +1,398 @@
+# CIZ Table Catalog
+
+Every table and column list below was read from `information_schema.columns` on the
+WRDS PostgreSQL server (`wrds-pgdata.wharton.upenn.edu:9737`) on 2026-07-26. Where CRSP's
+PDF documentation disagrees with this file, this file is right — the PDFs describe the
+flat files, and WRDS adds columns when it loads them.
+
+## Contents
+
+- [Naming and Suffixes](#naming-and-suffixes)
+- [Time Series — Stock](#time-series--stock)
+- [Identifier Tables](#identifier-tables)
+- [Event Tables](#event-tables)
+- [Index Tables](#index-tables)
+- [Metadata Tables](#metadata-tables)
+- [WRDS Convenience Tables](#wrds-convenience-tables)
+- [Coverage Notes](#coverage-notes)
+
+## Naming and Suffixes
+
+All CIZ tables live in the `crsp` schema alongside the legacy SIZ tables.
+
+| Suffix | Meaning | Example |
+|--------|---------|---------|
+| *(none)* | 1925-start US Stock product (CIZ) | `crsp.stkdlysecuritydata` |
+| `62` | 1962-start subset product | `crsp.stkdlysecuritydata62` |
+| `_ind` | Full Index database (many more rows) | `crsp.stkindmembership_ind` |
+| `_v2` | WRDS-built convenience table, CIZ content, legacy name | `crsp.dsf_v2` |
+
+Index tables appear in both the Stock and Index products under the same base name.
+Subscribers to the Index database should use `_ind` — the stock-product copies carry
+only 4 index series versus 274 in `crsp.indseriesinfohdr_ind`.
+
+The CRSP file-name/product codes: `CIZyyyymm` (1925 Stock & Index), `CAZ` (1925 Stock),
+`C6Z` (1962 Stock), `CXZ` (1962 Stock & Index), `COZ` (1925 Indexes). Their SIZ
+predecessors were `SIZ`, `SAZ`, `S6Z`, `SXZ`, `SFZ`.
+
+## Time Series — Stock
+
+### `crsp.stkdlysecurityprimarydata` — daily, 12 columns (~7 GB)
+
+Key: `permno, dlycaldt`. The default daily table; every column here also exists in
+`stkdlysecuritydata`. Analogous to legacy `SFZ_DP_DLY`.
+
+```
+permno, dlycaldt, dlydelflg, dlyprc, dlyprcflg, dlycap, dlycapflg,
+dlyret, dlyretx, dlyretmissflg, dlydistretflg, dlyvol
+```
+
+### `crsp.stkdlysecuritydata` — daily, 32 columns (~20 GB)
+
+Key: `permno, yyyymmdd`. Superset of the primary file; adds quotes, OHLC, previous-period
+values, denormalized dividend amounts, and the price factor.
+
+```
+permno, yyyymmdd, dlycaldt, dlydelflg, dlyprc, dlyprcflg, dlycap, dlycapflg,
+dlyprevprc, dlyprevprcflg, dlyprevdt, dlyprevcap, dlyprevcapflg,
+dlyret, dlyretx, dlyreti, dlyretmissflg, dlyretdurflg,
+dlyorddivamt, dlynonorddivamt, dlyfacprc, dlydistretflg,
+dlyvol, dlyclose, dlylow, dlyhigh, dlybid, dlyask, dlyopen,
+dlynumtrd, dlymmcnt, dlyprcvol
+```
+
+`dlyprevprc` / `dlyprevcap` / `dlyprevdt` remove the need for `LAG()` or a self-join —
+they are the exact values CRSP used in the return and weight calculations. Use them
+rather than re-deriving, because they respect trading gaps that a naive `LAG()` does not.
+
+`dlylow`/`dlyhigh` are trade-based low/high; `dlybid`/`dlyask` are closing quotes. In
+SIZ these were overloaded into `bidlo`/`askhi`, and some values that used to sit in
+`BIDLO`/`ASKHI` now sit in `DlyBid`/`DlyAsk` instead.
+
+### `crsp.stkmthsecuritydata` — monthly, 37 columns
+
+Key: `permno, yyyymm`. Aggregated from daily. Carries identifiers as of `mthprcdt`.
+
+```
+permno, yyyymm, mthcaldt, mthcompflg, mthcompsubflg,
+mthprc, mthprcflg, mthprcdt, mthdtflg, mthdelflg, mthcap,
+mthprevprc, mthprevprcflg, mthprevdt, mthprevdtflg, mthprevcap,
+mthret, mthretx, mthretflg, mthdiscnt, mthvol, mthvolflg, mthprcvol,
+mthfacshrflg, mthprcvolmisscnt,
+cusip, ticker, issuernm, usincflg, issuertype, securitytype, securitysubtype,
+sharetype, exchangetier, primaryexch, tradingstatusflg, conditionaltype
+```
+
+Because identifiers are already on the row, a monthly common-stock panel needs **no join**
+to `stksecurityinfohist` — the five universe columns are present and are already
+point-in-time (as of `mthprcdt`). `crsp.stkqtrsecuritydata` (`yyyyq`, `qtr*` prefixes) and
+`crsp.stkannsecuritydata` (`yyyy`, `ann*` prefixes) have identical shapes at their
+frequencies.
+
+`mthcompflg` / `mthcompsubflg` (and `qtr*`/`ann*` equivalents) are the completeness flags —
+they tell you whether the underlying daily data for that period was complete. Filter on
+them instead of hand-checking day counts. This is what makes the annual file usable as a
+substitute for scanning the ~100M-row daily file.
+
+### `crsp.stkdlycumulativeadjfactor` — daily, 5 columns
+
+Key: `permno, dlycaldt`. Where `CFACPR`/`CFACSHR` went.
+
+```
+permno, dlycaldt, dlyshrout, dlycumfacpr, dlycumfacshr
+```
+
+`crsp.stkmthcumulativeadjfactor` is the monthly twin (`mthcaldt`, `mthshrout`,
+`mthcumfacpr`, `mthcumfacshr`).
+
+### `crsp.stkmthfloatshares` — monthly, 4 columns
+
+Key: `permno, yyyymm`. New in CIZ; float shares for a subset of securities from as early
+as December 1999.
+
+```
+permno, yyyymm, mthfloatshrqty, mthfloatshrpct
+```
+
+## Identifier Tables
+
+### `crsp.stksecurityinfohist` — permno × interval, 36 columns
+
+Key: `permno, secinfostartdt`. **The table for universe filters and point-in-time
+identifiers.** Replaces `msenames`/`stocknames`.
+
+```
+permno, secinfostartdt, secinfoenddt, securitybegdt, securityenddt, securityhdrflg,
+hdrcusip, hdrcusip9, cusip, cusip9,
+primaryexch, conditionaltype, exchangetier, tradingstatusflg,
+securitynm, shareclass, usincflg, issuertype, securitytype, securitysubtype, sharetype,
+securityactiveflg, delactiontype, delstatustype, delreasontype, delpaymenttype,
+ticker, tradingsymbol, permco, siccd, naics, icbindustry, uesindustry,
+nasdcompno, nasdissuno, issuernm
+```
+
+`crsp.stksecurityinfohdr` has the **same 36 columns** but one row per `permno` (header /
+most-recent values). Using the header for a historical filter back-fills today's
+classification across the whole panel.
+
+CIZ produces **more** interval rows than legacy `msenames`: it splits on `exchangetier`
+changes that SIZ ignored, and it emits a separate one-day row for the delisting event
+(`tradingstatusflg = 'D'`). PERMNO 10001 has 14 CIZ rows against 10 legacy rows.
+
+### `crsp.stkissuerinfohdr` / `crsp.stkissuerinfohist` — permco, 18 columns
+
+Key: `permco` (plus `issinfostartdt, issinfoenddt` for the history table). New in CIZ.
+Gives non-duplicated issuer counts and enforces consistency for issuer-level fields.
+
+```
+permco, issinfostartdt, issinfoenddt, issuerbegdt, issuerenddt, issuerhdrflg,
+cnum, issuernm, securityrangecnt, securitytotalcnt,
+usincflg, issuertype, issuerstatustype, siccd, naics, icbindustry, uesindustry, nasdcompno
+```
+
+(`stkissuerinfohdr` uses `issinfostartdt`/`issinfoenddt` in the same positions.)
+
+About 98% of issuers have exactly one security. Most issuer fields are duplicated onto
+the security-level tables for convenience, so you rarely need to join — the issuer tables
+matter when you need a clean count of *firms* rather than *securities*, or issuer-level
+cap-based statistics.
+
+`icbindustry` and `uesindustry` are new in CIZ (high-level ICB and UES industry only).
+
+## Event Tables
+
+### `crsp.stkdelists` — 19 columns
+
+Key: `permno`. **Only actually-delisted securities appear.** Legacy `SFZ_DEL` carried a
+row for every security including active ones (with `DLSTCD = 100`); CIZ does not. An
+inner join to this table is now an implicit "delisted only" filter.
+
+```
+permno, delistingdt, deldtprc, deldtprcflg,
+delactiontype, delstatustype, delreasontype, delpaymenttype,
+delpermno, delpermco, delret, delretmisstype,
+delnextdt, delnextprc, delnextprcflg, delamtdt, deldivamt, deldistype, deldlydt
+```
+
+`deldtprc` is the price **on the delisting date**; `delnextprc` is the price on
+`delnextdt`. Legacy `DLPRC` corresponds to **`delnextprc`**, not `deldtprc` — comparing
+`DLPRC` to `deldtprc` produces 20,000+ spurious mismatches.
+
+`DLRETX` has no CIZ equivalent.
+
+### `crsp.stkdistributions` — 19 columns
+
+Key: `permno, disexdt, disseqnbr`. `disseqnbr` is new — it disambiguates multiple
+distributions with the same ex-date, which legacy handled through `distcd` + `acperm`.
+
+```
+permno, disexdt, disseqnbr, disordinaryflg,
+distype, disfreqtype, dispaymenttype, disdetailtype, distaxtype, disorigcurtype,
+disdivamt, disfacpr, disfacshr,
+disdeclaredt, disrecorddt, dispaydt, dispermno, dispermco, disamountsourcetype
+```
+
+The 4-digit `DISTCD` is unpacked into the seven type/flag columns above.
+
+`disdivamt` is **missing (NULL), not 0**, for distributions with no cash amount — e.g.
+splits (`distype='FRS'`, `dispaymenttype='SS'`, `disdetailtype='STKSPL'`). Legacy
+`divamt` was always 0 in that case. `SUM(disdivamt)` behaves differently as a result;
+`coalesce(disdivamt, 0)` restores legacy behaviour if you need it.
+
+A security can have two distributions in one month (AAPL, August 2020: a cash dividend
+on 8/7 and a 4:1 split on 8/31). Joining distributions to a monthly panel therefore
+duplicates rows — this is the documented cause of "duplicate rows" in the WRDS Daily and
+Monthly Stock File queries.
+
+### `crsp.stkshares` — 7 columns
+
+Key: `permno, shrstartdt`.
+
+```
+permno, shrstartdt, shrenddt, shrout, shrsource, shrfactype, shradrflg
+```
+
+CIZ splits share-observation intervals more finely than legacy `mseshares`, so an equality
+join on date ranges will appear to mismatch even when `shrout` agrees. About 88 records
+genuinely differ (mean 1.23%, median 0.07%) due to float-precision rounding — a documented
+and accepted difference.
+
+## Index Tables
+
+### `crsp.inddlyseriesdata` / `crsp.indmthseriesdata` — 15 columns
+
+Key: `indno, yyyymmdd` (or `indno, yyyymm`).
+
+```
+indno, yyyymmdd, dlycaldt, dlytotret, dlytotind, dlyprcret, dlyprcind,
+dlyincret, dlyincind, dlyusdcnt, dlyusdval, dlytotcnt, dlytotval,
+dlyeligcnt, dlywgtamt
+```
+
+`dlyeligcnt` and `dlywgtamt` are new in CIZ. Monthly uses `mth*` prefixes throughout.
+
+### `crsp.indseriesinfohdr` — 12 columns
+
+```
+indno, indfam, indfamtype, indnm, indbegdt, indenddt,
+baselvl, basedt, freqavail, weighttype, cntvaltype, portnum
+```
+
+### `crsp.indfamilyinfohdr_ind` — 23 columns
+
+```
+indfam, indfamtype, indfamnm, indfambegdt, indfamenddt, baselvl, basedt,
+freqavail, weighttype, cntvaltype, universetype, exchangegroup,
+indfamsize, indfamfirstindno, indfamlastindno, underlyingdatacd,
+portorder, assignstattype, breakpointformtype, breakpointstattype,
+breakpointfreqtype, betastatmrktindno, breakpointindfam
+```
+
+### `crsp.stkindmembership_ind` — 6 columns
+
+Key: `permno, indno, mbrstartdt, mbrenddt`.
+
+```
+permno, indno, mbrstartdt, mbrenddt, mbrflg, indfam
+```
+
+### `crsp.stkindsecuritystatistics_ind` / `crsp.stkindissuerstatistics_ind` — 9 columns
+
+Pre-calculated stock-level statistics (beta, standard deviation, capitalization) and the
+resulting decile assignment.
+
+```
+permno, indfam, yyyy, secstattype, secstat, secstatflg,
+secassignyyyy, secassignindno, secassignportnum
+```
+
+The issuer version is keyed on `permco, indfam, yyyyq` with `iss*` column names.
+
+### `crsp.indsecrebalancesummary_ind` / `crsp.indissrebalancesummary_ind` — 20 columns
+
+Breakpoints and rebalancing statistics per index and period.
+
+```
+indno, yyyy, indfam, portnum, secassignyyyy, secassignstartdt, secassignenddt,
+secissuerallcnt, secstattype, seclowbreakpoint, sechighbreakpoint,
+secminstat, secmaxstat, secminstatpermno, secminstatissuernm,
+secmaxstatpermno, secmaxstatissuernm,
+secsecurityallcnt, secsecuritydropcnt, secsecurityaddcnt
+```
+
+## Metadata Tables
+
+Ten metadata tables ship with CIZ. They are the fastest way to answer "what is this
+column" without opening a PDF, and they are queryable, so prefer them.
+
+| Table | Key | Contents |
+|-------|-----|----------|
+| `crsp.metafileinfo` | `filename` | One row per CIZ file: description, category, row frequency, column count, key columns |
+| `crsp.metaiteminfo` | `itemname` | One row per item: description, definition, category, class, **`itemflagtype`** |
+| `crsp.metacolumninfo` | `filename, colposition` | Per-column SQL/SAS/R datatypes, null flag, ASCII field width |
+| `crsp.metaflaginfo` | `flagtype, flagvalue` | All ~774 flag values with descriptions and definitions |
+| `crsp.metaflagtype` | `flagtype` | The 62 flag types |
+| `crsp.metacolumncoverage` | `filename, colposition` | Non-missing counts/percentages, first and last date with data |
+| `crsp.metaflagcoverage` | `filename, colposition, flagvalue` | How often each flag value actually occurs |
+| `crsp.metacalendarperiod` | `calperiodkey` | Daily/monthly/quarterly/annual period boundaries, CRSP trading start/end, next/prev period keys, trading-day counts |
+| `crsp.metaexchangecalendar` | `caldt` | Every day from 1925-12-31: trading/holiday/weekend flags and reason |
+| `crsp.metasiztociz` | `sizfilename, sizcolposition, sizcolmapseq` | The machine-readable SIZ→CIZ crosswalk |
+
+Column shapes:
+
+```
+metafileinfo   :: filename, filedesc, filedef, filecategory, filerowfreq,
+                  filecolumncnt, filedatacolumncnt, filekeycnt, filekeytype,
+                  fileitemname1..4, fileactiveflg, filekey, fileitemkey1..4
+metaiteminfo   :: itemname, itemdesc, itemdef, itemcategory, itemclass,
+                  itemmaxcharlen, itemnullflg, itemmissingflg, itemhasdataflg,
+                  itemflagtype, itemactiveflg, itemfilecnt, itemkey
+metaflaginfo   :: flagtype, flagvalue, flagtypedesc, flagdesc, flagdef,
+                  flagcoverageflg, flagkey
+metasiztociz   :: sizfilename, sizcolposition, sizcolmapseq, sizitemname, sizitemdesc,
+                  cizfilename, cizitemname, cizitemdesc,
+                  sizmappingtype, sizmappingsubtype,
+                  cizcolumnkey, cizfilekey, cizitemkey, sizcolumnmappingkey
+metacolumncoverage :: filename, colposition, itemname, colcount, colcountid,
+                  colmindt, colmaxdt, colcountpct, colcountidpct, coldatepct,
+                  columnkey, filekey, itemkey
+metacalendarperiod :: calperiodkey, calperiodtype, calperiodstartdt, calperiodenddt,
+                  calperiodcrspstartdt, calperiodcrspenddt, calperiodnextkey,
+                  calperiodprevkey, calperiodprevenddt, calperiodprevcrspenddt,
+                  calperiodnbr, calperioddaycnt, calperiodcrspdaycnt, calperiodflg
+metaexchangecalendar :: caldt, tradingflg, holidayflg, weekendflg, datestatusflg,
+                  weekday, exchangegroup
+```
+
+In `metasiztociz`, `sizcolmapseq = 1` is the best default mapping when a SIZ column maps
+to several CIZ columns. `sizcolposition = 0` rows describe the **join keys** between the
+SIZ and CIZ files; `sizcolposition > 900` rows describe CIZ columns that were *added*
+(denormalized from another SIZ file, or promoted out of the PDF documentation).
+
+Coverage figures worth knowing before designing a study, from `metacolumncoverage`:
+`DlyPrc` is 98% non-missing and present for 100% of PERMNOs; `DlyClose` 81% / 88%;
+`DlyOpen` 60% / 77%; `DlyNumTrd` starts only on 1982-11-01 and covers 48% of securities.
+
+## WRDS Convenience Tables
+
+Built by WRDS, not CRSP. They pre-join identifiers, shares, and adjustment factors onto
+the time series, so they are the fastest path for a straightforward panel — at the cost
+of the duplicate-row behaviour when a security has multiple distributions in a period.
+
+### `crsp.dsf_v2` — 50 columns
+
+```
+permno, hdrcusip, permco, siccd, nasdissuno, yyyymmdd,
+sharetype, securitytype, securitysubtype, usincflg, issuertype,
+primaryexch, conditionaltype, tradingstatusflg,
+dlycaldt, dlydelflg, dlyprc, dlyprcflg, dlycap, dlycapflg,
+dlyprevprc, dlyprevprcflg, dlyprevdt, dlyprevcap, dlyprevcapflg,
+dlyret, dlyretx, dlyreti, dlyretmissflg, dlyretdurflg,
+dlyorddivamt, dlynonorddivamt, dlyfacprc, dlydistretflg,
+dlyvol, dlyclose, dlylow, dlyhigh, dlybid, dlyask, dlyopen,
+dlynumtrd, dlymmcnt, dlyprcvol,
+dlycumfacpr, dlycumfacshr, cusip, ticker, exchangetier, shrout
+```
+
+This is `stkdlysecuritydata` + the universe columns + `shrout` + cumulative factors, so a
+common-stock daily panel can be written against `dsf_v2` alone with no joins.
+
+### `crsp.msf_v2` — 45 columns
+
+`stkmthsecuritydata` plus `hdrcusip, permco, siccd, nasdissuno, mthcumfacpr,
+mthcumfacshr, shrout, mthfloatshrqty`.
+
+### `crsp.stocknames_v2` — 22 columns
+
+```
+permno, permco, namedt, nameenddt, securitybegdt, securityenddt,
+hdrcusip, hdrcusip9, cusip, cusip9, ticker, issuernm,
+primaryexch, conditionaltype, tradingstatusflg, shareclass,
+sharetype, securitytype, securitysubtype, usincflg, issuertype, siccd
+```
+
+Keeps the legacy `namedt`/`nameenddt` column names (rather than
+`secinfostartdt`/`secinfoenddt`), which makes porting legacy `stocknames` code easier.
+
+### Index convenience tables
+
+`crsp.msp500list_v2` and `crsp.dsp500list_v2` are S&P 500 membership in the CIZ
+membership shape (`permno, indno, mbrstartdt, mbrenddt, mbrflg, indfam`), filtered to
+`indno = 1000500`.
+
+`crsp.dsp500_v2` / `crsp.msp500_v2` keep the legacy index-series column names:
+`yyyymmdd, caldt, vwretd, vwretx, ewretd, ewretx, totval, totcnt, usdval, usdcnt,
+spindx, sprtrn` — the easiest drop-in when porting code that referenced `vwretd`.
+
+Also present: `crsp.wrds_dsfv2_query`, `crsp.wrds_msfv2_query` (the backing tables for
+the WRDS web query tool), and `crsp.idx_const_*_v2` (index constituent files).
+
+## Coverage Notes
+
+Verified 2026-07-26:
+
+- `crsp.stkdlysecurityprimarydata`: 1925-12-31 → 2025-12-31
+- `crsp.stkmthsecuritydata`: → 2025-12-31
+- `crsp.dsf` (legacy SIZ): → 2024-12-31, frozen
+- `crsp.indseriesinfohdr`: 4 series (stock product); `crsp.indseriesinfohdr_ind`: 274 series
+- `crsp.stkindmembership_ind` for `indno = 1000500`: 1,956 distinct PERMNOs

--- a/skills/wrds/SKILL.md
+++ b/skills/wrds/SKILL.md
@@ -219,7 +219,7 @@ See **`references/sas-etl.md`** for complete patterns:
 |---------|--------|------------|
 | Compustat | `comp` | `company`, `funda`, `fundq`, `secd` |
 | ExecuComp | `comp_execucomp` | `anncomp` |
-| CRSP | `crsp` | `dsf`, `msf`, `stocknames`, `ccmxpf_linkhist` |
+| CRSP | `crsp` | `dsf`, `msf`, `stocknames`, `ccmxpf_lnkhist` |
 | CRSP v2 | `crsp` | `dsf_v2`, `msf_v2`, `stocknames_v2` |
 | Form 4 Insiders | `tr_insiders` | `table1`, `header`, `company` |
 | ISS Incentive Lab | `iss_incentive_lab` | `comppeer`, `sumcomp`, `participantfy` |
@@ -326,7 +326,8 @@ cursor.execute("""
 Detailed query patterns and table documentation:
 
 - **`references/compustat.md`** - Compustat tables, ExecuComp, financial variables
-- **`references/crsp.md`** - CRSP stock data, CCM linking, v2 format
+- **`references/crsp.md`** - CRSP legacy (SIZ) stock data and CCM linking
+- **`skills/crsp-v2/SKILL.md`** - CRSP CIZ / v2 format (required for any data after 2024-12-31)
 - **`references/insider-form4.md`** - Thomson Reuters Form 4, rolecodes, insider types
 - **`references/iss-compensation.md`** - ISS Incentive Lab, peer companies, compensation
 - **`references/formd.md`** - Form D / Reg D (canonical): two sources (WRDS `wrds_vc_formd` + SEC EDGAR TSV/XML), grain & keys, denormalization gotcha, exemption + industry codes, post-2020 gap, validated benchmarks

--- a/skills/wrds/SKILL.md
+++ b/skills/wrds/SKILL.md
@@ -327,7 +327,7 @@ Detailed query patterns and table documentation:
 
 - **`references/compustat.md`** - Compustat tables, ExecuComp, financial variables
 - **`references/crsp.md`** - CRSP legacy (SIZ) stock data and CCM linking
-- **`skills/crsp-v2/SKILL.md`** - CRSP CIZ / v2 format (required for any data after 2024-12-31)
+- **`${CLAUDE_SKILL_DIR}/../../skills/crsp-v2/SKILL.md`** - CRSP CIZ / v2 format (required for any data after 2024-12-31)
 - **`references/insider-form4.md`** - Thomson Reuters Form 4, rolecodes, insider types
 - **`references/iss-compensation.md`** - ISS Incentive Lab, peer companies, compensation
 - **`references/formd.md`** - Form D / Reg D (canonical): two sources (WRDS `wrds_vc_formd` + SEC EDGAR TSV/XML), grain & keys, denormalization gotcha, exemption + industry codes, post-2020 gap, validated benchmarks

--- a/skills/wrds/references/compustat.md
+++ b/skills/wrds/references/compustat.md
@@ -403,7 +403,7 @@ def get_crsp_permno(pool, gvkey: str) -> str | None:
     with pool.cursor() as cursor:
         cursor.execute("""
             SELECT lpermno
-            FROM crsp.ccmxpf_linkhist
+            FROM crsp.ccmxpf_lnkhist
             WHERE gvkey = %s
               AND linktype IN ('LC', 'LU')
               AND linkprim IN ('P', 'C')

--- a/skills/wrds/references/crsp.md
+++ b/skills/wrds/references/crsp.md
@@ -1,5 +1,13 @@
 # CRSP Stock Data
 
+> **The legacy SIZ tables below stop at 2024-12-31.** CRSP discontinued Flat File
+> Format 1.0 (SIZ) after the December 2024 release; only the CIZ / v2 format is
+> updated. For any data after 2024, the CIZ column semantics (no `shrcd`, no
+> `exchcd`, positive-only prices, delisting returns embedded in `dlyret`/`mthret`,
+> monthly returns compounded from daily), or migration of SIZ code, **use the
+> `crsp-v2` skill** — `skills/crsp-v2/SKILL.md`. This file covers the legacy format
+> and the CCM link, which CIZ did not change.
+
 ## Contents
 
 - [Tables](#tables)
@@ -12,21 +20,27 @@
 
 ## Tables
 
-### Legacy Format
+### Legacy Format (SIZ — frozen at 2024-12-31)
 | Table | Description |
 |-------|-------------|
 | `crsp.dsf` | Daily stock file |
 | `crsp.msf` | Monthly stock file |
 | `crsp.dse` | Daily stock events |
 | `crsp.stocknames` | Security names/identifiers |
-| `crsp.ccmxpf_linkhist` | CRSP-Compustat link |
+| `crsp.ccmxpf_lnkhist` | CRSP-Compustat link |
 
-### v2 (CIZ) Format
+### v2 (CIZ) Format — the only updated format
 | Table | Description |
 |-------|-------------|
-| `crsp.dsf_v2` | Daily stock file (CIZ) |
-| `crsp.msf_v2` | Monthly stock file (CIZ) |
-| `crsp.stocknames_v2` | Security names (CIZ) |
+| `crsp.dsf_v2` | Daily stock file (WRDS-built, CIZ) |
+| `crsp.msf_v2` | Monthly stock file (WRDS-built, CIZ) |
+| `crsp.stocknames_v2` | Security names (WRDS-built, CIZ) |
+| `crsp.stkdlysecurityprimarydata` | Daily, CRSP-native, 12 cols |
+| `crsp.stkdlysecuritydata` | Daily, CRSP-native, 32 cols |
+| `crsp.stkmthsecuritydata` | Monthly, CRSP-native |
+| `crsp.stksecurityinfohist` | Security attribute history (universe filters) |
+
+Full catalog, crosswalk, flag dictionary, and verified queries: **`skills/crsp-v2/`**.
 
 ## Key Fields
 
@@ -88,7 +102,7 @@ sql = """
     SELECT a.gvkey, a.datadate, a.at, a.sale,
            b.lpermno as permno, c.mthret
     FROM comp.funda a
-    INNER JOIN crsp.ccmxpf_linkhist b
+    INNER JOIN crsp.ccmxpf_lnkhist b
         ON a.gvkey = b.gvkey
         AND b.linktype IN ('LU', 'LC')
         AND b.linkprim IN ('P', 'C')
@@ -130,8 +144,14 @@ collapsed = df.drop_duplicates(subset=['gvkey', 'lpermno', 'linkdt'], keep='last
 
 ## Market Equity
 
+In CIZ, do **not** compute market equity — `mthcap` / `dlycap` is CRSP's own
+capitalization in $ thousands and is already on the row. Recomputing it reintroduces
+the documented share-rounding and bid/ask-precision differences. `abs()` is also
+unnecessary: CIZ prices are always positive (see `skills/crsp-v2/`). The legacy
+pattern below applies to SIZ data only.
+
 ```python
-# Calculate market equity
+# Legacy (SIZ) market equity
 crsp['me'] = abs(crsp['mthprc']) * crsp['shrout']
 
 # Aggregate to PERMCO level (sum across share classes)


### PR DESCRIPTION
## Why

CRSP discontinued Flat File Format 1.0 (SIZ) after the December 2024 release. Verified live on WRDS PostgreSQL:

| Table | Format | `max(date)` |
|-------|--------|-------------|
| `crsp.dsf` | legacy SIZ | **2024-12-31** |
| `crsp.stkdlysecurityprimarydata` | CIZ | **2025-12-31** |

A legacy query does not error when it runs off the end of the data — it returns a short panel and the sample period is quietly wrong. Anything after 2024 requires CIZ.

## What

New `skills/crsp-v2/`, written from the WRDS/CRSP transition docs (downloaded through the logged-in browser) and reconciled against the live WRDS schema:

- **SKILL.md** — three Iron Laws: no legacy table post-2024; `SHRCD IN (10,11)` needs five CIZ columns (`ShareType` is never `'COM'`); never add a delisting return (CIZ embeds it).
- **references/tables.md** — full catalog with column lists from `information_schema`, not from the PDFs.
- **references/siz-to-ciz.md** — column-by-column crosswalk per legacy SIZ file, plus columns with no CIZ equivalent (`DLRETX`, `EXCHCD`, monthly bid/ask).
- **references/flags.md** — all 774 flag values across 62 types, dumped from `crsp.metaflaginfo`.
- **references/known-differences.md** — WRDS/CRSP-documented discrepancies, incl. the monthly-return methodology change (90 stock-months differ by >100%).
- **references/queries.md** — recipes, each executed against WRDS with real output.
- **references/indexes.md** — INDNO/INDFAM, the +400 monthly renumbering, the three distinct S&P 500 series.
- **examples/ciz_panel.py** — runnable, verified on 2025 data.

## Drive-by fixes

- `crsp.ccmxpf_linkhist` → `crsp.ccmxpf_lnkhist` across the `wrds` skill. The former exists in no schema on WRDS; `linkage.md` already had it right.
- Legacy CRSP reference banner-flagged as SIZ-only, with the CIZ market-equity caveat (`mthcap` is on the row; don't recompute, don't `abs()`).

## Verification

- All example queries executed against `wrds-pgdata.wharton.upenn.edu:9737` on 2026-07-26; SQL in the example script validated via `EXPLAIN`.
- `ciz_panel.py --freq monthly` → 7,373 rows / 3,703 permnos (Nov–Dec 2025); `--freq daily` → 18,347 rows / 3,674 permnos.
- `scripts/check-all.sh` 4/4 passed; `scripts/check-hooks.sh` 63/63 passed.

Note: skill directory is `crsp-v2` rather than `crsp_v2` — skill names only allow letters, digits, and hyphens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnEXLsyHUkBmpXHSBQKh5N