### PR TITLE
sync(npx-panel): commit the grid tree that produced digests A-D

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_inst_own.py
+++ b/skills/npx-ownership-panel/scripts/build_inst_own.py
@@ -110,6 +110,9 @@ WHERE b.shrcd IN (10, 11)
 # 2020-09-30 is 16,976,763 / 1.0 / 115.81 in both. Verified before adopting.
 # shrout at the boundary differs ~0.5% (15,040,731 vs 15,115,823) — a vintage
 # revision between products, which is why crsp_src is stamped on every row.
+# crsp.msenames and crsp.msf freeze on the same date; keep it in one place.
+LEGACY_NAMES_END = "2024-12-31"
+
 CRSP_MONTHLY_V2_QUERY = """
 SELECT permno, mthcaldt AS date, mthprc AS prc, shrout,
        mthcumfacpr AS cfacpr, mthcumfacshr AS cfacshr, cusip AS ncusip
@@ -122,11 +125,68 @@ WHERE sharetype = 'NS'
   AND shrout IS NOT NULL
 """
 
+# DATE-BOUNDED. The undated form of this query -- SELECT DISTINCT ncusip, permno
+# -- maps EVERY historical CUSIP a permno ever carried to it, for all time. A
+# 2020 holding tagged with the 1985 ALLIED SIGNAL cusip (01951210) then resolves
+# to Honeywell's permno 10145, because CRSP records both under it:
+#
+#   permno 10145  01951210  ALLIED SIGNAL INC          1985-09-19 .. 1999-12-01
+#   permno 10145  43851610  HONEYWELL INTERNATIONAL    1999-12-02 ..
+#   permno 10401  00195710  A T & T CORP               1994-04-21 .. 2002-11-18
+#   permno 10401  00195750  A T & T CORP               2002-11-19 .. 2005-11-18
+#
+# Those are SUCCESSIONS, never concurrent. The undated join manufactured a
+# second row per (permno, rdate, cik), which the downstream
+# unique(subset=[permno,rdate,cik], keep="first") then resolved BY COIN FLIP --
+# sorting on exactly the dedup key leaves ties in arbitrary order. Measured on
+# 2018-2022: 8,804 such groups, 44.5% with a second position over half the size
+# of the first. So io_total for those cells was one draw, not an answer.
+#
+# Same shape as every other defect in this file: a join that silently
+# over-matches and returns plausible numbers. Note the CRSP monthly query above
+# ALREADY does the dated join correctly -- it was simply never propagated here.
 CUSIP8_PERMNO_QUERY = """
-SELECT DISTINCT ncusip, permno
+SELECT DISTINCT ncusip, permno, namedt, nameendt
 FROM crsp.msenames
 WHERE ncusip IS NOT NULL AND ncusip != ''
 """
+
+# THE NAMES TABLE IS FROZEN TOO, AND DATING THE JOIN IS WHAT EXPOSED IT.
+#
+# crsp.msenames stops with the legacy product: max(nameendt) = 2024-12-31 and
+# NOT ONE of its 83,815 common-stock rows has a NULL nameendt. So the
+# `nameendt IS NULL -> 29991231` branch above never fires, every validity window
+# closes on or before 2024-12-31, and `rdate_int <= nameendt_int` drops every
+# 2025 holding. Measured before this splice: 2025 got 0 cusip8 matches and all
+# 15,546 of its panel rows carried io_total = NULL.
+#
+# That is the SAME hole the msf/msf_v2 splice above exists to close, one table
+# over — and it is invisible without the date bound, because the undated join
+# matched 2025 rows on a stale window and returned plausible numbers. Fixing the
+# over-match uncovered an under-match.
+#
+# crsp.stocknames_v2 is the CIZ successor and runs to 2025-12-31. Spliced on the
+# same terms as the monthly: EXTEND, never replace. Only windows reaching past
+# the legacy boundary are taken and their start is clamped to it, so every
+# historical quarter keeps its legacy window and the difference is confined to
+# dates that had no window at all. Share-class filter is byte-identical to
+# CRSP_MONTHLY_V2_QUERY so the names and the prices admit the same universe.
+CUSIP8_PERMNO_V2_QUERY = """
+SELECT DISTINCT cusip AS ncusip, permno, namedt, nameenddt AS nameendt
+FROM crsp.stocknames_v2
+WHERE cusip IS NOT NULL AND cusip != ''
+  AND sharetype = 'NS'
+  AND securitytype = 'EQTY'
+  AND securitysubtype = 'COM'
+  AND usincflg = 'Y'
+  AND COALESCE(nameenddt, '2099-12-31') >= %(v2_start)s
+"""
+
+# First date the CIZ names table owns. The legacy table's windows CLOSE on
+# LEGACY_NAMES_END, and 2024-12-31 is itself a 13F quarter-end, so a v2 window
+# clamped to the boundary rather than the day after would double-match Q4 2024
+# and reintroduce exactly the duplicate this file now asserts against.
+V2_NAMES_START = "2025-01-01"
 
 
 def pull_crsp_monthly(user: str, start: str, end: str) -> pl.DataFrame:
@@ -286,16 +346,50 @@ def pull_cusip8_permno_map(user: str) -> pl.DataFrame:
     t0 = time.time()
     conn = wrds_pull.connect(user=user)
     df = pd.read_sql(CUSIP8_PERMNO_QUERY, conn)
+    df2 = pd.read_sql(CUSIP8_PERMNO_V2_QUERY, conn,
+                      params={"v2_start": V2_NAMES_START})
     conn.close()
+    if len(df2):
+        # COLLAPSE TO ONE WINDOW PER (cusip, permno), THEN clamp. stocknames_v2
+        # carries a separate row per name segment, so clamping first and
+        # concatenating would hand the join several windows for the same pair,
+        # all starting on the same day — overlapping windows that fan a single
+        # holding into several rows. Collapsing to [min(namedt), max(nameenddt)]
+        # is safe because every segment resolves to the SAME permno, so widening
+        # within the pair cannot change which permno a cusip maps to.
+        df2["namedt"] = pd.to_datetime(df2["namedt"])
+        df2["nameendt"] = pd.to_datetime(df2["nameendt"])
+        df2 = (df2.groupby(["ncusip", "permno"], as_index=False)
+                  .agg(namedt=("namedt", "min"), nameendt=("nameendt", "max")))
+        df2["namedt"] = df2["namedt"].clip(lower=pd.Timestamp(V2_NAMES_START))
+        df = pd.concat([df, df2], ignore_index=True)
+    print(f"[cusip] {len(df2):,} CIZ name windows from {V2_NAMES_START} "
+          f"(crsp.msenames ends {LEGACY_NAMES_END})")
 
     cmap = pl.from_pandas(df).with_columns(
         pl.col("ncusip").cast(pl.Utf8),
         pl.col("permno").cast(pl.Int64),
+        # YYYYMMDD ints so the validity window compares directly against
+        # rdate_int without a date cast on 97M rows.
+        (pl.col("namedt").cast(pl.Date).dt.year().cast(pl.Int64) * 10000
+         + pl.col("namedt").cast(pl.Date).dt.month().cast(pl.Int64) * 100
+         + pl.col("namedt").cast(pl.Date).dt.day().cast(pl.Int64)
+         ).cast(pl.Int32).alias("namedt_int"),
+        pl.when(pl.col("nameendt").is_null())
+        .then(pl.lit(29991231, dtype=pl.Int32))
+        .otherwise(
+            (pl.col("nameendt").cast(pl.Date).dt.year().cast(pl.Int64) * 10000
+             + pl.col("nameendt").cast(pl.Date).dt.month().cast(pl.Int64) * 100
+             + pl.col("nameendt").cast(pl.Date).dt.day().cast(pl.Int64)
+             ).cast(pl.Int32)
+        ).alias("nameendt_int"),
     )
-    # A cusip8 may map to multiple permnos; keep all (dedup after join)
-    cmap = cmap.unique(subset=["ncusip", "permno"])
+    # A cusip8 may map to multiple permnos ACROSS TIME; the window is what
+    # separates them, so it is part of the key.
+    cmap = cmap.select(["ncusip", "permno", "namedt_int", "nameendt_int"]).unique()
     cmap.write_parquet(CUSIP_MAP_CACHE)
-    print(f"[cusip] {len(cmap):,} unique (ncusip, permno) pairs ({time.time() - t0:.1f}s)")
+    print(f"[cusip] {len(cmap):,} unique (ncusip, permno) pairs "
+          f"(max window end {cmap['nameendt_int'].max()}) ({time.time() - t0:.1f}s)")
     return cmap
 
 
@@ -306,23 +400,34 @@ def pull_cusip8_permno_map(user: str) -> pl.DataFrame:
 def load_13f_holdings(
     start_int: int, end_int: int, zero_value_shares_threshold: int | None = 100_000
 ) -> pl.DataFrame:
-    """Load 13F parser output, apply F1 (rdate snap) and F2 (amendment dedup)."""
+    """Load 13F parser output, apply F1 (rdate snap) and F2/F7 (amendment dedup).
+
+    LAZY END TO END, collected once with the streaming engine. This is a memory
+    constraint, not a style choice: the WRDS grid caps a job at 48 GB (cgroups),
+    and the eager version peaked at 106.5 GB maxrss and was killed there — it
+    only ever fit on a 251 GB workstation. Column projection alone (24 -> 8) took
+    it from 198.8 GB to 106.5 GB, which was enough locally and not enough on the
+    grid.
+
+    What made it eager was the DIAGNOSTICS, not the arithmetic. Every
+    `len(holdings)` between steps forced the full 153M-row frame to materialise
+    just to print a row count. They are now separate cheap `select(pl.len())`
+    collects against the lazy plan, so the counts still print and nothing is
+    held.
+
+    Deliberately NOT chunked by year. build_manager_markers uses
+    shift(1).over(cik_int) ACROSS quarters, so a year-chunked run would reset
+    every manager's first_report each January and silently corrupt DBREADTH —
+    a wrong number rather than a crash.
+    """
     print(f"[13f] loading holdings ({start_int} to {end_int})...")
     t0 = time.time()
 
-    # Project to the seven columns this function actually uses BEFORE collecting.
-    # The parquet has 24, including filepath and name_of_issuer — long strings
-    # that are never read here but dominate the in-memory footprint. Collecting
-    # all of them over the full 2003-2025 range peaked at 198.8 GB RSS and was
-    # OOM-killed (SIGKILL/137); the projection is what makes the full-range
-    # build fit. Deliberately NOT chunked by year: build_manager_markers uses
-    # shift(1).over(cik_int) across quarters, so a year-chunked run would reset
-    # every manager's first_report each January and silently corrupt DBREADTH.
     NEEDED = [
         "cik", "period_of_report", "filed_date",
         "form_type", "accession", "cusip8", "shares", "value",
     ]
-    holdings = (
+    lf = (
         pl.scan_parquet(str(PROC / "holdings_13f" / "year=*" / "Q*.parquet"))
         .select(NEEDED)
         .with_columns(
@@ -333,102 +438,110 @@ def load_13f_holdings(
         .filter(
             (pl.col("rdate_raw") >= start_int) & (pl.col("rdate_raw") <= end_int)
         )
-        .collect()
+        # F1: snap rdate to quarter-end
+        .with_columns(snap_to_quarter_end(pl.col("rdate_raw")).alias("rdate_int"))
+        .with_columns(
+            pl.col("form_type")
+            .replace_strict(FORM_PRIORITY, default=0)
+            .alias("form_priority")
+        )
     )
-    print(f"[13f] {len(holdings):,} raw rows ({time.time() - t0:.1f}s)")
 
-    # F1: snap rdate to quarter-end
-    holdings = holdings.with_columns(
-        snap_to_quarter_end(pl.col("rdate_raw")).alias("rdate_int")
-    )
+    def _n(frame: pl.LazyFrame) -> int:
+        """Row count without materialising the frame."""
+        return int(frame.select(pl.len()).collect(engine="streaming").item())
 
-    # F2+F7: filing-level dedup — one accession per (cik, rdate).
-    # F2 (v1) deduped at the (cik, cusip8, rdate) level, which could mix
-    # holdings from different accessions for the same manager-quarter.
-    # F7 selects the single best accession per (cik, rdate) — the latest
-    # filing supersedes all prior filings for that quarter.  This resolves
-    # ~130K share-mismatch rows from multi-accession double/triple-counting.
+    n_raw = _n(lf)
+    print(f"[13f] {n_raw:,} raw rows ({time.time() - t0:.1f}s)")
+
+    # Exclude filings >365 days after the reporting period.
+    lf = lf.filter((pl.col("fdate_int") - pl.col("rdate_int")) <= 10000)
+    n_recent = _n(lf)
+    print(f"[13f]   dropped {n_raw - n_recent:,} rows filed >~1yr after period")
+
+    # F2+F7: one accession per (cik, rdate) — the latest filing supersedes all
+    # earlier ones for that quarter. Resolves ~130K share-mismatch rows from
+    # multi-accession double counting.
+    #
+    # `sort_by(...).last()` INSIDE the aggregation rather than a global sort
+    # followed by group_by().last(). The old form relied on group_by preserving
+    # a prior sort, which polars does not guarantee and the streaming engine
+    # certainly does not — it happened to hold, which is not the same as being
+    # correct. This states the tie-break where it is applied:
+    # latest fdate -> highest form_priority -> latest accession string.
     print("[13f] deduplicating filings (F7: one accession per cik×rdate)...")
-    holdings = holdings.with_columns(
-        pl.col("form_type")
-        .replace_strict(FORM_PRIORITY, default=0)
-        .alias("form_priority")
-    )
-
-    # Exclude filings >365 days after reporting period
-    before = len(holdings)
-    holdings = holdings.filter(
-        (pl.col("fdate_int") - pl.col("rdate_int")) <= 10000
-    )
-    print(f"[13f]   dropped {before - len(holdings):,} rows filed >~1yr after period")
-
-    # Select best accession per (cik, rdate): latest fdate → highest
-    # form_priority (HR/A > HR) → latest accession string.
     best_filing = (
-        holdings
-        .select(["cik_int", "rdate_int", "fdate_int", "form_priority", "accession"])
+        lf.select(["cik_int", "rdate_int", "fdate_int", "form_priority", "accession"])
         .unique(subset=["cik_int", "rdate_int", "accession"])
-        .sort(["cik_int", "rdate_int", "fdate_int", "form_priority", "accession"])
         .group_by(["cik_int", "rdate_int"])
-        .last()
-        .select(["cik_int", "rdate_int", pl.col("accession").alias("best_acc")])
+        .agg(
+            pl.col("accession")
+            .sort_by(["fdate_int", "form_priority", "accession"])
+            .last()
+            .alias("best_acc")
+        )
     )
-    n_multi = best_filing.join(
-        holdings.select(["cik_int", "rdate_int", "accession"]).unique(),
-        on=["cik_int", "rdate_int"],
-    ).filter(pl.col("accession") != pl.col("best_acc")).select(
-        ["cik_int", "rdate_int"]
-    ).unique().height
+
+    n_multi = _n(
+        best_filing.join(
+            lf.select(["cik_int", "rdate_int", "accession"]).unique(),
+            on=["cik_int", "rdate_int"],
+        )
+        .filter(pl.col("accession") != pl.col("best_acc"))
+        .select(["cik_int", "rdate_int"])
+        .unique()
+    )
     print(f"[13f]   {n_multi:,} (cik, rdate) pairs had multiple accessions → kept latest")
 
-    holdings = holdings.join(
-        best_filing, on=["cik_int", "rdate_int"]
-    ).filter(
-        pl.col("accession") == pl.col("best_acc")
-    ).drop(["best_acc", "form_priority"])
-
-    print(f"[13f]   after dedup: {len(holdings):,} rows")
+    lf = (
+        lf.join(best_filing, on=["cik_int", "rdate_int"])
+        .filter(pl.col("accession") == pl.col("best_acc"))
+        .drop(["best_acc", "form_priority"])
+    )
+    n_dedup = _n(lf)
+    print(f"[13f]   after dedup: {n_dedup:,} rows")
 
     # D9: drop text-parser rows carrying value = 0 with a large share count.
     # `value` is reported in $1000s, so a genuine holding worth under $1,000
-    # cannot also carry 100,000 shares at any plausible price. These rows are
-    # parse failures, not holdings: AAPL 2003-09-30 was ONE such row (cik
-    # 728100, 719,257,141 shares, value 0) against a next-largest holder of
-    # 19.8M, and the same filer reports 3,038,253,827 shares of Exxon Mobil --
-    # more than Exxon's entire float.
+    # cannot also carry 100,000 shares at any plausible price. These are parse
+    # failures, not holdings: AAPL 2003-09-30 was ONE such row (cik 728100,
+    # 719,257,141 shares, value 0) against a next-largest holder of 19.8M, and
+    # the same filer reports 3,038,253,827 shares of Exxon Mobil — more than
+    # Exxon's entire float.
     #
-    # The threshold is load-bearing, not cosmetic. At T = 0 the rule removes
-    # 2,820,455 rows for the SAME 13.9% of share mass -- 33x the rows for no
-    # additional benefit -- because a legitimate sub-$1,000 holding rounds to
-    # value = 0 (median such row: 479 shares). T = 100,000 captures 99.9% of
-    # the bad mass at 3% of the row cost.
+    # The threshold is load-bearing. At T = 0 the rule removes 2,820,455 rows
+    # for the SAME 13.9% of share mass — 33x the rows for no extra benefit —
+    # because a legitimate sub-$1,000 holding rounds to value = 0 (median such
+    # row: 479 shares). T = 100,000 captures 99.9% of the bad mass at 3% of the
+    # row cost.
     #
-    # NOT WRDS's rule. The May 2017 note prescribes `if pct > 0.5 then pct =
-    # 0.5` -- a cap, not a repair, scoped to 2013+ and explicitly provisional
-    # ("further investigation is warranted"). Capping leaves a fabricated 50%
-    # holding standing, which is exactly the clipping that makes this defect
-    # invisible in vendor panels.
+    # NOT WRDS's rule. Their May 2017 note prescribes `if pct > 0.5 then
+    # pct = 0.5` — a cap, not a repair, scoped to 2013+ and explicitly
+    # provisional. Capping leaves a fabricated 50% holding standing, which is
+    # the clipping that makes this defect invisible in vendor panels.
     if zero_value_shares_threshold is not None:
-        before = len(holdings)
-        holdings = holdings.filter(
+        lf = lf.filter(
             ~((pl.col("value") == 0) & (pl.col("shares") > zero_value_shares_threshold))
         )
+        n_d9 = _n(lf)
         print(
-            f"[13f]   D9: dropped {before - len(holdings):,} rows with value=0 and "
+            f"[13f]   D9: dropped {n_dedup - n_d9:,} rows with value=0 and "
             f"shares>{zero_value_shares_threshold:,}"
         )
 
-    # Aggregate sub-managers to (cik, cusip8, rdate) level
+    # Aggregate sub-managers to (cik, cusip8, rdate). This is the one collect
+    # that produces the working frame, and it is the point of the whole lazy
+    # chain: ~97M aggregated rows instead of ~153M raw ones, with the wide
+    # string columns already dropped.
     agg = (
-        holdings
-        .group_by(["cik_int", "cusip8", "rdate_int"])
+        lf.group_by(["cik_int", "cusip8", "rdate_int"])
         .agg(pl.col("shares").sum().alias("shares"))
         .filter(pl.col("shares") > 0)
         # F6 safety net: drop concatenated value+shares (parser bug residual)
         .filter(pl.col("shares") < 10_000_000_000)
+        .with_columns(pl.col("cusip8").str.slice(0, 6).alias("cusip6"))
+        .collect(engine="streaming")
     )
-    # Derive cusip6 for fallback matching
-    agg = agg.with_columns(pl.col("cusip8").str.slice(0, 6).alias("cusip6"))
     print(f"[13f]   after aggregation: {len(agg):,} unique (cik, cusip, rdate)")
     return agg
 
@@ -486,6 +599,7 @@ def join_and_adjust(
     cusip6_map: pl.DataFrame,
     crsp_m: pl.DataFrame,
     use_cusip6_fallback: bool = True,
+    stats: dict | None = None,
 ) -> pl.DataFrame:
     """Map cusip8→permno (with cusip6 fallback), adjust shares by cfacshr, dedup.
 
@@ -493,13 +607,39 @@ def join_and_adjust(
     Fallback: cusip6 = ncusip[:6] for unmatched holdings (matches SAS
     build_meetings.sas line 236: substr(cusip,1,6)=substr(ncusip,1,6)).
     """
-    # Attach manager markers
-    h = holdings.join(mgr_markers, on=["cik_int", "rdate_int"], how="left")
+    # LAZY from here. The eager form peaked at 79.4 GB against the WRDS grid's
+    # 48 GB cgroup cap, and the RSS trace put the spike HERE, not in the load:
+    # the frame roughly doubles across the permno join and the cfacshr join.
+    h = holdings.lazy().join(mgr_markers.lazy(), on=["cik_int", "rdate_int"], how="left")
+
+    def _n(frame: pl.LazyFrame) -> int:
+        return int(frame.select(pl.len()).collect(engine="streaming").item())
 
     # Primary: CUSIP8 → PERMNO
-    matched8 = h.join(cusip_map, left_on="cusip8", right_on="ncusip", how="inner")
-    unmatched = h.join(cusip_map, left_on="cusip8", right_on="ncusip", how="anti")
-    print(f"[join] cusip8 match: {len(matched8):,}, unmatched: {len(unmatched):,}")
+    matched8 = (
+        h.join(cusip_map.lazy(), left_on="cusip8", right_on="ncusip", how="inner")
+        # The date window is the whole point of the dated map: keep only the
+        # permno this cusip belonged to AT the reporting date.
+        .filter(
+            (pl.col("rdate_int") >= pl.col("namedt_int"))
+            & (pl.col("rdate_int") <= pl.col("nameendt_int"))
+        )
+        .drop(["namedt_int", "nameendt_int"])
+    )
+
+    # The anti-join is only needed to FEED the fallback. Computing it
+    # unconditionally meant a second full pass over ~97M rows purely to print a
+    # number that, with the fallback off (the default since D9 cause 2), nothing
+    # then consumed.
+    if use_cusip6_fallback:
+        unmatched = h.join(
+            matched8.select(["cik_int", "rdate_int", "cusip8"]).unique(),
+            on=["cik_int", "rdate_int", "cusip8"], how="anti",
+        )
+        print(f"[join] cusip8 match: {_n(matched8):,}, unmatched: {_n(unmatched):,}")
+    else:
+        unmatched = None
+        print(f"[join] cusip8 match: {_n(matched8):,}")
 
     # Fallback: CUSIP6 → PERMNO for unmatched.
     #
@@ -577,43 +717,94 @@ def join_and_adjust(
     # net out securities lending or report robustness excluding high-SI
     # firm-quarters. Tracked, not solved here.
     if use_cusip6_fallback:
-        matched6 = unmatched.join(cusip6_map, on="cusip6", how="inner")
-        print(f"[join] cusip6 fallback: {len(matched6):,} recovered")
+        matched6 = unmatched.join(cusip6_map.lazy(), on="cusip6", how="inner")
+        _c6 = _n(matched6)
+        if stats is None:
+            print(f"[join] cusip6 fallback: {_c6:,} recovered")
+        else:
+            stats["m6"] = stats.get("m6", 0) + _c6
         h = pl.concat([matched8, matched6])
     else:
-        print(
-            f"[join] cusip6 fallback DISABLED — {len(unmatched):,} unmatched rows dropped "
-            f"(D9 cause 2: cusip6 maps other share classes/preferreds onto the common permno)"
-        )
+        if stats is None:
+            print(
+                "[join] cusip6 fallback DISABLED (D9 cause 2: cusip6 maps other share "
+                "classes/preferreds onto the common permno)"
+            )
         h = matched8
-    print(f"[join] after cusip→permno: {len(h):,} rows")
+    _cus = _n(h)
+    if stats is None:
+        print(f"[join] after cusip→permno: {_cus:,} rows")
+    else:
+        stats["after_cusip"] = stats.get("after_cusip", 0) + _cus
 
     # Join with CRSP for cfacshr at rdate (LEFT — keep holdings without CRSP;
     # default cfacshr=1 for permnos not in CRSP monthly panel, since the
     # canonical IOR is recomputed in merge_panel using ISS tso anyway)
     h = h.join(
-        crsp_m.select(["permno", "qdate_int", "cfacshr", "P"]),
+        crsp_m.lazy().select(["permno", "qdate_int", "cfacshr", "P"]),
         left_on=["permno", "rdate_int"],
         right_on=["permno", "qdate_int"],
         how="left",
     )
-    n_no_crsp = h.filter(pl.col("cfacshr").is_null()).shape[0]
+    # Both counts in ONE streaming pass. Two separate scans (a filtered .shape[0]
+    # then a len()) meant materialising the widest frame in the pipeline twice,
+    # which is where the 79.4 GB peak came from.
+    _stats = (
+        h.select(
+            pl.len().alias("n_rows"),
+            pl.col("cfacshr").is_null().sum().alias("n_no_crsp"),
+        )
+        .collect(engine="streaming")
+    )
+    n_rows, n_no_crsp = int(_stats["n_rows"][0]), int(_stats["n_no_crsp"][0])
     h = h.with_columns(
         pl.col("cfacshr").fill_null(1.0),
         pl.col("P").fill_null(0.0),
     )
-    print(f"[join] after crsp join: {len(h):,} rows ({n_no_crsp:,} without CRSP, cfacshr=1)")
+    if stats is None:
+        print(f"[join] after crsp join: {n_rows:,} rows ({n_no_crsp:,} without CRSP, cfacshr=1)")
+    else:
+        stats["after_crsp"] = stats.get("after_crsp", 0) + n_rows
+        stats["no_crsp"] = stats.get("no_crsp", 0) + n_no_crsp
 
     # Share adjustment (SAS line 117)
     h = h.with_columns(
         (pl.col("shares").cast(pl.Float64) * pl.col("cfacshr")).alias("shares_adj")
     )
 
-    # Dedup (permno, rdate, cik) — matches SAS sort nodupkey
-    h = h.sort(["permno", "rdate_int", "cik_int"]).unique(
-        subset=["permno", "rdate_int", "cik_int"], keep="first"
+    # (permno, rdate, cik) must already be unique — ASSERT it, do not dedup it.
+    #
+    # This used to be `.sort([...]).unique(subset=[...], keep="first")`, sorting
+    # on EXACTLY the dedup key, which leaves ties in arbitrary order and picked
+    # a survivor by coin flip. It had ties to resolve only because the undated
+    # cusip->permno map manufactured them: 8,804 groups in 2018-2022, 44.5% with
+    # a second position over half the size of the first. With the dated join the
+    # duplicates are gone at source and this removes zero rows.
+    #
+    # So keeping a silent dedup here would only hide the NEXT thing that
+    # reintroduces duplicates. Assert instead: cheap (a group-by count rather
+    # than a full sort of 86M rows, which was the memory peak), and a future
+    # regression fails loudly instead of resolving itself at random.
+    h = h.collect(engine="streaming")
+    n_dup = (
+        h.group_by(["permno", "rdate_int", "cik_int"])
+        .len()
+        .filter(pl.col("len") > 1)
+        .height
     )
-    print(f"[join] after dedup: {len(h):,} rows")
+    if n_dup:
+        raise ValueError(
+            f"{n_dup:,} (permno, rdate, cik) groups carry multiple rows. That key "
+            "must be unique before aggregation. The historical cause was an "
+            "undated cusip->permno join mapping a superseded CUSIP onto the "
+            "successor's permno; check the namedt/nameendt window before "
+            "reaching for a dedup, because a dedup here picks a survivor at "
+            "random."
+        )
+    if stats is None:
+        print(f"[join] {len(h):,} rows, (permno, rdate, cik) unique — asserted, not deduped")
+    else:
+        stats["final"] = stats.get("final", 0) + len(h)
     return h
 
 
@@ -621,20 +812,130 @@ def join_and_adjust(
 # Step 4: IO metrics
 # ---------------------------------------------------------------------------
 
-def compute_io_metrics(holdings: pl.DataFrame) -> pl.DataFrame:
-    """Aggregate to permno-quarter level: NumOwners, IO_TOTAL, HHI, DBREADTH.
+def io_partial(holdings: pl.DataFrame) -> pl.DataFrame:
+    """Per-(permno, rdate) aggregate half of compute_io_metrics.
 
-    Matches SAS build_inst_own.sas lines 126-148.
+    Year-safe: every key contains rdate_int and every aggregate is a within-cell
+    sum/max/n_unique. The part that is NOT year-safe — the DBREADTH lag — lives
+    in finalize_io_metrics and runs once over the whole panel.
     """
     h = holdings.filter(pl.col("shares_adj") > 0)
-
-    io = h.group_by(["permno", "rdate_int"]).agg(
+    return h.group_by(["permno", "rdate_int"]).agg(
         pl.col("cik_int").n_unique().alias("numowners"),
         pl.col("NumInst").max().alias("NumInst"),
         pl.col("first_report").sum().alias("NewInst"),
         pl.col("last_report").sum().alias("OldInst"),
         pl.col("shares_adj").sum().alias("io_total"),
         (pl.col("shares_adj") ** 2).sum().alias("io_ss"),
+    )
+
+
+def join_adjust_and_aggregate(
+    holdings: pl.DataFrame,
+    mgr_markers: pl.DataFrame,
+    cusip_map: pl.DataFrame,
+    cusip6_map: pl.DataFrame,
+    crsp_m: pl.DataFrame,
+    use_cusip6_fallback: bool = True,
+) -> pl.DataFrame:
+    """join_and_adjust + io_partial, ONE REPORTING YEAR AT A TIME.
+
+    The RSS trace peaks at the end of join_and_adjust, not in the load: the 86M
+    x ~12 joined frame is materialised in full and nothing downstream needs it —
+    compute_io_metrics immediately reduces it to ~675K permno-quarter rows. Going
+    lazy end-to-end took the leg 106.5 -> 79.4 -> ~51 GB, still over the grid's
+    48 GB cgroup cap. Slicing the join by year removes the peak instead of
+    shrinking it: only ~1/23 of the joined frame exists at once, and what
+    accumulates is the aggregate.
+
+    Exact, for the same reason the loader's per-year pass is: every lookup joined
+    in is small and global (cusip_map, cusip6_map, crsp_m, mgr_markers — all
+    built over the WHOLE panel and passed in whole), and the only grouped
+    operations key on (permno, rdate_int, ...) with rdate_int in the key, so no
+    group straddles a year boundary. mgr_markers in particular carries the
+    cross-quarter shift(1).over(cik_int) and is computed by the CALLER before
+    this runs — the chunking never sees it.
+    """
+    years = sorted(
+        holdings.select((pl.col("rdate_int") // 10000).alias("y"))
+        .unique()["y"].to_list()
+    )
+    stats: dict = {}
+    parts: list[pl.DataFrame] = []
+    for y in years:
+        hy = holdings.filter((pl.col("rdate_int") // 10000) == y)
+        j = join_and_adjust(
+            hy, mgr_markers, cusip_map, cusip6_map, crsp_m,
+            use_cusip6_fallback, stats=stats,
+        )
+        # A year that resolves NOTHING is the shape of a frozen reference table,
+        # not of thin data: crsp.msenames ending 2024-12-31 gave 2025 exactly
+        # this — 0 matches and a full year of null ownership that still looked
+        # like a complete panel. Cheap to check here because the chunking
+        # already gives per-year counts.
+        if j.height == 0:
+            raise ValueError(
+                f"reporting year {y} resolved 0 rows through cusip8->permno. "
+                f"A whole year matching nothing means the reference window does "
+                f"not cover it — check that the cusip map extends past "
+                f"{LEGACY_NAMES_END} (crsp.msenames freezes there; "
+                f"crsp.stocknames_v2 continues)."
+            )
+        parts.append(io_partial(j))
+        del hy, j
+
+    if use_cusip6_fallback:
+        print(f"[join] cusip6 fallback: {stats.get('m6', 0):,} recovered")
+    else:
+        print("[join] cusip6 fallback DISABLED (D9 cause 2: cusip6 maps other share "
+              "classes/preferreds onto the common permno)")
+    print(f"[join] after cusip→permno: {stats.get('after_cusip', 0):,} rows")
+    print(f"[join] after crsp join: {stats.get('after_crsp', 0):,} rows "
+          f"({stats.get('no_crsp', 0):,} without CRSP, cfacshr=1)")
+    print(f"[join] {stats.get('final', 0):,} rows, (permno, rdate, cik) unique — "
+          f"asserted, not deduped, over {len(years)} reporting years")
+
+    out = pl.concat(parts, how="vertical")
+
+    # THE PER-CHUNK UNIQUENESS ASSERTION IS ONLY AS GOOD AS THE CHUNK BOUNDARY.
+    # join_and_adjust asserts (permno, rdate_int, cik_int) uniqueness inside each
+    # year, which is equivalent to asserting it globally ONLY BECAUSE the chunk
+    # key (rdate_int // 10000) is a function of rdate_int, which is itself part
+    # of the assertion key — so two rows sharing that key necessarily share a
+    # chunk and cannot slip past by straddling one.
+    #
+    # That is an argument, and finalize_io_metrics re-groups by
+    # (permno, rdate_int), which would SILENTLY SUM a leak rather than fail. So
+    # check the argument instead of trusting it: after concatenation each
+    # (permno, rdate_int) must appear exactly once. Cheap — this frame is ~675K
+    # rows, not 91M.
+    leaked = out.height - out.select(["permno", "rdate_int"]).unique().height
+    if leaked:
+        raise ValueError(
+            f"{leaked:,} (permno, rdate_int) keys appear in more than one year "
+            f"chunk. The per-year uniqueness assertion is therefore not "
+            f"equivalent to a global one, and finalize_io_metrics would sum the "
+            f"duplicates silently. Chunking must partition on a function of "
+            f"rdate_int for that equivalence to hold."
+        )
+    return out
+
+
+def finalize_io_metrics(io: pl.DataFrame) -> pl.DataFrame:
+    """HHI + DBREADTH over the WHOLE permno-quarter panel.
+
+    Must not be chunked: the DBREADTH lag is shift(1).over(permno) across
+    quarters, so a per-year pass would make every January look like a permno's
+    first observation. Safe here because io_partial has already collapsed the
+    panel to ~675K rows.
+    """
+    io = io.group_by(["permno", "rdate_int"]).agg(
+        pl.col("numowners").sum().alias("numowners"),
+        pl.col("NumInst").max().alias("NumInst"),
+        pl.col("NewInst").sum().alias("NewInst"),
+        pl.col("OldInst").sum().alias("OldInst"),
+        pl.col("io_total").sum().alias("io_total"),
+        pl.col("io_ss").sum().alias("io_ss"),
     )
 
     # HHI
@@ -660,14 +961,65 @@ def compute_io_metrics(holdings: pl.DataFrame) -> pl.DataFrame:
         .alias("dbreadth")
     )
 
-    return io.select([
+    io = io.select([
         "permno", "rdate_int", "numowners", "io_total", "ioc_hhi", "dbreadth",
     ])
+    # The one collect for this stage: the aggregate, not the 86M-row input.
+    return io.collect(engine="streaming") if isinstance(io, pl.LazyFrame) else io
 
 
 # ---------------------------------------------------------------------------
 # Step 5: Final panel
 # ---------------------------------------------------------------------------
+
+def _assert_no_dead_tail(panel: pl.DataFrame, col: str = "io_total",
+                         null_threshold: float = 0.99, min_periods: int = 1) -> None:
+    """Fail if `col` is (near-)entirely null for a contiguous TAIL of quarters.
+
+    THIS GUARD EXISTS BECAUSE I BUILT ITS DETECTOR AND THEN SHIPPED THE BUG IT
+    DETECTS. crsp.msf is frozen at 2024-12-31, which silently nulled every 2025
+    quarter; that was found, fixed by splicing msf_v2, and generalised into
+    `detect_join_coverage_tail` in the wrds skill. Then the dated cusip->permno
+    join reintroduced exactly the same failure through a DIFFERENT frozen table:
+    crsp.msenames also stops at 2024-12-31 and has ZERO null nameendt, so every
+    validity window closes there and `rdate <= nameendt` dropped all of 2025 —
+    0 cusip8 matches, io_total null for all 15,546 rows. Fixed by splicing
+    crsp.stocknames_v2.
+
+    A detector that lives in a test suite catches nothing at build time. So the
+    check runs HERE, on the output, where it is blind to which upstream table
+    froze — which is the point: the next frozen reference table will be a third
+    one nobody has looked at.
+
+    Deliberately silent when the column is null in EVERY period: that is a
+    reference table never joined at all, a different defect, and reporting it
+    here would bury this one.
+    """
+    per = (
+        panel.group_by("rdate")
+        .agg(pl.col(col).is_null().mean().alias("null_rate"))
+        .sort("rdate")
+    )
+    rates = list(zip(per["rdate"].to_list(), per["null_rate"].to_list()))
+    tail = []
+    for rdate, rate in reversed(rates):
+        if rate >= null_threshold:
+            tail.append(rdate)
+        else:
+            break
+    if len(tail) >= min_periods and len(tail) < len(rates):
+        tail.reverse()
+        raise ValueError(
+            f"{col} is null for >={null_threshold:.0%} of rows in the last "
+            f"{len(tail)} quarter(s) ({tail[0]}..{tail[-1]}) but not before. A "
+            f"reference table is frozen while the holdings kept going. Known "
+            f"culprits, both already spliced once: crsp.msf (-> msf_v2) and "
+            f"crsp.msenames (-> stocknames_v2, which also has ZERO null "
+            f"nameendt, so every window closes at its last date). Extend the "
+            f"source or lower --end deliberately."
+        )
+    print(f"[guard] no dead tail in {col} — checked {len(rates)} quarters")
+
 
 def build_final_panel(
     io_metrics: pl.DataFrame, crsp_m: pl.DataFrame
@@ -945,14 +1297,18 @@ def main():
     # Step 2: manager entry/exit markers
     mgr_markers = build_manager_markers(holdings)
 
-    # Step 3: join and adjust
-    adjusted = join_and_adjust(
+    # Step 3 + 4a: join, adjust and aggregate to permno-quarter, one reporting
+    # year at a time. mgr_markers is built above over the WHOLE panel and passed
+    # in whole, so the cross-quarter window it carries is untouched by chunking.
+    io_parts = join_adjust_and_aggregate(
         holdings, mgr_markers, cusip_map, cusip6_map, crsp_m,
         use_cusip6_fallback=args.cusip6_fallback,
     )
+    del holdings
 
-    # Step 4: IO metrics
-    io_metrics = compute_io_metrics(adjusted)
+    # Step 4b: HHI + DBREADTH over the whole panel (the lag must see every
+    # quarter in sequence).
+    io_metrics = finalize_io_metrics(io_parts)
     print(f"[io] {len(io_metrics):,} permno-quarter IO observations")
 
     # Step 5: final panel
@@ -960,6 +1316,7 @@ def main():
     print(f"[panel] {len(panel):,} rows in final panel")
 
     # Step 5b: D1 split-adjacent flags, then net securities lending out
+    _assert_no_dead_tail(panel, "io_total")
     panel = add_split_flags(panel, crsp_m)
     panel = add_net_of_lending(panel)
 
@@ -979,20 +1336,42 @@ def main():
     print(f"[out] wrote {out_path} ({len(panel):,} rows)")
 
     if not args.no_sas:
-        sas_path = out_path.with_suffix(".xpt")
-        # pyreadstat writes SAS transport (xport) format; no sas7bdat writer
-        pdf = panel.to_pandas()
-        pdf["rdate"] = pd.to_datetime(pdf["rdate"].astype(str), format="%Y%m%d")
-        # xport has 8-char column name limit — truncate
-        col_map = {
-            "numowners": "NUMOWN", "io_total": "IO_TOT", "ioc_hhi": "IOC_HHI",
-            "dbreadth": "DBREADTH", "io_missing": "IO_MISS", "io_g1": "IO_G1",
-            "cfacshr": "CFACSHR", "permno": "PERMNO", "rdate": "RDATE",
-            "ior": "IOR", "tso": "TSO", "me": "ME", "p": "P",
-        }
-        pdf = pdf.rename(columns=col_map)
-        pyreadstat.write_xport(pdf, str(sas_path))
-        print(f"[out] wrote {sas_path}")
+        # SAS-facing handoff for import_inst_own.sas, which lands out.inst_own
+        # for merge_panel. THE COLUMN ORDER BELOW IS THE INTERFACE — the SAS side
+        # reads positionally and verifies this header, so change the two together.
+        #
+        # NOT xport, which is what this wrote before and why leg 2's output never
+        # reached merge_panel at all. Two independent failures:
+        #   1. SAS 9.4 rejects pyreadstat's file outright — `libname xin xport`
+        #      then `set xin.dataset` gives
+        #      "ERROR: File XIN.DATASET.DATA is not a SAS data set."
+        #   2. xport's 8-char limit forced a rename map turning `numowners` into
+        #      NUMOWN and `io_total` into IO_TOT — exactly the names
+        #      merge_panel's MERGE_ASOF(num_vars=...) asks for — and it covered
+        #      only 13 of the 22 columns.
+        # CSV keeps full names, and polars writes shortest-roundtrip floats, so
+        # SAS's best32. informat reads back bit-identical doubles.
+        SAS_COLUMNS = [
+            "permno", "rdate", "numowners", "io_total", "ioc_hhi", "dbreadth",
+            "ior", "tso", "me", "p", "cfacshr", "io_missing", "io_g1",
+            "split_quarter", "split_adjacent", "shortint", "si_missing",
+            "shortint_adj", "io_total_net", "si_frac", "ior_net", "net_clamped",
+        ]
+        missing = [c for c in SAS_COLUMNS if c not in panel.columns]
+        extra = [c for c in panel.columns if c not in SAS_COLUMNS]
+        if missing or extra:
+            raise ValueError(
+                f"SAS_COLUMNS is out of sync with the panel — missing {missing}, "
+                f"unexpected {extra}. Update it and import_inst_own.sas together."
+            )
+        csv_path = out_path.with_suffix(".csv")
+        sas_out = panel.select(SAS_COLUMNS).with_columns(
+            # SAS has no boolean; emit 0/1 not the strings "true"/"false"
+            [pl.col(c).cast(pl.Int8)
+             for c, t in panel.schema.items() if t == pl.Boolean]
+        )
+        sas_out.write_csv(csv_path)
+        print(f"[out] wrote {csv_path} ({len(sas_out):,} rows) → import_inst_own.sas")
 
     print(f"[done] total time: {time.time() - t_start:.1f}s")
 

--- a/skills/npx-ownership-panel/scripts/build_short_interest.py
+++ b/skills/npx-ownership-panel/scripts/build_short_interest.py
@@ -78,6 +78,24 @@ WHERE a.datadate BETWEEN %(start)s AND %(end)s
   AND a.shortint IS NOT NULL
 """
 
+# Denominator for the units check below. Deliberately its own small query rather
+# than a read of leg 2's crsp_monthly_13f.parquet cache: leg 5 runs BEFORE leg 2
+# in the DAG (leg 2 consumes short_interest), so that cache does not exist on any
+# cold start and the check that depended on it silently did nothing — see the
+# comment at the call site. Quarter-end months only, so this stays small.
+TSO_CHECK_QUERY = """
+SELECT a.permno, a.date, a.shrout, a.cfacshr
+FROM crsp.msf a
+INNER JOIN crsp.msenames b
+  ON a.permno = b.permno
+  AND b.namedt <= a.date
+  AND a.date <= COALESCE(b.nameendt, '2099-12-31')
+WHERE b.shrcd IN (10, 11)
+  AND a.date BETWEEN %(start)s AND %(end)s
+  AND a.shrout IS NOT NULL
+  AND EXTRACT(MONTH FROM a.date) IN (3, 6, 9, 12)
+"""
+
 
 def snap_to_quarter_end(d: pl.Expr) -> pl.Expr:
     """Quarter-end YYYYMMDD int for a date column.
@@ -140,36 +158,70 @@ def main() -> None:
             f"short interest covers quarter-end months {months}, expected [3, 6, 9, 12]"
         )
 
-    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
-    si.select(["permno", "rdate", "si_datadate", "shortint"]).write_parquet(args.out)
-    print(f"[si] wrote {args.out}")
-
     # Units sanity check. `shortint` must be in SHARES to be subtractable from
     # io_total. If Compustat ever reported it in thousands, median SI/TSO would come
     # out near 0.00x% rather than the ~1-2% every published short-interest study finds,
     # and the netting would quietly do nothing. Fail loudly rather than silently
     # subtract a rounding error.
+    #
+    # THIS RUNS UNCONDITIONALLY AND BEFORE THE WRITE, and both matter. It used to be
+    # wrapped in `if crsp_monthly_13f.parquet exists`, reading leg 2's cache — but
+    # leg 5 runs BEFORE leg 2 in the DAG (leg 2 consumes short_interest), so on a
+    # cold start that cache never exists and the check silently no-opped. Verified:
+    # the 2026-07-26 cold run's leg 5 log contains no "units check" line at all. A
+    # guard that only fires on a warm re-run is not a guard. It also sat AFTER the
+    # write, so a bad file landed on disk before anything was validated.
     crsp_cache = PROC / "crsp_monthly_13f.parquet"
     if crsp_cache.exists():
         crsp = pl.read_parquet(crsp_cache).select(
             ["permno", "qdate_int", "TSO", "cfacshr"]
         )
-        chk = (
-            si.join(crsp, left_on=["permno", "rdate"], right_on=["permno", "qdate_int"])
-            .filter(pl.col("TSO") > 0)
-            .with_columns(
-                (pl.col("shortint") * pl.col("cfacshr") / pl.col("TSO")).alias("si_frac")
-            )
+        src = "leg-2 cache"
+    else:
+        cdf = pd.read_sql(
+            TSO_CHECK_QUERY, wrds_pull.connect(user=args.user),
+            params={"start": args.start, "end": args.end},
         )
-        med = chk.select(pl.col("si_frac").median()).item()
-        p99 = chk.select(pl.col("si_frac").quantile(0.99)).item()
-        print(f"[si] units check: median SI/TSO = {med:.4%}, p99 = {p99:.2%}, n={len(chk):,}")
-        if not (0.001 < med < 0.15):
-            raise ValueError(
-                f"median SI/TSO = {med:.6%} is outside the plausible 0.1%-15% band. "
-                "`shortint` is probably not in shares, or the cfacshr basis is wrong. "
-                "Refusing to publish a netting input that would silently do nothing."
+        crsp = (
+            pl.from_pandas(cdf)
+            .with_columns(
+                pl.col("permno").cast(pl.Int64),
+                pl.col("date").cast(pl.Date),
+                (pl.col("shrout").cast(pl.Float64) * 1000).alias("TSO"),
+                pl.col("cfacshr").cast(pl.Float64),
             )
+            .with_columns(snap_to_quarter_end(pl.col("date")).alias("qdate_int"))
+            .select(["permno", "qdate_int", "TSO", "cfacshr"])
+            .unique(subset=["permno", "qdate_int"], keep="first", maintain_order=True)
+        )
+        src = "direct CRSP pull"
+
+    chk = (
+        si.join(crsp, left_on=["permno", "rdate"], right_on=["permno", "qdate_int"])
+        .filter(pl.col("TSO") > 0)
+        .with_columns(
+            (pl.col("shortint") * pl.col("cfacshr") / pl.col("TSO")).alias("si_frac")
+        )
+    )
+    if chk.is_empty():
+        raise ValueError(
+            "units check joined 0 rows against CRSP — cannot validate that "
+            "`shortint` is in shares. Refusing to publish an unvalidated netting input."
+        )
+    med = chk.select(pl.col("si_frac").median()).item()
+    p99 = chk.select(pl.col("si_frac").quantile(0.99)).item()
+    print(f"[si] units check ({src}): median SI/TSO = {med:.4%}, "
+          f"p99 = {p99:.2%}, n={len(chk):,}")
+    if not (0.001 < med < 0.15):
+        raise ValueError(
+            f"median SI/TSO = {med:.6%} is outside the plausible 0.1%-15% band. "
+            "`shortint` is probably not in shares, or the cfacshr basis is wrong. "
+            "Refusing to publish a netting input that would silently do nothing."
+        )
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    si.select(["permno", "rdate", "si_datadate", "shortint"]).write_parquet(args.out)
+    print(f"[si] wrote {args.out}")
 
     print(f"[done] {time.time() - t0:.1f}s")
 

--- a/skills/npx-ownership-panel/scripts/canonical_dump.sas
+++ b/skills/npx-ownership-panel/scripts/canonical_dump.sas
@@ -1,0 +1,106 @@
+/* canonical_dump.sas — emit a SAS dataset as a canonical CSV for byte-identity checks.
+ *
+ * WHY: the pipeline's output (out.pass_npx) lives on the WRDS grid as a
+ * sas7bdat. canonical_hash.py reads parquet/CSV locally. This is the bridge:
+ * it writes a deterministic CSV that canonical_hash.py can digest, so a leg
+ * rewritten on the grid can be proven identical to its frozen baseline WITHOUT
+ * shipping the whole dataset down and WITHOUT trusting sas7bdat bytes (which
+ * embed timestamps and page layout and differ between identical runs).
+ *
+ * THE THREE THINGS THAT MAKE IT CANONICAL, each of which is a real failure mode:
+ *
+ *   1. SORT. SGE array tasks finish out of order, so the physical row order of a
+ *      stacked result is nondeterministic. Sorting on a declared total key is
+ *      what makes two runs comparable at all.
+ *   2. FIXED NUMERIC FORMAT. SAS BEST. format emits shortest-round-trip, which
+ *      changes with the value. A weighted fraction computed via PostgreSQL and
+ *      the same fraction computed in a datastep can differ one ULP and print
+ *      differently under BEST. — that is not a data change and must not fail the
+ *      test. &PREC significant digits (default 12) is the tolerance.
+ *   3. MISSING RENDERED EXPLICITLY. SAS missing prints as "." for numerics and
+ *      "" for character, so a null numeric and the string "." are
+ *      indistinguishable downstream. Both become empty here, matching what
+ *      canonical_hash.py does on the python side.
+ *
+ * USAGE
+ *   %include "canonical_dump.sas";
+ *   %canonical_dump(data=out.pass_npx, by=itemonagendaid block,
+ *                   out=/scratch/nyu/hue/pass_npx_canon.csv);
+ * then locally:
+ *   scp wrds:/scratch/.../pass_npx_canon.csv .
+ *   python canonical_hash.py pass_npx_canon.csv --keys itemonagendaid,block
+ *
+ * The digest must equal the frozen baseline. Column ORDER does not matter --
+ * canonical_hash.py sorts columns itself -- but the column SET does.
+ */
+
+%macro canonical_dump(data=, by=, out=, prec=12);
+
+    %if %superq(data)= or %superq(by)= or %superq(out)= %then %do;
+        %put ERROR: canonical_dump requires data=, by= and out=;
+        %return;
+    %end;
+
+    /* --- 1. total order on the declared key ------------------------------- */
+    proc sort data=&data. out=_cd_sorted;
+        by &by.;
+    run;
+
+    /* --- 2. discover the schema so numeric/char are handled separately ----- */
+    proc contents data=_cd_sorted out=_cd_vars(keep=name type varnum format) noprint; run;
+    proc sort data=_cd_vars; by varnum; run;
+
+    data _null_;
+        set _cd_vars end=eof;
+        length hdr $32767 num $32767 chr $32767;
+        retain hdr num chr "";
+        hdr = catx(",", hdr, lowcase(name));
+        /* (P) Only numerics WITHOUT a date/time/datetime format get best&prec.
+         * A blanket format clobbers them: meetingdate rendered as 15768 (raw SAS
+         * days) instead of a date, which is deterministic but makes the dump
+         * incomparable to a parquet baseline holding real dates. Caught on the
+         * first grid test. Date-formatted numerics keep their own format. */
+        if type = 1 and not (upcase(format) in
+              ("DATE" "YYMMDD" "MMDDYY" "DDMMYY" "DATETIME" "TIME" "MONYY" "YYMMDDN"))
+            then num = catx(" ", num, name);
+        else             chr = catx(" ", chr, name);
+        if eof then do;
+            call symputx("_CD_HDR", hdr);
+            call symputx("_CD_NUM", num);
+            call symputx("_CD_CHR", chr);
+        end;
+    run;
+
+    /* --- 3. write it, rendering every value to a stable string ---------- */
+    /* One data step, not PROC EXPORT. EXPORT does not reliably honour an
+     * attached FORMAT for csv output, so an earlier draft of this macro applied
+     * best&prec. and still emitted default-formatted numbers -- the fixed
+     * precision silently did nothing. A PUT with DSD is explicit:
+     *   - FORMAT is honoured, so numerics render at &prec sig digits
+     *   - DSD writes an EMPTY field for a SAS missing, not "." — matching what
+     *     canonical_hash.py emits for null on the python side
+     *   - DSD quotes any value containing the delimiter, so an embedded comma
+     *     in a fund name cannot shift every downstream column
+     */
+    data _null_;
+        set _cd_sorted;
+        %if %superq(_CD_NUM) ne %then %do;
+            format &_CD_NUM. best&prec..;
+        %end;
+        /* dequote: the macro must work whether the caller writes
+         *   out=/scratch/x.csv      or   out="/scratch/x.csv"
+         * Without this, a quoted path expands to ""/scratch/x.csv"" and SAS
+         * parses the path fragments as FILE options ("Invalid option name
+         * SCRATCH"). Caught on the first grid test of this macro. */
+        file "%sysfunc(dequote(&out.))" dsd dlm="," lrecl=32767;
+        if _n_ = 1 then put "&_CD_HDR.";
+        put (_all_) (~);
+    run;
+
+    proc datasets lib=work nolist nowarn;
+        delete _cd_sorted _cd_vars;
+    quit;
+
+    %put NOTE: canonical_dump wrote %sysfunc(dequote(&out.)) sorted by (&by.) at &prec. sig digits;
+
+%mend canonical_dump;

--- a/skills/npx-ownership-panel/scripts/canonical_hash.py
+++ b/skills/npx-ownership-panel/scripts/canonical_hash.py
@@ -1,0 +1,186 @@
+"""Canonical content hash — the byte-identity primitive for pipeline refactors.
+
+WHY THIS EXISTS. When you rewrite a pipeline leg (PostgreSQL -> native SAS,
+sequential -> SGE array) the requirement is that the DATA is unchanged. The naive
+test -- diff the output files -- does not work: parquet and sas7bdat embed
+creation timestamps, compression state and page layout, so two runs of the SAME
+unmodified code produce different bytes. Chasing that burns hours proving nothing.
+
+What IS meaningful, and what this computes:
+
+    canonical sort  ->  fixed numeric formatting  ->  sha256
+
+Any two datasets with the same content produce the same digest regardless of row
+order, column order, file format, or which engine wrote them. That is the claim
+worth making, and "the canonical dump is byte-identical" is the honest phrasing
+of it -- not "the files are identical", which will not be true and does not matter.
+
+THE FIXED FORMATTING IS THE LOAD-BEARING PART. `repr(float)` differs across
+platforms and library versions, and a weighted mean computed via PostgreSQL's
+numeric path can land one ULP away from the same mean computed in a SAS datastep.
+Both are "the same number" and neither is wrong. So floats are emitted at a
+declared precision (default 12 significant digits, ~1e-12 relative) rather than
+full repr. If a refactor moves a value by more than that, you want to know; if it
+moves it by less, you do not.
+
+DIAGNOSIS, NOT JUST A VERDICT. A bare hash mismatch tells you nothing about where
+the divergence is, and on a 2M-row table that is a miserable place to start. So
+this also emits row count, per-group counts, and per-column sums/nulls/min/max --
+compare those first and the mismatch usually localises to one column immediately.
+
+Usage:
+    python canonical_hash.py FILE [--keys k1,k2] [--group block] [--precision 12]
+    python canonical_hash.py a.parquet b.parquet --keys itemonagendaid,block   # compare two
+
+Exit code is 1 on comparison mismatch, so it works as a gate in a shell script.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import polars as pl
+
+DEFAULT_PRECISION = 12
+
+
+def _load(path: Path) -> pl.DataFrame:
+    p = str(path)
+    if p.endswith((".parquet", ".pq")):
+        return pl.read_parquet(p)
+    if p.endswith((".csv", ".csv.gz", ".txt")):
+        try:
+            return pl.read_csv(p)
+        except Exception:
+            # (P) A CSV produced by canonical_dump.sas is ALREADY canonicalised —
+            # every field is a stable string and "." may appear as a literal.
+            # Type inference on it is both unnecessary and fragile (polars raises
+            # "invalid primitive value" on the mixed column). Read it verbatim:
+            # re-canonicalising an already-canonical value is a no-op, whereas
+            # guessing its type can change it.
+            return pl.read_csv(p, infer_schema=False)
+    raise SystemExit(f"unsupported format: {path} (parquet or csv)")
+
+
+def canonical_frame(d: pl.DataFrame, keys: list[str] | None, precision: int) -> pl.DataFrame:
+    """Sort deterministically and render every value to a stable string."""
+    cols = sorted(d.columns)                      # column ORDER must not matter
+    d = d.select(cols)
+
+    sort_by = keys or cols                        # no keys -> total order on all columns
+    missing = [k for k in sort_by if k not in d.columns]
+    if missing:
+        raise SystemExit(f"sort keys not in data: {missing}")
+    # nulls_last makes the order total even when a key is null
+    d = d.sort(sort_by, nulls_last=True)
+
+    out = {}
+    for c in cols:
+        s = d[c]
+        if s.dtype in (pl.Float32, pl.Float64):
+            # (P) fixed significant digits, NOT repr(). See module docstring: a
+            # PG numeric path and a SAS datastep can differ by an ULP on the same
+            # true value, and that is not a data change.
+            # (P) skip_nulls=False is REQUIRED: polars' map_elements skips nulls by
+            # default, so the lambda never sees them and None survives into the
+            # hash, where .encode() dies. NaN and null must both render "".
+            out[c] = s.map_elements(
+                lambda v, _p=precision: "" if v is None or v != v else f"{v:.{_p}g}",
+                return_dtype=pl.String, skip_nulls=False,
+            ).fill_null("")
+        elif s.dtype == pl.Boolean:
+            out[c] = s.map_elements(lambda v: "" if v is None else ("1" if v else "0"),
+                                    return_dtype=pl.String, skip_nulls=False).fill_null("")
+        else:
+            out[c] = s.cast(pl.String, strict=False).fill_null("")
+    return pl.DataFrame(out)
+
+
+def digest(d: pl.DataFrame, keys, precision, group: str | None) -> dict:
+    canon = canonical_frame(d, keys, precision)
+    h = hashlib.sha256()
+    for c in canon.columns:                       # column-major: stable, no row assembly
+        h.update(c.encode())
+        h.update(b"\x1e")
+        h.update(b"\x1f".join(v.encode() for v in canon[c]))
+        h.update(b"\x1d")
+
+    prof = {}
+    for c in sorted(d.columns):
+        s = d[c]
+        e = {"nulls": int(s.null_count())}
+        if s.dtype.is_numeric():
+            e["sum"] = float(s.sum()) if s.len() else 0.0
+            e["min"] = None if s.null_count() == s.len() else float(s.min())
+            e["max"] = None if s.null_count() == s.len() else float(s.max())
+        else:
+            e["n_unique"] = int(s.n_unique())
+        prof[c] = e
+
+    res = {"rows": d.height, "cols": d.width, "sha256": h.hexdigest(),
+           "precision": precision, "sort_keys": keys or "ALL", "columns": prof}
+    if group and group in d.columns:
+        res["groups"] = {str(r[0]): int(r[1]) for r in
+                         d.group_by(group).len().sort(group).rows()}
+    return res
+
+
+def report_diff(a: dict, b: dict) -> None:
+    """Localise a mismatch instead of just declaring one."""
+    print("\n--- WHERE THEY DIVERGE ---")
+    if a["rows"] != b["rows"]:
+        print(f"  ROW COUNT  {a['rows']:,} vs {b['rows']:,}  (delta {b['rows']-a['rows']:+,})")
+    if set(a["columns"]) != set(b["columns"]):
+        print(f"  COLUMNS only in A: {sorted(set(a['columns'])-set(b['columns']))}")
+        print(f"  COLUMNS only in B: {sorted(set(b['columns'])-set(a['columns']))}")
+    for c in sorted(set(a["columns"]) & set(b["columns"])):
+        ca, cb = a["columns"][c], b["columns"][c]
+        for k in ("sum", "nulls", "min", "max", "n_unique"):
+            if k in ca and k in cb and ca[k] != cb[k]:
+                print(f"  {c}.{k}: {ca[k]} vs {cb[k]}")
+    if "groups" in a and "groups" in b and a["groups"] != b["groups"]:
+        for g in sorted(set(a["groups"]) | set(b["groups"])):
+            x, y = a["groups"].get(g), b["groups"].get(g)
+            if x != y:
+                print(f"  group {g}: {x} vs {y}")
+    print("  (if only float sums differ at the far decimals, raise --precision to see it)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("files", nargs="+", help="one file to hash, or two to compare")
+    ap.add_argument("--keys", help="comma-separated canonical sort keys")
+    ap.add_argument("--group", help="column to report per-group counts on")
+    ap.add_argument("--precision", type=int, default=DEFAULT_PRECISION)
+    ap.add_argument("--json", action="store_true", help="emit JSON only")
+    a = ap.parse_args()
+    keys = [k.strip() for k in a.keys.split(",")] if a.keys else None
+
+    results = []
+    for f in a.files[:2]:
+        r = digest(_load(Path(f)), keys, a.precision, a.group)
+        r["file"] = f
+        results.append(r)
+        if not a.json:
+            print(f"{f}\n  rows {r['rows']:,} x {r['cols']}  sha256 {r['sha256']}")
+            if "groups" in r:
+                print("  groups: " + "  ".join(f"{k}={v:,}" for k, v in r["groups"].items()))
+
+    if a.json:
+        print(json.dumps(results if len(results) > 1 else results[0], indent=2, sort_keys=True))
+
+    if len(results) == 2:
+        same = results[0]["sha256"] == results[1]["sha256"]
+        print(f"\n{'IDENTICAL' if same else 'DIFFERENT'} "
+              f"(canonical sort + {a.precision} sig digits)")
+        if not same:
+            report_diff(results[0], results[1])
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/npx-ownership-panel/scripts/freeze.sas
+++ b/skills/npx-ownership-panel/scripts/freeze.sas
@@ -1,0 +1,39 @@
+/* freeze.sas — canonical, deterministic dump of out.pass_npx for identity testing.
+ * NOT a byte-compare of sas7bdat/parquet: those embed timestamps, compression state
+ * and page layout, so two runs of identical code differ in bytes while the data is
+ * the same. This dumps a canonically sorted, fixed-format text form; sha256 of THAT
+ * is the identity claim. */
+%let tag = &sysparm.;
+
+proc sort data=out.pass_npx out=canon; by itemonagendaid block; run;
+
+/* Fixed formatting at full precision — best20. is deterministic per value and wide
+ * enough to expose a float-path difference rather than round it away. */
+data _null_;
+    set canon;
+    file "canon_&tag..txt" lrecl=4000;
+    put itemonagendaid best20. "|" block $24. "|"
+        n_rows best20. "|" n_for best20. "|" n_against best20. "|"
+        n_abstain best20. "|" n_other best20. "|"
+        sv_for best20. "|" sv_against best20. "|" sv_abstain best20. "|" n_no_sv best20. "|"
+        tna_for best20. "|" tna_against best20. "|" tna_abstain best20. "|" n_no_tna best20. "|"
+        n_usable best20. "|" for_frac best20. "|" against_frac best20. "|" abstain_frac best20. "|"
+        sv_total best20. "|" tna_total best20. "|" sv_for_frac best20. "|" tna_for_frac best20.;
+run;
+
+/* Localisers: if the hash moves, these say WHERE. */
+proc sql;
+    create table sums_&tag. as
+    select count(*) as n_rows_total,
+           count(distinct itemonagendaid) as n_items,
+           sum(n_rows) as s_n_rows, sum(n_for) as s_n_for, sum(n_against) as s_n_against,
+           sum(n_abstain) as s_n_abstain, sum(n_other) as s_n_other,
+           sum(sv_for) as s_sv_for, sum(tna_for) as s_tna_for,
+           sum(for_frac) as s_for_frac, sum(tna_for_frac) as s_tna_for_frac
+    from canon;
+    create table blocks_&tag. as
+    select block, count(*) as cells, sum(n_rows) as vote_rows
+    from canon group by block order by block;
+quit;
+title "BASELINE SUMS &tag."; proc print data=sums_&tag. noobs; run;
+title "BASELINE BLOCKS &tag."; proc print data=blocks_&tag. noobs; run; title;

--- a/skills/npx-ownership-panel/scripts/import_inst_own.sas
+++ b/skills/npx-ownership-panel/scripts/import_inst_own.sas
@@ -1,0 +1,66 @@
+/* import_inst_own.sas — land build_inst_own.py's panel as out.inst_own.
+ *
+ * WHY THIS STEP EXISTS. merge_panel.sas requires out.inst_own and its header
+ * still says "(from build_inst_own.sas)". When leg 2 became the EDGAR Python
+ * builder, nothing replaced the SAS leg's direct write to the out library, so
+ * merge_panel aborted its own prerequisite gate on a pipeline that had
+ * otherwise run clean. This is that missing step.
+ *
+ * WHY CSV AND NOT THE .xpt build_inst_own.py used to write: SAS 9.4 cannot read
+ * it ("ERROR: File XIN.DATASET.DATA is not a SAS data set"), and xport's 8-char
+ * limit renamed `numowners`->NUMOWN and `io_total`->IO_TOT, which are the names
+ * merge_panel's MERGE_ASOF asks for by name.
+ *
+ * Usage: qsub run_sas.sh import_inst_own.sas <path/to/inst_own.csv>
+ */
+%let csv = %sysfunc(compress(&sysparm., %str(%'%")));
+%put NOTE: IMPORT reading &csv.;
+
+/* The INPUT below is POSITIONAL. build_inst_own.py writes SAS_COLUMNS in this
+ * exact order and a drift would silently shift every value one column left.
+ * Read the header and abort on mismatch rather than trust it. */
+%let expected = permno,rdate,numowners,io_total,ioc_hhi,dbreadth,ior,tso,me,p,cfacshr,io_missing,io_g1,split_quarter,split_adjacent,shortint,si_missing,shortint_adj,io_total_net,si_frac,ior_net,net_clamped;
+
+data _null_;
+    infile "&csv." obs=1 truncover lrecl=32767;
+    input hdr $32767.;
+    call symputx("got", strip(hdr));
+run;
+
+%macro check_header;
+    %if %quote(&got.) ne %quote(&expected.) %then %do;
+        %put ERROR: inst_own.csv header does not match the expected column order.;
+        %put ERROR- expected: &expected.;
+        %put ERROR- got     : &got.;
+        %abort cancel;
+    %end;
+    %else %put NOTE: IMPORT header OK (22 columns, order verified);
+%mend;
+%check_header;
+
+data out.inst_own;
+    infile "&csv." dsd firstobs=2 truncover lrecl=32767;
+    input permno rdate_yyyymmdd numowners io_total ioc_hhi dbreadth ior tso me p
+          cfacshr io_missing io_g1 split_quarter split_adjacent shortint
+          si_missing shortint_adj io_total_net si_frac ior_net net_clamped;
+
+    /* merge_panel does `recorddate = rdate` and MERGE_ASOFs it against
+     * out.meetings.recorddate, which is a SAS date. The panel carries rdate as
+     * a YYYYMMDD integer, so convert — comparing 20170930 against a SAS date
+     * would match nothing and quietly empty the join. */
+    rdate = input(put(rdate_yyyymmdd, 8.), yymmdd8.);
+    format rdate yymmdd10.;
+    drop rdate_yyyymmdd;
+run;
+
+proc sql noprint;
+    select count(*), count(distinct permno), min(rdate), max(rdate)
+      into :n trimmed, :np trimmed, :d1 trimmed, :d2 trimmed
+    from out.inst_own;
+quit;
+%put NOTE: IMPORTSTAT out.inst_own rows=&n. permnos=&np. rdate=&d1.-&d2.;
+
+%if &n. = 0 %then %do;
+    %put ERROR: out.inst_own imported 0 rows.;
+    %abort cancel;
+%end;

--- a/skills/npx-ownership-panel/scripts/merge_panel.sas
+++ b/skills/npx-ownership-panel/scripts/merge_panel.sas
@@ -1,4 +1,31 @@
-/* merge_panel.sas — Merge meetings + inst_own + index_own, compute pivotalness
+/* merge_panel.sas — CANONICAL. Merge meetings + inst_own + index_own, compute
+ * pivotalness, join the N-PX cells.
+ *
+ * CONSOLIDATED FROM THREE DIVERGENT COPIES (2026-07-26). There were:
+ *   mirror scripts/merge_panel.py   — R2 tso convention, ior_raw/ior_capped/
+ *                                     ior_net/inst_pivotal_net, split_adjacent,
+ *                                     si_missing, dbreadth
+ *   mirror sas/merge_panel.sas      — R2 tso convention, no prerequisite gates
+ *   skills/.../merge_panel.sas      — the gates, but NO R2 and none of the
+ *                                     above columns  <- what the grid ran
+ * and the two .sas files were not even the same file. This is the union: the
+ * gates from the grid copy, the R2 convention and the CRSP/ISS diagnostic from
+ * mirror, the derived columns from the .py.
+ *
+ * WHY IT MATTERS, and it is not cosmetic. The grid copy took `ior` straight from
+ * leg 2, where it is denominated by CRSP `shrout * 1000` — per-permno, a SINGLE
+ * SHARE CLASS. ISS `outstandingshare` is COMPANY-WIDE. For dual-class firms
+ * (STZ, BRK.B, BF.B, MOG.A, RUSHA) that mismatch inflated implied share counts
+ * 5-15x, and every pivotalness flag is derived from those pcts. The correct
+ * denominator was already sitting in out.meetings as `tso` and simply went
+ * unused, so the panel looked complete and plausible — the same shape as every
+ * other defect in this pipeline.
+ *
+ * R2 (TSO denominator): ior, mf_pct, passive_pct and index_pct are ALL
+ * recomputed here from raw totals over ISS tso. The CRSP-denominated values are
+ * retained behind a `_crsp` suffix for diagnostics only. Do not reintroduce a
+ * pct that divides by CRSP tso.
+ *
  *
  * Prereqs: autoexec.sas loaded (provides libnames: out)
  *          out.meetings (from build_meetings.sas)
@@ -104,9 +131,14 @@ run;
 
 proc sort data=index_own nodupkey; by qtr permno; run;
 
-/* Rename to match original variable names */
+/* Rename to match original variable names, and segregate the CRSP-denominated
+ * pcts behind a `_crsp` suffix — they are diagnostics now, not the answer.
+ * See the R2 note in the header. */
 data out.index_own;
-    set index_own;
+    set index_own (rename=(mf_pct=mf_pct_crsp
+                           passive_pct=passive_pct_crsp
+                           index_pct=index_pct_crsp
+                           tso=tso_crsp));
     rqdate = qtr;
     format rqdate yymmddn8.;
     drop qtr;
@@ -124,19 +156,19 @@ data _meetings / view=_meetings;
     set out.meetings;
 run;
 
+/* IOR/TSO here are CRSP-denominated; keep them as diagnostics under `_crsp`
+ * and derive the canonical ior below from io_total / ISS tso. The >1.2 drop
+ * stays on the CRSP ratio: it flags broken 13F coverage or CUSIP misalignment
+ * at the permno level, which recomputing against ISS tso cannot recover. */
 data _inst_own / view=_inst_own;
-    set out.inst_own;
+    set out.inst_own (rename=(IOR=ior_crsp TSO=tso_crsp_inst));
     recorddate = rdate;
-    if IOR > 1.2 then delete;
-    IOR = min(max(IOR,0.0),1.0)*100;
+    if ior_crsp > 1.2 then delete;
 run;
 
 data _index_own / view=_index_own;
     set out.index_own;
     recorddate = rqdate;
-    MF_PCT = 100 * MF_PCT;
-    PASSIVE_PCT = 100 * PASSIVE_PCT;
-    INDEX_PCT = 100 * INDEX_PCT;
 run;
 
 /* --- As-of merges --- */
@@ -146,22 +178,68 @@ run;
     merged=pass1,
     idvar=permno,
     datevar=recorddate,
-    num_vars=numowners io_total ioc_hhi me ior);
+    num_vars=numowners io_total ioc_hhi dbreadth me ior_crsp tso_crsp_inst
+             io_total_net si_missing split_adjacent cfacshr);
 
 %MERGE_ASOF(a=pass1, b=_index_own,
     merged=pass2,
     idvar=permno,
     datevar=recorddate,
-    num_vars=num_mf_owners mf_total passive_total pure_index_total mf_pct passive_pct index_pct);
+    num_vars=num_mf_owners mf_total passive_total pure_index_total
+             mf_pct_crsp passive_pct_crsp index_pct_crsp tso_crsp);
 
-/* --- Pivotalness indicators --- */
+/* --- Canonical pcts from raw totals and ISS tso (R2), then pivotalness ----- */
 data out.pass;
     set pass2;
-    inst_pivotal = abs(forpct-50) <= ior;
-    mf_pivotal = abs(forpct-50) <= mf_pct;
-    passive_pivotal = abs(forpct-50) <= passive_pct;
-    index_pivotal = abs(forpct-50) <= index_pct;
+
+    /* R2. Every ownership pct uses ISS `outstandingshare` (carried into
+     * out.meetings as `tso`) as the denominator. */
+    if not missing(tso) and tso > 0 then do;
+        mf_pct      = min(100, max(0, coalesce(mf_total,0)         / tso * 100));
+        passive_pct = min(100, max(0, coalesce(passive_total,0)    / tso * 100));
+        index_pct   = min(100, max(0, coalesce(pure_index_total,0) / tso * 100));
+        ior         = min(100, max(0, coalesce(io_total,0)         / tso * 100));
+        /* The cap above is load-bearing for pivotalness — a lent share carries
+         * no vote, so votable ownership cannot exceed 100% — but on its own it
+         * HIDES what it caps. Keep the uncapped ratio and a flag beside it, so
+         * a parse artifact cannot masquerade as a clean 100.0. */
+        ior_raw    = coalesce(io_total,0) / tso * 100;
+        ior_capped = (ior_raw > 100);
+    end;
+    else do;
+        mf_pct = .; passive_pct = .; index_pct = .; ior = .;
+        ior_raw = .; ior_capped = 0;
+    end;
+
+    /* Institutional ownership with securities lending netted out — the measure
+     * to use when ownership stands in for VOTING power, since the vote on a
+     * lent share belongs to the borrower unless recalled before the record
+     * date. Null where short interest did not match, NEVER silently equal to
+     * ior. */
+    if not missing(tso) and tso > 0 and si_missing = 0 then
+        ior_net = min(100, max(0, io_total_net / tso * 100));
+    else ior_net = .;
+
+    /* Pivotalness: forpct and the pcts are both on [0,100] */
+    inst_pivotal    = abs(forpct-50) <= coalesce(ior,0);
+    mf_pivotal      = abs(forpct-50) <= coalesce(mf_pct,0);
+    passive_pivotal = abs(forpct-50) <= coalesce(passive_pct,0);
+    index_pivotal   = abs(forpct-50) <= coalesce(index_pct,0);
+    /* Reported ALONGSIDE inst_pivotal, not instead of it: null where lending
+     * is unknown, so it cannot quietly fall back to the gross measure. */
+    if not missing(ior_net) then inst_pivotal_net = abs(forpct-50) <= ior_net;
+    else inst_pivotal_net = .;
 run;
+
+/* --- Diagnostic: how far apart are the CRSP and ISS denominators? ---------- */
+proc sql;
+    select
+        sum(case when abs(tso_crsp_inst - tso) / tso > 0.10 then 1 else 0 end)
+            as n_crsp_iss_gap_gt_10pct format comma12.,
+        count(*) as n_total format comma12.
+    from out.pass
+    where tso > 0 and tso_crsp_inst > 0;
+quit;
 
 proc contents data=out.pass order=varnum; run;
 

--- a/skills/npx-ownership-panel/scripts/run_import.sh
+++ b/skills/npx-ownership-panel/scripts/run_import.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#$ -cwd
+#$ -N imp_io
+#$ -j y
+#$ -l m_mem_free=8G
+#
+# run_import.sh — SGE wrapper for import_inst_own.sas.
+#
+# Not run_sas.sh, for the same reason run_npx_stage.sh is not: run_sas.sh builds
+# the log filename from the sysparm, and this sysparm is a PATH. Passing it
+# through run_sas.sh produces
+#   logs/import_inst_own-/scratch/.../inst_own.csv.log
+# and SAS fails with "Physical file does not exist" before reading a single row.
+#
+#   qsub -v "INST_OWN_CSV=$PWD/../data/processed/inst_own.csv" run_import.sh
+
+set -u
+mkdir -p logs
+
+CSV="${INST_OWN_CSV:-$(pwd)/../data/processed/inst_own.csv}"
+echo "import host=$(hostname) csv=${CSV} started=$(date -Is)"
+
+sas -nodms -noterminal -nosyntaxcheck \
+    -sysparm "${CSV}" \
+    -log   logs/import_inst_own.log \
+    -print logs/import_inst_own.lst \
+    import_inst_own.sas
+rc=$?
+
+grep -hE "IMPORTSTAT|IMPORT header|^ERROR" logs/import_inst_own.log || true
+echo "import finished=$(date -Is) rc=$rc"
+exit $rc

--- a/skills/npx-ownership-panel/scripts/run_pipeline.sh
+++ b/skills/npx-ownership-panel/scripts/run_pipeline.sh
@@ -12,7 +12,8 @@
 # DAG (hold_jid edges are real dependencies, not decoration):
 #
 #   build_meetings ─────────────────────────────────────────────────┐
-#   build_inst_own ─────────────────────────────────────────────────┤
+#   short_interest ──→ build_inst_own ──→ import_inst_own ──────────┤
+#                        (EDGAR, py)      (csv → out.inst_own)      │
 #   build_mflinks ──┐                                               │
 #   split_s12 ──────┴──→ tfn_holdings_parallel ×N ──────────────────┤
 #   npx_stage ───────────→ npx_array ×M (one task per year) ────────┤
@@ -63,6 +64,7 @@ read -r -a YEAR_RANGES <<< "$(sed -n 's/^%let S12_RANGES *= *\([^;]*\);.*/\1/p' 
 # 40 minutes in is 40 minutes of grid time and a confusing log.
 preflight_fail=0
 for f in pipeline_config.sas build_meetings.sas build_inst_own.py build_short_interest.py \
+         import_inst_own.sas run_import.sh \
          build_mflinks.sas split_s12.sas tfn_holdings_parallel.sas stage_npx_link.sas \
          build_npx.sas merge_panel.sas run_sas.sh run_python.sh run_npx_stage.sh \
          run_npx_array.sh; do
@@ -97,7 +99,7 @@ fi
 [ -f ~/.pgpass ] || { echo "PREFLIGHT ERROR: ~/.pgpass missing (WRDS PG credentials)" >&2; preflight_fail=1; }
 [ "$preflight_fail" = "0" ] || { echo "Preflight failed — nothing submitted." >&2; exit 1; }
 
-chmod +x run_sas.sh run_npx_stage.sh run_npx_array.sh 2>/dev/null || true
+chmod +x run_sas.sh run_npx_stage.sh run_npx_array.sh run_import.sh 2>/dev/null || true
 
 echo "=========================================="
 echo "N-PX x Ownership Pipeline"
@@ -127,6 +129,17 @@ JOB_IO=$(qsub -terse -N inst_own -hold_jid "$JOB_SI" \
     -o logs/build_inst_own.log -j y \
     run_python.sh build_inst_own.py | cut -d. -f1)
 echo "  [2] build_inst_own:  job $JOB_IO  (~3 min, held on short_interest)"
+
+# Leg 2 writes parquet + CSV; merge_panel reads out.inst_own from the SAS `out`
+# library. The SAS leg used to write that directly, and when leg 2 became Python
+# nothing replaced it — merge_panel aborted its prerequisite gate on an
+# otherwise-clean run. This step is that bridge, and it is a REAL DAG edge:
+# merge waits on it, not on build_inst_own.
+JOB_IMP=$(qsub -terse -N imp_io -hold_jid "$JOB_IO" \
+    -o logs/import_inst_own.sge.log -j y \
+    -v "INST_OWN_CSV=$(pwd)/../data/processed/inst_own.csv" \
+    run_import.sh | cut -d. -f1)
+echo "  [2] import_inst_own: job $JOB_IMP  (held on build_inst_own → out.inst_own)"
 
 # --- Leg 1: mutual-fund holdings ---------------------------------------------
 JOB_MFL=$(qsub -terse -N mflinks -o logs/build_mflinks.log -j y \
@@ -163,7 +176,9 @@ JOB_NPX=$(qsub -terse -N npx_cells -hold_jid "$JOB_STAGE" \
 echo "  [3] npx_array:       job $JOB_NPX  (${NTASKS} tasks) — held on npx_stage"
 
 # --- Merge: waits on everything ----------------------------------------------
-ALL_DEPS="$JOB_MTG,$JOB_IO,$TFN_JOBS,$JOB_NPX"
+# $JOB_IMP, not $JOB_IO: out.inst_own exists only after the import step, and
+# merge_panel's prerequisite gate checks for exactly that dataset.
+ALL_DEPS="$JOB_MTG,$JOB_IMP,$TFN_JOBS,$JOB_NPX"
 JOB_MERGE=$(qsub -terse -N merge -hold_jid "$ALL_DEPS" \
     -o logs/merge_panel.log -j y \
     run_sas.sh merge_panel.sas | cut -d. -f1)

--- a/skills/npx-ownership-panel/scripts/run_python.sh
+++ b/skills/npx-ownership-panel/scripts/run_python.sh
@@ -1,8 +1,32 @@
 #!/bin/bash
 #$ -cwd
 #$ -q all.q
+#$ -l m_mem_free=24G
 #
 # SGE wrapper: run a Python script with the system Python (has psycopg2, pandas, pyarrow).
 # Usage: qsub run_python.sh <script.py> [args...]
+#
+# m_mem_free IS LOAD-BEARING, NOT TUNING. build_inst_own.py collects the full
+# EDGAR 13F panel (172.9M rows across 137 parquet files) into memory before the
+# CRSP join. With no memory request at all — which is how this wrapper shipped —
+# SGE grants the cgroup default and the job is SIGKILLed mid-load:
+#     qacct -j <id>  ->  failed 52 : cgroups enforced memory limit
+#                        exit_status 137
+#                        ru_maxrss   16774076   (16.0G, killed on the way up)
+# 24G is the ceiling this grid allows for a single job, not a chosen value:
+# qsub rejects 25G and above with "Too much memory requested. Jobs may not use
+# more than 48GB" (the queue prices m_mem_free per slot at 2 slots, so 24G is
+# the largest request that fits the 48GB cap).
+#
+# The other runners in this tree already request memory (run_s12_array.sh 8G,
+# run_npx_stage.sh 4G); this wrapper was the only one that requested none.
 
+# BASELINE MODE. A parallel group-by sum reduces in thread-arrival order, so two
+# identical runs produce floats differing by 1 ULP — enough that canonical_hash
+# reports DIFFERENT at 12 sig digits (measured: 6,048 io_total cells raw, 101
+# still differing after rounding, because a 1-ULP nudge flips exact half-way
+# ties). Pinning the reduction order makes the digest reproducible: verified
+# IDENTICAL across two runs. Costs ~2.1x on this leg, which is off the critical
+# path. Unset for production runs; set it for anything that will be frozen.
+export POLARS_MAX_THREADS=${POLARS_MAX_THREADS:-1}
 /usr/local/bin/python3 "$@"


### PR DESCRIPTION
The pipeline that produced frozen digests A–D existed **only** on the WRDS grid at `/scratch/nyu/hue/npx_panel/scripts`. Two of its files existed in no repository at all. A digest is only as good as the ability to re-derive it — until this lands, A–D certify a run nobody can rebuild.

This is the tree **as it ran**, copied verbatim. Not a reconstruction from mirror. Where it diverges from mirror, the divergence is reported below rather than tidied away, because a tidied version would not be the thing that ran.

## New — existed nowhere, one `rm -rf` from gone

| file | why |
|---|---|
| `import_inst_own.sas` | Lands `out.inst_own` for `merge_panel`. Leg 2 became Python and nothing replaced the SAS leg's direct write, so `merge_panel` aborted its own prerequisite gate on an otherwise-clean run. CSV not xport: SAS 9.4 **cannot read** pyreadstat's transport file, and xport's 8-char limit renames `numowners`→`NUMOWN` and `io_total`→`IO_TOT` — the exact names `MERGE_ASOF` asks for. |
| `run_import.sh` | Wrapper for the above. Not `run_sas.sh`, which builds its log filename from the sysparm — and this sysparm is a path, producing a filename SAS cannot open. |
| `freeze.sas` | The vote-side canonical dump behind digest A. |

## Modified

- **`build_inst_own.py`** — chunked join, dated cusip→permno, `stocknames_v2` splice, per-year zero-match guard, dead-tail guard, cross-chunk leak check. **106.5 GB → 28.0 GB**, under the grid's 48 GB cap.
- **`merge_panel.sas`** — the consolidated canonical version: gates from this copy, R2 ISS-`tso` convention and the CRSP/ISS diagnostic from mirror, derived columns from `merge_panel.py`. Fixes a **100× error**: the old `_index_own` view did `MF_PCT = 100 * MF_PCT` on values `tfn_holdings_parallel.sas:187` already emits as percentages, so `mf_pct` averaged **2564%**.
- **`build_short_interest.py`** — units check now runs unconditionally and **before** the write. It was wrapped in `if leg-2 cache exists`, and leg 5 runs *before* leg 2, so on every cold start the only guard against a units error silently did nothing.
- **`run_python.sh`** — `m_mem_free=24G`. It requested no memory at all and leg 2 was SIGKILLed by the cgroup.
- **`run_pipeline.sh`** — wires `import_inst_own` as a real DAG edge with merge held on it; adds the new files to the preflight.

## Divergence from mirror — reported, not reconciled

**`build_inst_own.py`** — mirror's is this file **plus** the #10 thread-pinning block (`os.environ.setdefault("POLARS_MAX_THREADS", "1")`). Verified by content comparison: **nothing is on the grid that is not in mirror.** The grid pinned threads via `run_python.sh`'s export instead, so this tree **is self-consistent and does reproduce** — but it carries the weaker form, which is exactly the "one forgotten line" failure #10 exists to prevent.

> **Recommended follow-up:** take mirror's version of that block, after which the two files converge exactly. Not done here because the ask was the tree that ran.

Everything else, for the record:

| file | vs mirror |
|---|---|
| `build_short_interest.py` | units-check fix is **here**, not in mirror |
| `merge_panel.sas` | mirror's `sas/` copy is ~3 months stale, pre-R2 |
| `run_python.sh` | mirror's `sas/` copy predates the memory request |
| `run_pipeline.sh` | mirror's `sas/` copy still runs `build_inst_own.SAS` |
| `canonical_dump.sas` | **byte-identical** to mirror `scripts/` |
| `canonical_hash.py` | **byte-identical** to mirror `scripts/` |

The two canonical tools are included so digests can be re-derived from this tree alone. They are a **knowing** duplication of mirror — to be treated as one source, not forked.

## Verified, this tree, on the grid

```
full cold DAG   31m 38s, 0 ERROR lines
gates           PREREQ mf_own_chunks=9 npx_cell_years=21/21 s12_partitions=9/9
                UNIVERSE meetings_items=623,642 npx_items=712,466 orphans=0
leg 2           cross-machine determinism: 5 runs, 2 machines, digest 15dbb912
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AL2p8VC1ULxSibcCdEAsh
