### PR TITLE
fix(npx-panel): the fifth and sixth undefined choices, and three silent degradations

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_inst_own.py
+++ b/skills/npx-ownership-panel/scripts/build_inst_own.py
@@ -289,11 +289,27 @@ def pull_crsp_monthly(user: str, start: str, end: str) -> pl.DataFrame:
         (pl.col("P") * pl.col("TSO") / 1_000_000.0).alias("ME")
     )
 
-    # Keep last observation per (permno, qdate) — end-of-quarter snapshot
-    crsp = (
-        crsp.sort(["permno", "qdate_int", "date_int"])
-        .group_by(["permno", "qdate_int"])
-        .last()
+    # Keep last observation per (permno, qdate) — end-of-quarter snapshot.
+    #
+    # The tie-break is stated INSIDE the aggregation, not implied by a preceding
+    # sort. This used to be `.sort([..., "date_int"]).group_by([...]).last()`,
+    # which relies on group_by preserving a prior sort — something polars does not
+    # promise. `.last()` then means "whichever row the reduction saw last", and on
+    # a multithreaded run that is not necessarily the latest `date_int`; the
+    # quarter's snapshot could come from any month in it.
+    #
+    # This is the same defect class as the leg-5 `group_by().last()` and the F7
+    # accession dedup, and it is NOT fixed by POLARS_MAX_THREADS=1: pinning
+    # threads fixes a *sum*, whose answer is well defined and only reduction order
+    # varies. A row *selection* among ties has no defined answer at all, so a pin
+    # merely freezes one arbitrary pick and puts a stable digest on top of it.
+    # This site needs a rule, and `sort_by("date_int").last()` is that rule.
+    #
+    # It matters more than most: this collapse produces TSO, P, ME and cfacshr for
+    # every (permno, quarter) — the ownership denominator, and the cfacshr the
+    # split-basis correction depends on.
+    crsp = crsp.group_by(["permno", "qdate_int"]).agg(
+        pl.exclude(["permno", "qdate_int"]).sort_by("date_int").last()
     )
 
     # Keep only columns needed downstream
@@ -1098,10 +1114,30 @@ def build_final_panel(
     # Rename qdate_int → rdate for output (matches merge_panel expectation)
     panel = panel.rename({"qdate_int": "rdate", "P": "p", "TSO": "tso", "ME": "me"})
 
-    # Sort and dedup
-    panel = panel.sort(["rdate", "permno"]).unique(
-        subset=["rdate", "permno"], keep="first"
-    )
+    # Sort for a stable output order, then ASSERT the grain — do not dedup it.
+    #
+    # This used to be `.sort(["rdate","permno"]).unique(subset=["rdate","permno"],
+    # keep="first")`: the sort key EQUALLED the dedup key, so every row in a
+    # duplicate group was a tie and `keep="first"` picked one by row order. If the
+    # sort key equals the dedup key there is no tie-break — the same construction
+    # already removed at the (permno, rdate, cik) site above.
+    #
+    # It is also a no-op, and provably so: `panel_crsp` is unique because `crsp_m`
+    # is one row per (permno, qdate_int) by construction (see the aggregation in
+    # load_crsp_monthly), `io_only` is anti-joined against exactly those keys, and
+    # io_metrics uniqueness is already asserted by the cross-chunk leak check. So
+    # a silent dedup here can only ever hide the next thing that breaks one of
+    # those three invariants. Assert instead: free when it holds, loud when it
+    # does not.
+    panel = panel.sort(["rdate", "permno"])
+    n_dup = panel.height - panel.select(["rdate", "permno"]).unique().height
+    if n_dup:
+        raise ValueError(
+            f"{n_dup:,} duplicate (rdate, permno) keys in the final panel. "
+            "One of three invariants broke: crsp_m unique per (permno, qdate_int), "
+            "io_only anti-joined against those keys, or io_metrics unique per "
+            "(permno, rdate_int). Fix the source — do not dedup here."
+        )
 
     return panel.select([
         "permno", "rdate", "numowners", "io_total", "ioc_hhi", "dbreadth",

--- a/skills/npx-ownership-panel/scripts/build_meetings.sas
+++ b/skills/npx-ownership-panel/scripts/build_meetings.sas
@@ -91,6 +91,39 @@
 %mend;
 %load_recs;
 
+/* --- OPTIONAL-INPUT GATE ---------------------------------------------------
+ * Both loads above degrade silently: absent file -> WARNING -> `fight` is 0 for
+ * every row / recommendation columns null -> run succeeds -> panel is different
+ * and nothing says so. A /scratch purge removed the SharkRepellent workbook and
+ * four frozen digests were taken afterwards, every one of them carrying an
+ * all-zero `fight` column that nobody had chosen.
+ *
+ * The NOTE prints unconditionally and in the same shape as the PREREQ/UNIVERSE
+ * gates, so `grep -E 'PREREQ|UNIVERSE|OPTIONAL|ERROR'` says which panel this is.
+ * Whether absence is fatal is REQUIRE_OPTIONAL_INPUTS in pipeline_config.sas. */
+%put NOTE: OPTIONAL shark=&have_shark. recs=&have_recs.;
+
+%macro require_optional_inputs;
+    %if &REQUIRE_OPTIONAL_INPUTS. = 1 %then %do;
+        %local missing_opt;
+        %let missing_opt = ;
+        %if not &have_shark. %then %let missing_opt = &missing_opt. SharkRepellent(&shark_file.);
+        %if not &have_recs.  %then %let missing_opt = &missing_opt. recs(&recs_file.);
+        %if %length(&missing_opt.) > 0 %then %do;
+            %put ERROR: OPTIONAL INPUT(S) MISSING —&missing_opt.;
+            %put ERROR- These are not decorative: without SharkRepellent every `fight`;
+            %put ERROR- is 0, and without recs the recommendation columns are null. The;
+            %put ERROR- run would SUCCEED and produce a different panel with no marker;
+            %put ERROR- on it, which is how four digests were frozen on an all-zero;
+            %put ERROR- `fight` column without anyone choosing that.;
+            %put ERROR- Either stage the file(s), or set REQUIRE_OPTIONAL_INPUTS = 0 in;
+            %put ERROR- pipeline_config.sas to say you meant the degraded panel.;
+            data _null_; abort abend; run;
+        %end;
+    %end;
+%mend;
+%require_optional_inputs
+
 /* --- ISS vote results, native indexed read --- */
 /* %vaFilterSAS is the SAS-literal form of the same predicate stage_npx_link.sas
  * uses, from pipeline_config.sas — one universe, both legs. The date range is a

--- a/skills/npx-ownership-panel/scripts/merge_panel.sas
+++ b/skills/npx-ownership-panel/scripts/merge_panel.sas
@@ -105,6 +105,16 @@
         %let missing = &missing. out.s12_[&missing_s12.];
     %end;
 
+    /* The concat below names its partitions from S12_RANGES, so a stray MF_OWN%
+     * dataset is inert. Say so anyway: an operator reading `mf_own_chunks=11`
+     * against a 9-partition config should be told which two are being ignored,
+     * not left to wonder whether they went into the panel. */
+    %if &n_mf. ne &want_s12. %then %do;
+        %put WARNING: &n_mf. MF_OWN%% datasets in the out library but &want_s12. partitions in S12_RANGES.;
+        %put WARNING- The concat names its partitions explicitly, so the extras are IGNORED, not stacked.;
+        %put WARNING- Clean them up if they are leftovers from an ad-hoc run.;
+    %end;
+
     %put NOTE: PREREQ mf_own_chunks=&n_mf. npx_cell_years=&n_cells./%eval(&year2. - &year1. + 1) s12_partitions=&n_s12./&want_s12.;
 
     %if %length(&missing_years.) > 0 %then %do;
@@ -124,9 +134,30 @@
 %mend;
 %require_prereqs
 
-/* --- Concatenate parallel MF ownership outputs --- */
+/* --- Concatenate parallel MF ownership outputs -------------------------------
+ * The partition list comes from S12_RANGES, the SAME list run_pipeline.sh uses to
+ * submit the tfn jobs and the gate above uses to check them. It used to be
+ * `set out.mf_own_:;` — a bare wildcard, which stacks in ANY dataset whose name
+ * starts with MF_OWN. An analysis leaves `mf_own_2021_pre` and `mf_own_2021_a` in
+ * the library and 2021 is silently counted three times; the gate reports
+ * `mf_own_chunks=11` and nothing says that is wrong, because the gate COUNTS what
+ * the wildcard does not CONSTRAIN.
+ *
+ * Observed: both of those datasets were sitting in the out library from an
+ * afternoon's work when this was found. Naming the partitions makes a stray
+ * dataset inert instead of load-bearing. */
+%macro mf_own_list;
+    %local i r;
+    %let i = 1;
+    %do %while (%scan(&S12_RANGES., &i., %str( )) ne );
+        %let r = %scan(&S12_RANGES., &i., %str( ));
+        out.mf_own_%scan(&r., 1, -)_%scan(&r., 2, -)
+        %let i = %eval(&i. + 1);
+    %end;
+%mend;
+
 data index_own;
-    set out.mf_own_:;
+    set %mf_own_list;
 run;
 
 proc sort data=index_own nodupkey; by qtr permno; run;

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_fundid_seriesid.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_fundid_seriesid.py
@@ -257,7 +257,7 @@ sid_counts = (
     .collect(engine="streaming")
     .sort(["fundid", "n", "yr_max", "seriesid"], descending=[False, True, True, False])
 )
-modal_sid = sid_counts.group_by("fundid").head(1).select(
+modal_sid = sid_counts.group_by("fundid", maintain_order=True).head(1).select(
     "fundid", pl.col("seriesid").alias("iss_seriesid")
 )
 
@@ -269,7 +269,7 @@ cik_counts = (
     .collect(engine="streaming")
     .sort(["fundid", "n", "fundcik"], descending=[False, True, False])
 )
-modal_cik = cik_counts.group_by("fundid").head(1).select(
+modal_cik = cik_counts.group_by("fundid", maintain_order=True).head(1).select(
     "fundid", pl.col("fundcik").alias("iss_fundcik")
 )
 
@@ -654,7 +654,7 @@ def best(df, mask, thresh, tier):
         .unique(subset=["fundid", "name"], keep="first", maintain_order=True)
     )
     # margin over the next-best candidate pointing at a DIFFERENT series
-    top = sub.group_by("fundid").head(1)
+    top = sub.group_by("fundid", maintain_order=True).head(1)
     second = (
         sub.join(top.select("fundid", top_series="series_id"), on="fundid", how="left")
         .filter(pl.col("series_id") != pl.col("top_series"))
@@ -803,7 +803,7 @@ unres_cand = (
     cand.filter(pl.col("fundid").is_in(list(remaining)))
     .sort(["fundid", "score"], descending=[False, True])
     .unique(subset=["fundid", "series_id"], keep="first", maintain_order=True)
-    .group_by("fundid").head(3)
+    .group_by("fundid", maintain_order=True).head(3)
     .sort(["n_vote_rows", "fundid", "score"], descending=[True, False, True])
     .select("fundid", "fundname_modal", "institutionname_modal", "n_vote_rows",
             "iss_nonregistrant", "series_id", "entity_name", "name", "src", "score",
@@ -822,11 +822,11 @@ alt_top = (
     .join(corpus.with_row_index("col").with_columns(pl.col("col").cast(pl.Int32))
           .select("col", "series_id"), on="col", how="left")
     .sort(["fundid", "score"], descending=[False, True])
-    .group_by("fundid").head(1).select("fundid", alt_series="series_id")
+    .group_by("fundid", maintain_order=True).head(1).select("fundid", alt_series="series_id")
 )
 base_top = (
     cand.sort(["fundid", "score"], descending=[False, True])
-    .group_by("fundid").head(1).select("fundid", "series_id")
+    .group_by("fundid", maintain_order=True).head(1).select("fundid", "series_id")
 )
 sens = base_top.join(alt_top, on="fundid", how="inner")
 print(f"n-gram sensitivity: top-1 series differs between {L2_TFIDF_NGRAM} and "

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link.py
@@ -221,7 +221,7 @@ def agg_classes(pairs, key):
             d.filter(pl.col(col).is_not_null())
             .group_by([key, col]).agg(n=pl.len())
             .sort([key, "n", col], descending=[False, True, False])
-            .group_by(key).head(1)
+            .group_by(key, maintain_order=True).head(1)
             .select(key, pl.col(col).alias(out))
         )
 
@@ -232,7 +232,7 @@ def agg_classes(pairs, key):
     rep = (
         d.sort([key, "tna_latest", "crsp_fundno"], descending=[False, True, False],
                nulls_last=True)
-        .group_by(key).head(1)
+        .group_by(key, maintain_order=True).head(1)
         .select(key, crsp_fundno=pl.col("crsp_fundno"), crsp_fund_name=pl.col("fund_name"))
     )
     base = d.group_by(key).agg(
@@ -535,7 +535,7 @@ def best(df, mask, thresh, tier):
               descending=[False, True, True, True, False])
         .unique(subset=["fundid", "name"], keep="first", maintain_order=True)
     )
-    top = sub.group_by("fundid").head(1)
+    top = sub.group_by("fundid", maintain_order=True).head(1)
     second = (
         sub.join(top.select("fundid", top_unit="unit"), on="fundid", how="left")
         .filter(pl.col("unit") != pl.col("top_unit"))
@@ -946,7 +946,7 @@ unl = (
     cand.filter(pl.col("fundid").is_in(list(remaining)))
     .sort(["fundid", "score"], descending=[False, True])
     .unique(subset=["fundid", "unit"], keep="first", maintain_order=True)
-    .group_by("fundid").head(3)
+    .group_by("fundid", maintain_order=True).head(3)
     .sort(["n_vote_rows", "fundid", "score"], descending=[True, False, True])
     .select("fundid", "fundname_modal", "institutionname_modal", "n_vote_rows", "first_year",
             "last_year", "unit", "crsp_fund_name", "mgmt_name", "name", "score",

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap.py
@@ -385,14 +385,14 @@ def agg_classes(pairs, key):
             d.filter(pl.col(col).is_not_null())
             .group_by([key, col]).agg(n=pl.len())
             .sort([key, "n", col], descending=[False, True, False])
-            .group_by(key).head(1)
+            .group_by(key, maintain_order=True).head(1)
             .select(key, pl.col(col).alias(out))
         )
 
     rep = (
         d.sort([key, "tna_latest", "crsp_fundno"], descending=[False, True, False],
                nulls_last=True)
-        .group_by(key).head(1)
+        .group_by(key, maintain_order=True).head(1)
         .select(key, crsp_fundno=pl.col("crsp_fundno"),
                 crsp_fund_name=pl.col("fund_name"))
     )
@@ -860,7 +860,7 @@ def best(df, mask, thresh):
               descending=[False, True, True, True, False])
         .unique(subset=["fundid", "unit"], keep="first", maintain_order=True)
     )
-    top = sub.group_by("fundid").head(1)
+    top = sub.group_by("fundid", maintain_order=True).head(1)
     second = (
         sub.join(top.select("fundid", top_unit="unit"), on="fundid", how="left")
         .filter(pl.col("unit") != pl.col("top_unit"))

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap2.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap2.py
@@ -449,14 +449,14 @@ def agg_classes(pairs, key):
             d.filter(pl.col(col).is_not_null())
             .group_by([key, col]).agg(n=pl.len())
             .sort([key, "n", col], descending=[False, True, False])
-            .group_by(key).head(1)
+            .group_by(key, maintain_order=True).head(1)
             .select(key, pl.col(col).alias(out))
         )
 
     rep = (
         d.sort([key, "tna_latest", "crsp_fundno"], descending=[False, True, False],
                nulls_last=True)
-        .group_by(key).head(1)
+        .group_by(key, maintain_order=True).head(1)
         .select(key, crsp_fundno=pl.col("crsp_fundno"),
                 crsp_fund_name=pl.col("fund_name"))
     )
@@ -1100,7 +1100,7 @@ def best(df, mask, thresh):
               descending=[False, True, True, True, False])
         .unique(subset=["fundid", "unit"], keep="first", maintain_order=True)
     )
-    top = sub.group_by("fundid").head(1)
+    top = sub.group_by("fundid", maintain_order=True).head(1)
     second = (
         sub.join(top.select("fundid", top_unit="unit"), on="fundid", how="left")
         .filter(pl.col("unit") != pl.col("top_unit"))

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_ticker.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_ticker.py
@@ -488,12 +488,12 @@ def modal(col, out):
     return (d.filter(pl.col(col).is_not_null())
             .group_by(["unit", col]).agg(n=pl.len())
             .sort(["unit", "n", col], descending=[False, True, False])
-            .group_by("unit").head(1).select("unit", pl.col(col).alias(out)))
+            .group_by("unit", maintain_order=True).head(1).select("unit", pl.col(col).alias(out)))
 
 
 rep = (d.sort(["unit", "tna_latest", "crsp_fundno"], descending=[False, True, False],
               nulls_last=True)
-       .group_by("unit").head(1)
+       .group_by("unit", maintain_order=True).head(1)
        .select("unit", crsp_fundno="crsp_fundno", crsp_fund_name="fund_name"))
 agg = d.group_by("unit").agg(
     n_crsp_classes=pl.col("crsp_fundno").n_unique(),

--- a/skills/npx-ownership-panel/scripts/pipeline_config.sas
+++ b/skills/npx-ownership-panel/scripts/pipeline_config.sas
@@ -70,6 +70,30 @@
  */
 %let S12_RANGES = 2003-2010 2011-2016 2017-2018 2019-2019 2020-2020 2021-2021 2022-2022 2023-2023 2024-2024;
 
+/* OPTIONAL INPUTS: present or absent CHANGES THE PANEL, so say which you meant.
+ *
+ * build_meetings.sas reads two files behind `fileexist` guards — SharkRepellent
+ * (the `fight` flag) and the ISS/GL recommendations. If either is missing it
+ * emits a WARNING and carries on: `fight` becomes 0 for every observation and
+ * the recommendation columns go null. The run succeeds, the panel is different,
+ * and nothing downstream can tell which panel it is holding.
+ *
+ * That happened here. A /scratch purge removed the SharkRepellent workbook and
+ * four separate frozen digests were taken afterwards, all silently carrying
+ * `fight = 0` everywhere. Nobody noticed, because a WARNING in a 90,000-line SAS
+ * log is not a signal.
+ *
+ * So the absence has to be DECLARED rather than discovered:
+ *   1  (default) missing optional input is FATAL — matches how this pipeline
+ *      treats every other missing input (a lost N-PX year aborts the merge)
+ *   0  absence is accepted; you are saying you want the degraded panel
+ *
+ * Either way build_meetings prints  NOTE: OPTIONAL shark=<0|1> recs=<0|1>
+ * next to the PREREQ and UNIVERSE gate lines, so the same grep that checks the
+ * others reports which panel this is.
+ */
+%let REQUIRE_OPTIONAL_INPUTS = 1;
+
 /* MEASURED EFFECT of these two filters on the item frame, 2005-2025 (2026-07-25):
  *
  *   filters            distinct items   raw rows   fanout

--- a/skills/npx-ownership-panel/scripts/run_pipeline.sh
+++ b/skills/npx-ownership-panel/scripts/run_pipeline.sh
@@ -86,10 +86,28 @@ if ! "$PYBIN" -c 'import polars, pyarrow, psycopg2' 2>/dev/null; then
 fi
 # Leg 2 reads the EDGAR 13F parquet. Absent, it would build an empty panel and
 # every downstream ownership column would be silently null.
-[ -d "${HOLDINGS_13F:-holdings_13f}" ] || {
-    echo "PREFLIGHT ERROR: EDGAR holdings not found at ${HOLDINGS_13F:-holdings_13f}" >&2
+# The default must be where build_inst_own.py ACTUALLY looks: it resolves
+# PROJ/data/processed/holdings_13f with PROJ = <script dir>/.., and this script
+# has already cd'd to the script dir. The old default was a bare `holdings_13f`,
+# i.e. scripts/holdings_13f, which exists in no correct layout — so the preflight
+# failed on a tree that was in fact complete, and the only way to run was to set
+# HOLDINGS_13F by hand. Note this file passes ../data/processed/inst_own.csv a
+# few lines below, so the rest of the script already assumed the right layout.
+HOLDINGS_13F="${HOLDINGS_13F:-../data/processed/holdings_13f}"
+[ -d "$HOLDINGS_13F" ] || {
+    echo "PREFLIGHT ERROR: EDGAR holdings not found at $HOLDINGS_13F" >&2
     echo "  Set HOLDINGS_13F, or run the 13F scrape first (wrds skill, parse_13f)." >&2
     preflight_fail=1; }
+# A directory that exists but is EMPTY is the /scratch purge signature: it deletes
+# files by mtime (~7 days) and leaves the directory shells, so the glob still
+# resolves and the failure surfaces downstream as "0 rows" instead of here.
+if [ -d "$HOLDINGS_13F" ] && [ -z "$(find "$HOLDINGS_13F" -name '*.parquet' -print -quit)" ]; then
+    echo "PREFLIGHT ERROR: $HOLDINGS_13F exists but contains no .parquet files." >&2
+    echo "  This is the /scratch purge signature (files removed, shells left)." >&2
+    echo "  Re-ship with 'tar xmf -' so extraction time becomes the mtime;" >&2
+    echo "  tar's default preserves the source mtimes and re-arms the purge." >&2
+    preflight_fail=1
+fi
 if [ ! -f "$LINKCSV" ]; then
     echo "PREFLIGHT ERROR: crosswalk not found at $LINKCSV" >&2
     echo "  Build it locally (npx_linking/) and scp it here:" >&2


### PR DESCRIPTION
`DATA_QUALITY.md` §6d tabulates four undefined-choice defects and closes with: *"If the sort key equals the dedup key, there is no tie-break… It is worth grepping for as a pattern rather than waiting to be surprised by it a fifth time."*

I ran that grep. There is a fifth and a sixth, both in `build_inst_own.py` — the same file the first two were found in. Plus three ways the pipeline was quietly producing a different panel.

## Undefined choices

| # | Site | What was undefined | Remedy |
|---|---|---|---|
| 5 | `build_inst_own.py` end-of-quarter snapshot | `.sort([…,"date_int"]).group_by([…]).last()` relied on group_by preserving a prior sort | **rule** — `sort_by("date_int").last()` inside the agg |
| 6 | `build_inst_own.py` final panel dedup | sort key **equalled** dedup key, `keep="first"` picked by row order | **assert** — it is provably a no-op |
| — | `npx_linking` ×19 `group_by().head(n)` | rule already stated by the sort; group_by need only honour it | **`maintain_order=True`** |

Instance 5 matters most: that collapse produces `TSO`, `P`, `ME` and `cfacshr` for every (permno, quarter) — the ownership denominator, and the `cfacshr` the split-basis correction depends on. Per §6d's own taxonomy it needs a *rule*, not a pin: `POLARS_MAX_THREADS=1` (which every frozen run sets) would have **masked** it, because pinning settles a sum but freezes an arbitrary pick for a selection.

## Verified byte-identical

Leg 2 rebuilt on the grid from a **full CRSP pull** with these changes:

```
675,639 rows x 22   sha256 15dbb91269e3a2ed7a283e764e5315d50445c7b133c7b306ff6ae801c5d9ab76
baseline            15dbb91269e3a2ed7a283e764e5315d50445c7b133c7b306ff6ae801c5d9ab76
```

Same digest, and the new assertion did not fire. That is §6d's own signature of a contract fix — polars *was* reading in sorted order, so the intent was being met by implementation detail rather than by contract. (`--no-pull` could not have tested this: the CRSP cache is written *after* the aggregation.)

## Silent degradations

- **Optional inputs.** `build_meetings.sas` reads SharkRepellent and the ISS recs behind `fileexist` guards; absent, it WARNs and continues with `fight = 0` for every row. A `/scratch` purge removed the workbook and **four frozen digests were taken afterwards**, every one carrying an all-zero `fight` column nobody had chosen. Absence must now be declared — `REQUIRE_OPTIONAL_INPUTS` (default `1`) aborts, and either way the run prints `NOTE: OPTIONAL shark=<0|1> recs=<0|1>` next to the PREREQ/UNIVERSE gates.
- **`set out.mf_own_:`.** A bare wildcard that stacks in any `MF_OWN*` dataset. Two ad-hoc `mf_own_2021_*` sets were in the out library and would have counted 2021 three times; the gate reported `mf_own_chunks=11` and nothing said that was wrong, because it **counts what the wildcard does not constrain**. Partitions are now named from `S12_RANGES`; a mismatch WARNs and names the extras as ignored.
- **Preflight holdings path.** Checked `scripts/holdings_13f` while `build_inst_own.py` resolves `PROJ/data/processed/holdings_13f` — matching no correct layout, so preflight failed on a complete tree. Also added an empty-directory check: `/scratch` purges files and leaves the shells, so the glob still resolves and the failure surfaces downstream as "0 rows".

## ⚠️ Operator note

With the SharkRepellent workbook still missing, `REQUIRE_OPTIONAL_INPUTS = 1` **makes the next run abort**. Either stage it (two copies exist on rjds under `mirror/data/raw/`) or set the flag to `0` to say you want the degraded panel. Staging it will move digest B, since `fight` is a panel column.

Verification: SAS macro expansion checked on the grid (9 partitions, correct names, 0 ERRORs); all edited Python compiles; `bash -n` clean.