### PR TITLE
feat(npx-panel): wire the detector sweep into the DAG as a post-merge job

### DIFF
--- a/skills/npx-ownership-panel/SKILL.md
+++ b/skills/npx-ownership-panel/SKILL.md
@@ -185,8 +185,11 @@ Both fired during verification and caught real failures. That is the point.
 > disabling the cusip6 fallback removes rows and the `msf_v2` splice adds 2025. Re-freeze
 > it deliberately once the corrected DAG has run clean.
 >
-> A timed run should include the detector sweep (`ownership_dq.py`, seconds) so the
-> number means "a panel you can use", not "a panel that exists".
+> A timed run includes the detector sweep (`dq_panel.py`, seconds, held on the merge)
+> so the number means "a panel you can use", not "a panel that exists". This was a
+> standing instruction that nothing implemented — no script referenced
+> `ownership_dq.py` at all — so every wall time quoted before 2026-07-27 was the
+> time to build a panel of unmeasured quality.
 
 Clean checkout on WRDS, one `bash run_pipeline.sh`, 2026-07-25. Two runs, both clean:
 
@@ -305,11 +308,32 @@ This skill builds the panel; it does not certify the numbers in it. The sources
 have documented defects, several of which produce a **complete-looking panel with
 plausible values**, so they cannot be caught by eyeballing output.
 
-Before analysis, run the detectors in the `wrds` skill against what you built:
+**`run_pipeline.sh` now does this for you** — `dq_sweep` is the last node, held on
+the merge, and it reports rather than gates. Read it out of the run:
+
+```bash
+grep -rE 'PREREQ|UNIVERSE|OPTIONAL|DQ|ERROR' logs/    # every gate, one grep
+```
+
+Measured on the 2026-07-27 run (675,639 × 22 leg-2 panel):
+
+```
+DQ rows=675,639 coverage_end=0 duplicate_grain=0 join_coverage_tail=0
+   unit_discontinuity=0 split_factor_ratio=2747 owner_dropout=5577
+DQ impossible_ratio=11,761/378,129=3.110% testable=56.0%_of_panel
+```
+
+**Read that denominator.** `impossible_ratio` can only fire on rows carrying both
+`io_total` and a positive `tso` — 378,129 of 675,639. The remaining 297,510 (44%)
+are invisible to it, so "3.110%" does not mean "the panel is 96.9% clean". The
+check is also one-sided: a denominator that is too *small* trips >100%, one that is
+too *large* never trips anything and just biases ownership downward.
+
+To run it by hand, or against a panel built elsewhere:
 
 ```bash
 uv run python3 tests/ownership_dq_test.py          # 105 assertions, stdlib only
-# then, on your panel, via skills/wrds/scripts/ownership_dq.py
+qsub -v OWNERSHIP_DQ=/path/to/ownership_dq.py run_dq.sh    # on the grid
 ```
 
 Read `skills/wrds/references/tfn-ownership.md` → **Known Data Defects (D1-D9)**

--- a/skills/npx-ownership-panel/scripts/dq_panel.py
+++ b/skills/npx-ownership-panel/scripts/dq_panel.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""dq_panel.py — run the ownership detectors against the panel this DAG just built.
+
+WHY THIS IS A DAG JOB AND NOT A THING YOU REMEMBER TO DO.
+SKILL.md says a timed run should include the detector sweep "so the number means
+'a panel you can use'". Until now nothing in run_pipeline.sh referenced
+ownership_dq.py at all, so every timing quoted for this pipeline was the time to
+build a panel of unmeasured quality. The sweep costs seconds against a ~35 minute
+DAG; leaving it out bought nothing and cost the one number that says the output is
+usable.
+
+IT REPORTS, IT DOES NOT GATE. No detector count fails this job. The thresholds in
+ownership_dq.py belong to whoever set them and are not this script's to enforce,
+and a panel with a known 3.1% impossible-ratio rate is still the panel you meant
+to build. What would be wrong is not knowing.
+
+The summary prints in the same shape as the PREREQ / UNIVERSE / OPTIONAL gate
+lines, so one grep covers the lot:
+
+    grep -E 'PREREQ|UNIVERSE|OPTIONAL|DQ|ERROR' logs/*.log
+
+ownership_dq.py IS NOT DUPLICATED HERE. It lives in the `wrds` skill and
+SKILL.md says, in as many words, "Deliberately not duplicated here." So this
+resolves it rather than carrying a third copy that can drift. Resolution order:
+
+    $OWNERSHIP_DQ                                  explicit wins
+    ../../wrds/scripts/ownership_dq.py             the repo layout
+    ./ownership_dq.py                              deployed alongside
+
+If none resolve the job fails LOUDLY with the remedy. It is the last job in the
+DAG and holds nothing, so failing here costs a message, not a panel.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import polars as pl
+
+HERE = Path(__file__).resolve().parent
+PROJ = HERE.parent
+PROC = PROJ / "data" / "processed"
+
+
+def load_odq():
+    """Import ownership_dq.py from wherever it actually is."""
+    candidates = []
+    env = os.environ.get("OWNERSHIP_DQ")
+    if env:
+        candidates.append(Path(env))
+    # repo layout: skills/npx-ownership-panel/scripts -> skills/wrds/scripts
+    candidates.append(HERE.parent.parent / "wrds" / "scripts" / "ownership_dq.py")
+    candidates.append(HERE / "ownership_dq.py")
+
+    for p in candidates:
+        if p.is_file():
+            spec = importlib.util.spec_from_file_location("odq", p)
+            mod = importlib.util.module_from_spec(spec)
+            # MUST be registered before exec_module: ownership_dq.py uses
+            # @dataclass, and dataclasses resolves the module out of sys.modules
+            # to inspect annotations. Absent, it dies with an unhelpful
+            # AttributeError: 'NoneType' object has no attribute '__dict__'.
+            sys.modules["odq"] = mod
+            spec.loader.exec_module(mod)
+            print(f"[dq] detectors from {p}", flush=True)
+            return mod
+
+    sys.stderr.write(
+        "ERROR: cannot find ownership_dq.py. Tried:\n"
+        + "".join(f"  {c}\n" for c in candidates)
+        + "  It lives in the `wrds` skill and is deliberately not duplicated into\n"
+        "  this one. Either set OWNERSHIP_DQ=/path/to/ownership_dq.py, or scp it\n"
+        "  next to these scripts.\n"
+    )
+    raise SystemExit(2)
+
+
+def main() -> int:
+    odq = load_odq()
+
+    src = Path(os.environ.get("INST_OWN_PARQUET", PROC / "inst_own.parquet"))
+    if not src.is_file():
+        sys.stderr.write(f"ERROR: leg 2 output not found at {src}\n")
+        return 2
+
+    d = pl.read_parquet(src)
+    # Report the panel's OWN shape, before the working column is added — `rd` is
+    # ours, and printing 23 where the panel has 22 puts a wrong number in a log
+    # that exists to be trusted.
+    print(f"[dq] {src.name}: {d.height:,} rows x {d.width} cols", flush=True)
+    # Detectors that group by entity need a real date, not an int YYYYMMDD.
+    d = d.with_columns(
+        pl.col("rdate").cast(pl.Utf8).str.strptime(pl.Date, "%Y%m%d").alias("rd")
+    )
+
+    counts: dict[str, int] = {}
+
+    def run(name, det, frame, **kw):
+        f = odq.from_dataframe(frame, det, **kw)
+        counts[name] = len(f)
+        print(f"[dq] {name:28s} {len(f):>8,}", flush=True)
+        for x in f[:3]:
+            print(f"       {str(x)[:150]}", flush=True)
+        return f
+
+    # --- structural: does the panel exist over the range it claims? -----------
+    per_period = d.group_by("rd").agg(pl.len().alias("n_rows")).sort("rd")
+    year2 = int(os.environ.get("YEAR2", "2025"))
+    run("coverage_end", odq.detect_coverage_end, per_period,
+        period_col="rd", expected_through=dt.date(year2, 12, 31))
+    run("duplicate_grain", odq.detect_duplicate_grain,
+        d.select(["permno", "rdate"]), grain=["permno", "rdate"])
+    run("join_coverage_tail", odq.detect_join_coverage_tail,
+        d.select(["rd", "tso"]), period_col="rd", joined_col="tso")
+
+    # --- units / adjustment --------------------------------------------------
+    sp = (d.filter(pl.col("io_total").is_not_null() & (pl.col("io_total") > 0))
+            .select(["permno", "rd", "io_total", "numowners"])
+            .sort(["permno", "rd"]))
+    run("split_factor_ratio", odq.detect_split_factor_ratio, sp, period_col="rd")
+    run("owner_dropout", odq.detect_owner_dropout,
+        d.select(["permno", "rd", "numowners"]).sort(["permno", "rd"]), period_col="rd")
+    run("unit_discontinuity", odq.detect_unit_discontinuity,
+        d.select(["rd", "io_total"]).rename({"io_total": "value"}), period_col="rd")
+
+    # --- the headline ratio --------------------------------------------------
+    # ITS DENOMINATOR IS NOT d.height AND MUST NOT BE PRINTED AS IF IT WERE.
+    # Only rows carrying both io_total and a positive tso can trip this at all;
+    # on the current panel that is 378,129 of 675,639 (56%). Quoting "3.1%"
+    # against the full row count reads as "the panel is 96.9% clean" and is
+    # wrong about the 44% the check cannot see.
+    ir = d.filter(
+        pl.col("io_total").is_not_null()
+        & pl.col("tso").is_not_null()
+        & (pl.col("tso") > 0)
+    )
+    run("impossible_ratio", odq.detect_impossible_ratio,
+        ir.select(["permno", "rd", "io_total", "tso"]), period_col="rd")
+
+    n_testable = ir.height
+    n_imp = counts["impossible_ratio"]
+    pct = (100.0 * n_imp / n_testable) if n_testable else 0.0
+    cov = (100.0 * n_testable / d.height) if d.height else 0.0
+
+    print(flush=True)
+    print(
+        "NOTE: DQ rows={:,} coverage_end={} duplicate_grain={} join_coverage_tail={} "
+        "unit_discontinuity={} split_factor_ratio={} owner_dropout={}".format(
+            d.height, counts["coverage_end"], counts["duplicate_grain"],
+            counts["join_coverage_tail"], counts["unit_discontinuity"],
+            counts["split_factor_ratio"], counts["owner_dropout"],
+        ),
+        flush=True,
+    )
+    print(
+        "NOTE: DQ impossible_ratio={:,}/{:,}={:.3f}% testable={:.1f}%_of_panel".format(
+            n_imp, n_testable, pct, cov
+        ),
+        flush=True,
+    )
+    print(
+        "NOTE: DQ the impossible_ratio denominator is rows with BOTH io_total and "
+        "tso>0, not the panel; {:,} rows ({:.1f}%) are invisible to it".format(
+            d.height - n_testable, 100.0 - cov
+        ),
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/npx-ownership-panel/scripts/run_dq.sh
+++ b/skills/npx-ownership-panel/scripts/run_dq.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#$ -cwd
+#$ -q all.q
+#$ -l m_mem_free=16G
+#
+# SGE wrapper for the post-merge detector sweep. Seconds against a ~35 minute DAG.
+#
+# This job REPORTS and does not gate: it is the last node, holds nothing, and no
+# detector count fails it. Its exit status still matters for a missing module or
+# a missing panel, which are operator errors rather than data findings.
+#
+# OWNERSHIP_DQ is passed through so a deployment that does not carry the `wrds`
+# skill alongside can point at the module wherever it landed. dq_panel.py falls
+# back to the repo layout and then to its own directory.
+export OWNERSHIP_DQ="${OWNERSHIP_DQ:-}"
+export YEAR2="${YEAR2:-2025}"
+/usr/local/bin/python3 dq_panel.py

--- a/skills/npx-ownership-panel/scripts/run_pipeline.sh
+++ b/skills/npx-ownership-panel/scripts/run_pipeline.sh
@@ -22,7 +22,9 @@
 #                                                     │      merge_panel.sas      │
 #                                                     │ prereq gate → universe    │
 #                                                     │ assert → join → pass_npx  │
-#                                                     └───────────────────────────┘
+#                                                     └─────────────┬─────────────┘
+#                                                                   ▼
+#                                                            dq_sweep (reports)
 #
 # npx_stage gates npx_array: the array hash-merges out.npx_link and out.npx_items,
 # and without them every task opens a missing dataset and exits 0 having written
@@ -67,9 +69,21 @@ for f in pipeline_config.sas build_meetings.sas build_inst_own.py build_short_in
          import_inst_own.sas run_import.sh \
          build_mflinks.sas split_s12.sas tfn_holdings_parallel.sas stage_npx_link.sas \
          build_npx.sas merge_panel.sas run_sas.sh run_python.sh run_npx_stage.sh \
-         run_npx_array.sh; do
+         run_npx_array.sh dq_panel.py run_dq.sh; do
     [ -f "$f" ] || { echo "PREFLIGHT ERROR: missing $f" >&2; preflight_fail=1; }
 done
+
+# The detector module lives in the `wrds` skill and is deliberately NOT duplicated
+# here, so a deployment that ships only this directory will not have it. WARN
+# rather than fail: the sweep is the last node and holds nothing, so a missing
+# module costs a report, not a panel. Better to say so now than 35 minutes in.
+if [ -z "$OWNERSHIP_DQ" ] \
+   && [ ! -f ../../wrds/scripts/ownership_dq.py ] \
+   && [ ! -f ownership_dq.py ]; then
+    echo "PREFLIGHT WARNING: ownership_dq.py not found — the post-merge detector" >&2
+    echo "  sweep will fail (the panel will still build). Set OWNERSHIP_DQ, or scp" >&2
+    echo "  skills/wrds/scripts/ownership_dq.py next to these scripts." >&2
+fi
 
 # Legs 2 and 5 are Python and need polars; the SAS legs do not. Check the
 # interpreter HERE rather than discovering it in a job log 30 minutes in — a
@@ -202,6 +216,21 @@ JOB_MERGE=$(qsub -terse -N merge -hold_jid "$ALL_DEPS" \
     run_sas.sh merge_panel.sas | cut -d. -f1)
 echo "  [M] merge_panel:     job $JOB_MERGE — held on everything"
 
+# --- Detector sweep: the number that says the panel is usable ----------------
+# SKILL.md: "A timed run should include the detector sweep (ownership_dq.py,
+# seconds) so the number means 'a panel you can use'." Nothing referenced it, so
+# every wall time quoted for this pipeline was the time to build a panel of
+# unmeasured quality. It costs seconds and holds nothing.
+#
+# Held on the MERGE rather than on leg 2 so it reports against the same panel the
+# run actually produced. It REPORTS and does not gate — no detector count fails
+# it, because the thresholds are not this DAG's to enforce.
+JOB_DQ=$(qsub -terse -N dq_sweep -hold_jid "$JOB_MERGE" \
+    -o logs/dq_panel.log -j y \
+    -v "OWNERSHIP_DQ=${OWNERSHIP_DQ:-},YEAR2=${Y2}" \
+    run_dq.sh | cut -d. -f1)
+echo "  [Q] dq_sweep:        job $JOB_DQ — held on merge (reports, does not gate)"
+
 cat <<MSG
 
 ==========================================
@@ -210,7 +239,7 @@ Expected wall: ~25 min (split_s12 ~15 min and the TFN chunks dominate).
 
   qstat -u \$USER                                        # progress
   grep -h NPXSTAT logs/build_npx_*.log                   # N-PX per-year reconciliation
-  grep -E 'PREREQ|UNIVERSE|ERROR' logs/merge_panel.log   # the gates
+  grep -rE 'PREREQ|UNIVERSE|OPTIONAL|DQ|ERROR' logs/     # every gate, one grep
 
 Output:
   out.pass      grain = itemonagendaid            (item-level ownership panel)


### PR DESCRIPTION
SKILL.md has said for a while:

> A timed run should include the detector sweep (`ownership_dq.py`, seconds) so the number means "a panel you can use", not "a panel that exists".

**Nothing implemented it.** No script in this skill referenced `ownership_dq.py` at all — so every wall time ever quoted for this pipeline (34m17s, 32m44s) was the time to build a panel of *unmeasured quality*. The sweep costs seconds against a ~35 minute DAG.

`dq_sweep` is now the last node, held on the merge so it reports against the panel the run actually produced.

## Three deliberate choices

**It reports, it does not gate.** No detector count fails the job. The thresholds in `ownership_dq.py` belong to whoever set them and are not this DAG's to enforce — a panel with a known 3.1% impossible-ratio rate is still the panel you meant to build. What would be wrong is *not knowing*.

**Not duplicated.** `ownership_dq.py` lives in the `wrds` skill, and SKILL.md says in as many words *"Deliberately not duplicated here."* So `dq_panel.py` **resolves** it — `$OWNERSHIP_DQ` → repo layout → own directory — rather than carrying a third copy that can drift. Preflight *warns* when it can't find it rather than failing: the sweep holds nothing, so a missing module costs a report and not a panel, and saying so at submit time beats discovering it 35 minutes in.

**The denominator is printed**, because it is the easiest number here to misread. `impossible_ratio` can only fire on rows carrying both `io_total` and `tso > 0` — 378,129 of 675,639. Quoting "3.110%" against the full row count reads as *"the panel is 96.9% clean"* and is silent about the 44% the check cannot see.

## Verified on the grid

Against the panel from the run that produced `A=272d4b96 B=842f984d C=34d76b49 C2=15dbb912`:

```
NOTE: DQ rows=675,639 coverage_end=0 duplicate_grain=0 join_coverage_tail=0
      unit_discontinuity=0 split_factor_ratio=2747 owner_dropout=5577
NOTE: DQ impossible_ratio=11,761/378,129=3.110% testable=56.0%_of_panel
NOTE: DQ the impossible_ratio denominator is rows with BOTH io_total and tso>0,
      not the panel; 297,510 rows (44.0%) are invisible to it
```

Reproduces the hand-run sweep exactly. Summary lines use the same shape as the PREREQ / UNIVERSE / OPTIONAL gates, so one grep covers all of them:

```bash
grep -rE 'PREREQ|UNIVERSE|OPTIONAL|DQ|ERROR' logs/
```