### PR TITLE
chore(release): v5.87.1 — bump bmll submodule to the Printable-filter fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.87.0"
+    "version": "5.87.1"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.87.0",
+      "version": "5.87.1",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.87.0",
+  "version": "5.87.1",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"


### PR DESCRIPTION
Points `skills/bmll` at [edwinhu/bmll-skill@217d29d](https://github.com/edwinhu/bmll-skill/commit/217d29df57da52570e7a53342f90b14f7e808ffd) (bmll-skill PR #1, merged), and bumps the plugin version 5.87.0 → 5.87.1 in all three required locations.

## What the submodule fix does

The `bmll` skill's Iron Law and Red Flag table both require `Printable == True` before any volume or notional sum. `scripts/bmll_checks.py::printable_only` and `examples/trades_plus_execution_quality.py` apply it — but four worked examples in `references/` did not, including the base `equity` frame that three `TradeNotionalEUR` recipes and the markout recipes all build on. Reference examples are the copy-paste path, so the doctrine lost to the exemplar.

Verified against the vendored BMLL schema docs: `Printable` is a column of the harmonised `trades` schema for **both** equities and futures, with `Size` documented negative for cancellations in both. BMLL's own `trades_plus_use_cases` notebook never filters it — that's where the omission was inherited.

## Audit result

Found by `/workflows:skill-creator audit`. Everything else scored clean and is untouched: trigger-only description, 16 non-derivable fact rows, 8 action-targeted red flags, Iron Law with drive-consequence, no `${CLAUDE_PLUGIN_ROOT}` in skill content, deterministic logic already extracted to `scripts/`. Phase-chaining patterns are N/A for a tool skill.

Factual grounding sweep: ~420 backticked identifiers, 42 method names, and all 43 cited dates across `SKILL.md` + `references/` resolve against `vendor/`. Both script test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sh6y37YK3X3wq5UGbNM8wq