### PR TITLE
fix(si): make .last() mean latest datadate, not whichever row a thread saw last

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_short_interest.py
+++ b/skills/npx-ownership-panel/scripts/build_short_interest.py
@@ -142,7 +142,21 @@ def main() -> None:
     si = si.with_columns(snap_to_quarter_end(pl.col("datadate")).alias("rdate"))
     si = (
         si.sort(["permno", "rdate", "datadate"])
-        .group_by(["permno", "rdate"])
+        # maintain_order=True is what makes `.last()` mean "latest datadate".
+        # polars' group_by is not documented to read rows in sorted order, so
+        # without it "last" means "whichever row a thread happened to see last"
+        # and the intent above — closest to but not after quarter-end — lives
+        # only in the sort, where nothing enforces it. Short interest is
+        # semi-monthly, so a permno-quarter carries ~6 rows and there is always
+        # a tie to break. Same defect class as the (permno, rdate, cik) dedup in
+        # leg 2 and the (wficn, rqdate, cusip8) dedup in the S12 leg; this is the
+        # third instance and the cheapest to close.
+        #
+        # Note this leg is NOT exposed to the float-sum-order problem that forced
+        # POLARS_MAX_THREADS=1 in build_inst_own.py — it selects whole rows and
+        # sums nothing. Thread pinning would MASK this rather than fix it, and
+        # this file is pinned by nothing in mirror, so the guard has to be here.
+        .group_by(["permno", "rdate"], maintain_order=True)
         .last()
         .rename({"datadate": "si_datadate"})
     )


### PR DESCRIPTION
One keyword. `maintain_order=True` on the quarter-end pick in `build_short_interest.py`.

## The problem

```python
si.sort(["permno", "rdate", "datadate"])
  .group_by(["permno", "rdate"])
  .last()
```

polars' `group_by` is not documented to read rows in sorted order, so `.last()` meant *"whichever row a thread happened to see last"*. The stated intent — closest to but not after quarter-end, never using future information — lived only in the sort, where nothing enforced it. Short interest is semi-monthly, so a permno-quarter carries ~6 rows and there is **always** a tie to break.

Third instance of this defect class, after the `(permno, rdate, cik)` dedup in leg 2 and the `(wficn, rqdate, cusip8)` dedup in the S12 leg — and the cheapest to close.

## Why not thread pinning

This leg is **not** exposed to the float-sum-order problem that forced `POLARS_MAX_THREADS=1` in `build_inst_own.py`. It selects whole rows and sums nothing, so thread count cannot perturb a *value*, only which row wins. Pinning would **mask** the undefined choice rather than remove it.

It also wouldn't help here: this file is pinned by **nothing** in mirror — no in-script setting, and `sas/run_python.sh` doesn't export it. The guard has to be in the file.

## Verified — WRDS grid, full 2003–2025

```
determinism   two runs, identical
vs pre-fix    byte-identical, 446,636 rows unchanged
units check   median SI/TSO 1.5643%, p99 25.18%, n=300,629
wall          8.4s
```

**Byte-identical output is the point, not a disappointment.** polars *was* reading rows in sorted order here, so the intent was being met by implementation detail rather than by contract. This makes it the form that cannot be run wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AL2p8VC1ULxSibcCdEAsh
