### PR TITLE
refactor(npx-panel): move the whole pipeline to CRSP CIZ; retire the SIZ splice

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_inst_own.py
+++ b/skills/npx-ownership-panel/scripts/build_inst_own.py
@@ -102,40 +102,41 @@ def quarter_index(rdate_int: pl.Expr) -> pl.Expr:
 # Step 0: CRSP data from WRDS
 # ---------------------------------------------------------------------------
 
+# CRSP 2.0 (CIZ) THROUGHOUT. This used to be a SPLICE: legacy crsp.msf +
+# crsp.msenames for everything through 2024-12-31, then crsp.msf_v2 for 2025,
+# because the legacy tables freeze there. That kept every historical quarter on
+# the source it had been validated against, and confined the CIZ universe to
+# quarters that previously had no data at all.
+#
+# It also meant THE PANEL CHANGED UNIVERSE MID-SAMPLE. The legacy filter is
+# shrcd IN (10,11); the CIZ filter is sharetype/securitytype/securitysubtype/
+# usincflg = NS/EQTY/COM/Y, and the two do not select the same securities.
+# Measured on this WRDS vintage (2026-07-27), distinct permnos in the universe:
+#
+#     2005-12-31   4,899 legacy   5,059 CIZ   +3.3%
+#     2010-12-31   4,031          4,161       +3.2%
+#     2015-12-31   3,796          3,984       +5.0%
+#     2020-12-31   3,767          3,957       +5.0%
+#     2024-06-30   3,930          4,095       +4.2%
+#
+# So under the splice, 2025 was measured on a universe 3-5% wider than every
+# year before it. A single break of that size inside the sample is worse than
+# being uniformly wider: it puts a discontinuity exactly where a researcher is
+# least likely to look for one, and it is invisible in any statistic that does
+# not cut on year. The 2025 stratum ALREADY reads as a different population —
+# 4,059 permnos against 10,335 in 2024, and zero null denominators where every
+# other year has many.
+#
+# One product, one universe, all history. The legacy tables are frozen and will
+# never be anything but further behind, so the splice was a growing seam.
+#
+# The adjustment bases agree, which is what made the splice safe and makes the
+# switch safe: AAPL 2014-06-30 is shrout 5,989,171 / factor 4.0 in BOTH tables,
+# and 2020-09-30 is 16,976,763 / 1.0 / 115.81 in both. shrout at the old
+# boundary differs ~0.5% (15,040,731 vs 15,115,823) — a vintage revision between
+# products, which is why crsp_src is still stamped on every row even though it
+# now carries one value.
 CRSP_MONTHLY_QUERY = """
-SELECT a.permno, a.date, a.prc, a.shrout, a.cfacpr, a.cfacshr,
-       b.ncusip
-FROM crsp.msf a
-INNER JOIN crsp.msenames b
-  ON a.permno = b.permno
-  AND b.namedt <= a.date
-  AND a.date <= COALESCE(b.nameendt, '2099-12-31')
-WHERE b.shrcd IN (10, 11)
-  AND a.date BETWEEN %(start)s AND %(end)s
-  AND a.shrout IS NOT NULL
-"""
-
-# CRSP 2.0 (CIZ) monthly. crsp.msf is the FROZEN legacy table and stops at
-# 2024-12-31; crsp.msf_v2 runs to 2025-12-31. Without this the panel silently
-# carried tso = NULL and ior = 0 for all four 2025 quarters — the same shape as
-# the Int8 overflow, and _assert_all_quarters did NOT catch it because the
-# months [3,6,9,12] all still existed; only the RANGE was short.
-#
-# Used to extend, not to replace. The CIZ share-class filter admits ~5% more
-# permnos than legacy shrcd IN (10,11) (4,229 vs 4,018 in 2015), so switching
-# wholesale would move the universe under results already validated against
-# Thomson. Splicing at the legacy boundary keeps every historical quarter on its
-# original source and confines the difference to quarters that had NO data.
-#
-# The adjustment bases agree, which is what makes the splice safe at all:
-# AAPL 2014-06-30 is shrout 5,989,171 / factor 4.0 in BOTH tables, and
-# 2020-09-30 is 16,976,763 / 1.0 / 115.81 in both. Verified before adopting.
-# shrout at the boundary differs ~0.5% (15,040,731 vs 15,115,823) — a vintage
-# revision between products, which is why crsp_src is stamped on every row.
-# crsp.msenames and crsp.msf freeze on the same date; keep it in one place.
-LEGACY_NAMES_END = "2024-12-31"
-
-CRSP_MONTHLY_V2_QUERY = """
 SELECT permno, mthcaldt AS date, mthprc AS prc, shrout,
        mthcumfacpr AS cfacpr, mthcumfacshr AS cfacshr, cusip AS ncusip
 FROM crsp.msf_v2
@@ -168,70 +169,67 @@ WHERE sharetype = 'NS'
 # over-matches and returns plausible numbers. Note the CRSP monthly query above
 # ALREADY does the dated join correctly -- it was simply never propagated here.
 CUSIP8_PERMNO_QUERY = """
-SELECT DISTINCT ncusip, permno, namedt, nameendt
-FROM crsp.msenames
-WHERE ncusip IS NOT NULL AND ncusip != ''
-"""
-
-# THE NAMES TABLE IS FROZEN TOO, AND DATING THE JOIN IS WHAT EXPOSED IT.
-#
-# crsp.msenames stops with the legacy product: max(nameendt) = 2024-12-31 and
-# NOT ONE of its 83,815 common-stock rows has a NULL nameendt. So the
-# `nameendt IS NULL -> 29991231` branch above never fires, every validity window
-# closes on or before 2024-12-31, and `rdate_int <= nameendt_int` drops every
-# 2025 holding. Measured before this splice: 2025 got 0 cusip8 matches and all
-# 15,546 of its panel rows carried io_total = NULL.
-#
-# That is the SAME hole the msf/msf_v2 splice above exists to close, one table
-# over — and it is invisible without the date bound, because the undated join
-# matched 2025 rows on a stale window and returned plausible numbers. Fixing the
-# over-match uncovered an under-match.
-#
-# crsp.stocknames_v2 is the CIZ successor and runs to 2025-12-31. Spliced on the
-# same terms as the monthly: EXTEND, never replace. Only windows reaching past
-# the legacy boundary are taken and their start is clamped to it, so every
-# historical quarter keeps its legacy window and the difference is confined to
-# dates that had no window at all. Share-class filter is byte-identical to
-# CRSP_MONTHLY_V2_QUERY so the names and the prices admit the same universe.
-CUSIP8_PERMNO_V2_QUERY = """
-SELECT DISTINCT cusip AS ncusip, permno, namedt, nameenddt AS nameendt
-FROM crsp.stocknames_v2
+SELECT DISTINCT cusip AS ncusip, permno,
+       secinfostartdt AS namedt, secinfoenddt AS nameendt
+FROM crsp.stksecurityinfohist
 WHERE cusip IS NOT NULL AND cusip != ''
   AND sharetype = 'NS'
   AND securitytype = 'EQTY'
   AND securitysubtype = 'COM'
   AND usincflg = 'Y'
-  AND COALESCE(nameenddt, '2099-12-31') >= %(v2_start)s
 """
 
-# First date the CIZ names table owns. The legacy table's windows CLOSE on
-# LEGACY_NAMES_END, and 2024-12-31 is itself a 13F quarter-end, so a v2 window
-# clamped to the boundary rather than the day after would double-match Q4 2024
-# and reintroduce exactly the duplicate this file now asserts against.
-V2_NAMES_START = "2025-01-01"
+# crsp.stksecurityinfohist IS the CIZ replacement for msenames/stocknames — the
+# CRSP-built identifier history, not the WRDS convenience wrapper
+# (crsp.stocknames_v2, 22 columns, legacy column names). Same share-class filter
+# as the monthly above, so the names and the prices admit the same universe.
+#
+# WHAT THIS DELETED. There used to be a second query against stocknames_v2 plus
+# a V2_NAMES_START constant, a clamp to the day AFTER the legacy boundary
+# (2024-12-31 is itself a 13F quarter-end, so clamping TO it double-matched
+# Q4 2024), and a collapse to one window per (cusip, permno) because
+# stocknames_v2 carries a row per name segment and clamping them all to one
+# start made them overlap. All of that existed only to reconcile a frozen table
+# with its successor. One table, no seam, none of it needed.
+#
+# THE CLIFF DID NOT GO AWAY. stksecurityinfohist has the same convention as
+# every other CRSP names table: 191,048 rows, ZERO null secinfoenddt, every
+# interval closing at the data vintage (2025-12-31 on this pull, against
+# msenames' 2024-12-31). The `nameendt IS NULL -> 29991231` branch below still
+# never fires. This buys one year and removes a seam; it does not remove the
+# hole, and the zero-match guard in the join is still the thing that catches it.
+#
+# CIZ is MORE granular than legacy: 191,048 intervals against msenames' 117,830,
+# because it splits on exchangetier changes SIZ ignored and emits a one-day row
+# for the delisting event. Adjacent intervals do not overlap, so a dated join
+# still matches exactly one — and the (permno, rdate, cik) uniqueness assertion
+# downstream is what proves that rather than this comment.
 
 
 def pull_crsp_monthly(user: str, start: str, end: str) -> pl.DataFrame:
     """Pull CRSP monthly panel from WRDS and compute adjusted fields."""
-    print(f"[crsp] pulling crsp.msf + msenames ({start} to {end})...")
+    print(f"[crsp] pulling crsp.msf_v2 ({start} to {end})...")
     t0 = time.time()
     conn = wrds_pull.connect(user=user)
     df = pd.read_sql(CRSP_MONTHLY_QUERY, conn, params={"start": start, "end": end})
-    df["crsp_src"] = "msf"
-    legacy_max = pd.to_datetime(df["date"]).max()
-    print(f"[crsp] {len(df):,} legacy rows to {legacy_max.date()} ({time.time() - t0:.1f}s)")
-
-    # Extend past the frozen legacy table with CIZ, if the request runs past it.
-    if pd.Timestamp(end) > legacy_max:
-        v2_start = (legacy_max + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
-        df2 = pd.read_sql(
-            CRSP_MONTHLY_V2_QUERY, conn, params={"start": v2_start, "end": end}
-        )
-        df2["crsp_src"] = "msf_v2"
-        print(f"[crsp] {len(df2):,} CIZ rows for {v2_start}..{end} (legacy ends {legacy_max.date()})")
-        df = pd.concat([df, df2], ignore_index=True)
+    df["crsp_src"] = "msf_v2"
     conn.close()
-    print(f"[crsp] {len(df):,} raw rows total")
+    obs_max = pd.to_datetime(df["date"]).max()
+    print(f"[crsp] {len(df):,} CIZ rows to {obs_max.date()} ({time.time() - t0:.1f}s)")
+
+    # The CIZ tables are frozen at their vintage exactly as the legacy ones were,
+    # so a request running past the data still comes back short — silently, and
+    # with every month present up to the cut. Say it here rather than let it
+    # surface as a year of null ownership. _assert_all_quarters checks the SHAPE
+    # of what arrived; this checks it against what was ASKED for.
+    if pd.Timestamp(end) > obs_max:
+        print(
+            f"[crsp] WARNING: requested through {end} but crsp.msf_v2 ends "
+            f"{obs_max.date()}. Quarters after that will carry no denominator "
+            f"(tso null, ior null). This is the CIZ vintage boundary — the same "
+            f"shape as the legacy freeze it replaced, one product later.",
+            flush=True,
+        )
 
     crsp = pl.from_pandas(df)
 
@@ -356,8 +354,10 @@ def _assert_covers_range(crsp: pl.DataFrame, end: str) -> None:
         raise ValueError(
             f"CRSP panel ends {got}, requested through {want}. Every holdings "
             f"quarter after {got} would join to nothing and silently carry "
-            f"tso = NULL and ior = 0. Extend the source (crsp.msf is frozen at "
-            f"2024-12-31; crsp.msf_v2 continues) or lower --end deliberately."
+            f"tso = NULL and ior = NULL. crsp.msf_v2 is frozen at ITS vintage "
+            f"just as crsp.msf was frozen at 2024-12-31 — CIZ moved the boundary, "
+            f"it did not remove it. Wait for the next CRSP vintage or lower --end "
+            f"deliberately."
         )
     print(f"[crsp] range check ok: covers through {got} (requested {want})")
 
@@ -389,29 +389,20 @@ def _assert_all_quarters(crsp: pl.DataFrame) -> None:
 
 def pull_cusip8_permno_map(user: str) -> pl.DataFrame:
     """Pull CUSIP8 → PERMNO mapping from WRDS."""
-    print("[cusip] pulling cusip8→permno from crsp.msenames...")
+    print("[cusip] pulling cusip8→permno from crsp.stksecurityinfohist...")
     t0 = time.time()
     conn = wrds_pull.connect(user=user)
     df = pd.read_sql(CUSIP8_PERMNO_QUERY, conn)
-    df2 = pd.read_sql(CUSIP8_PERMNO_V2_QUERY, conn,
-                      params={"v2_start": V2_NAMES_START})
     conn.close()
-    if len(df2):
-        # COLLAPSE TO ONE WINDOW PER (cusip, permno), THEN clamp. stocknames_v2
-        # carries a separate row per name segment, so clamping first and
-        # concatenating would hand the join several windows for the same pair,
-        # all starting on the same day — overlapping windows that fan a single
-        # holding into several rows. Collapsing to [min(namedt), max(nameenddt)]
-        # is safe because every segment resolves to the SAME permno, so widening
-        # within the pair cannot change which permno a cusip maps to.
-        df2["namedt"] = pd.to_datetime(df2["namedt"])
-        df2["nameendt"] = pd.to_datetime(df2["nameendt"])
-        df2 = (df2.groupby(["ncusip", "permno"], as_index=False)
-                  .agg(namedt=("namedt", "min"), nameendt=("nameendt", "max")))
-        df2["namedt"] = df2["namedt"].clip(lower=pd.Timestamp(V2_NAMES_START))
-        df = pd.concat([df, df2], ignore_index=True)
-    print(f"[cusip] {len(df2):,} CIZ name windows from {V2_NAMES_START} "
-          f"(crsp.msenames ends {LEGACY_NAMES_END})")
+    names_max = pd.to_datetime(df["nameendt"]).max()
+    print(f"[cusip] {len(df):,} CIZ name windows to {names_max.date()} "
+          f"({time.time() - t0:.1f}s)")
+    # Read dynamically, exactly as build_meetings.sas reads its own vintage, so
+    # the open-interval rule below follows the data through the next freeze.
+    _names_vintage = names_max
+    n_open = int((pd.to_datetime(df["nameendt"]) >= _names_vintage).sum())
+    print(f"[cusip] vintage {_names_vintage.date()}: {n_open:,} windows end there "
+          f"and are treated as OPEN (still current), not expired")
 
     cmap = pl.from_pandas(df).with_columns(
         pl.col("ncusip").cast(pl.Utf8),
@@ -422,7 +413,21 @@ def pull_cusip8_permno_map(user: str) -> pl.DataFrame:
          + pl.col("namedt").cast(pl.Date).dt.month().cast(pl.Int64) * 100
          + pl.col("namedt").cast(pl.Date).dt.day().cast(pl.Int64)
          ).cast(pl.Int32).alias("namedt_int"),
-        pl.when(pl.col("nameendt").is_null())
+        # AN INTERVAL ENDING AT THE VINTAGE MEANS "STILL CURRENT", NOT "EXPIRED".
+        #
+        # CRSP closes EVERY interval at its last data date and leaves no nulls —
+        # crsp.stksecurityinfohist: 191,048 rows, 0 null secinfoenddt, all ending
+        # on or before the vintage. So the `is_null -> 29991231` branch below has
+        # never once fired, on either product, and taking those end dates at face
+        # value is what silently emptied 2025 when msenames froze at 2024-12-31:
+        # every window had "expired", so every holding past it matched nothing.
+        #
+        # Moving to CIZ does not fix that; it only moves the date. The fix is to
+        # read a window that ends at the vintage as OPEN, which is what
+        # build_meetings.sas has always done for its own permno join. Same rule,
+        # same reason, now in both legs — and it follows the data rather than a
+        # constant someone has to remember to bump at the next freeze.
+        pl.when(pl.col("nameendt").is_null() | (pl.col("nameendt") >= _names_vintage))
         .then(pl.lit(29991231, dtype=pl.Int32))
         .otherwise(
             (pl.col("nameendt").cast(pl.Date).dt.year().cast(pl.Int64) * 10000
@@ -974,9 +979,10 @@ def join_adjust_and_aggregate(
             raise ValueError(
                 f"reporting year {y} resolved 0 rows through cusip8->permno. "
                 f"A whole year matching nothing means the reference window does "
-                f"not cover it — check that the cusip map extends past "
-                f"{LEGACY_NAMES_END} (crsp.msenames freezes there; "
-                f"crsp.stocknames_v2 continues)."
+                f"not cover it. crsp.stksecurityinfohist has ZERO null "
+                f"secinfoenddt and every interval closes at the data vintage, so "
+                f"a year past that vintage matches nothing — exactly how "
+                f"crsp.msenames ending 2024-12-31 silently emptied 2025."
             )
         parts.append(io_partial(j))
         del hy, j
@@ -1257,11 +1263,13 @@ def _assert_no_dead_tail(panel: pl.DataFrame, col: str = "io_total",
         raise ValueError(
             f"{col} is null for >={null_threshold:.0%} of rows in the last "
             f"{len(tail)} quarter(s) ({tail[0]}..{tail[-1]}) but not before. A "
-            f"reference table is frozen while the holdings kept going. Known "
-            f"culprits, both already spliced once: crsp.msf (-> msf_v2) and "
-            f"crsp.msenames (-> stocknames_v2, which also has ZERO null "
-            f"nameendt, so every window closes at its last date). Extend the "
-            f"source or lower --end deliberately."
+            f"reference table is frozen while the holdings kept going. The two "
+            f"sources are crsp.msf_v2 (prices/shrout) and "
+            f"crsp.stksecurityinfohist (cusip windows); BOTH close every interval "
+            f"at the CRSP vintage and neither carries a null end date, so a "
+            f"holdings quarter past that vintage matches nothing. This is the "
+            f"same shape as the legacy freeze at 2024-12-31 that this pipeline "
+            f"already hit once. Wait for the next vintage or lower --end."
         )
     print(f"[guard] no dead tail in {col} — checked {len(rates)} quarters")
 

--- a/skills/npx-ownership-panel/scripts/build_meetings.sas
+++ b/skills/npx-ownership-panel/scripts/build_meetings.sas
@@ -348,28 +348,37 @@ proc sort data=meetings1 nodupkey;
 run;
 
 /* --- CRSP permno: CUSIP match then ticker fallback --- */
-/* msenames.nameendt at the data vintage is "still current" — extend those records
- * to an open interval so post-vintage meetings (e.g. current-year) match their
- * latest name record instead of being dropped. Vintage is read dynamically. */
+/* crsp.stksecurityinfohist, not crsp.msenames: legacy SIZ froze at 2024-12-31
+ * and will never advance, so every additional year on it widens the gap against
+ * the CIZ tables the ownership legs read. A meetings leg on the legacy universe
+ * joined to an ownership leg on the CIZ universe is a 3-5% disagreement INSIDE
+ * one panel, which is worse than either universe on its own.
+ *
+ * The open-interval trick is UNCHANGED and still load-bearing. CIZ closes every
+ * interval at its data vintage exactly as SIZ did — crsp.stksecurityinfohist has
+ * 191,048 rows and ZERO null secinfoenddt — so a record ending at the vintage
+ * means "still current", not "expired". Without this, post-vintage meetings
+ * match nothing and drop silently. Vintage is read dynamically so it follows the
+ * data instead of a constant someone has to remember to bump. */
 proc sql noprint;
-    select max(nameendt) format=date9. into :crsp_vintage trimmed
-        from crsp.msenames;
+    select max(secinfoenddt) format=date9. into :crsp_vintage trimmed
+        from crsp.stksecurityinfohist;
 quit;
-%put NOTE: crsp.msenames vintage max nameendt = &crsp_vintage;
+%put NOTE: crsp.stksecurityinfohist vintage max secinfoenddt = &crsp_vintage;
 
 proc sql;
     create table meetings2 as
         select distinct b.permno, a.*
-        from meetings1 a, crsp.msenames b
-        where substr(a.cusip,1,6)=substr(b.ncusip,1,6)
-        and a.meetingdate >= b.namedt
-        and (a.meetingdate <= b.nameendt or b.nameendt >= "&crsp_vintage"d);
+        from meetings1 a, crsp.stksecurityinfohist b
+        where substr(a.cusip,1,6)=substr(b.cusip,1,6)
+        and a.meetingdate >= b.secinfostartdt
+        and (a.meetingdate <= b.secinfoenddt or b.secinfoenddt >= "&crsp_vintage"d);
     create table meetings3 as
         select distinct b.permno, a.*
-        from meetings1 a, crsp.msenames b
-        where a.ticker = coalescec(b.ticker,b.tsymbol)
-        and a.meetingdate >= b.namedt
-        and (a.meetingdate <= b.nameendt or b.nameendt >= "&crsp_vintage"d)
+        from meetings1 a, crsp.stksecurityinfohist b
+        where a.ticker = coalescec(b.ticker,b.tradingsymbol)
+        and a.meetingdate >= b.secinfostartdt
+        and (a.meetingdate <= b.secinfoenddt or b.secinfoenddt >= "&crsp_vintage"d)
         and a.meetingid not in (select distinct meetingid from meetings2);
 quit;
 

--- a/skills/npx-ownership-panel/scripts/build_short_interest.py
+++ b/skills/npx-ownership-panel/scripts/build_short_interest.py
@@ -84,15 +84,14 @@ WHERE a.datadate BETWEEN %(start)s AND %(end)s
 # cold start and the check that depended on it silently did nothing — see the
 # comment at the call site. Quarter-end months only, so this stays small.
 TSO_CHECK_QUERY = """
-SELECT a.permno, a.date, a.shrout, a.cfacshr
-FROM crsp.msf a
-INNER JOIN crsp.msenames b
-  ON a.permno = b.permno
-  AND b.namedt <= a.date
-  AND a.date <= COALESCE(b.nameendt, '2099-12-31')
-WHERE b.shrcd IN (10, 11)
-  AND a.date BETWEEN %(start)s AND %(end)s
-  AND a.shrout IS NOT NULL
+SELECT permno, mthcaldt AS date, shrout, mthcumfacshr AS cfacshr
+FROM crsp.msf_v2
+WHERE sharetype = 'NS'
+  AND securitytype = 'EQTY'
+  AND securitysubtype = 'COM'
+  AND usincflg = 'Y'
+  AND mthcaldt BETWEEN %(start)s AND %(end)s
+  AND shrout IS NOT NULL
   AND EXTRACT(MONTH FROM a.date) IN (3, 6, 9, 12)
 """
 

--- a/skills/npx-ownership-panel/scripts/tfn_holdings_parallel.sas
+++ b/skills/npx-ownership-panel/scripts/tfn_holdings_parallel.sas
@@ -187,12 +187,23 @@ run;
 
 %put NOTE: Fund-level holdings saved. Starting aggregation...;
 
-/* --- Step 4: CUSIP -> PERMNO mapping --- */
+/* --- Step 4: CUSIP -> PERMNO mapping ---------------------------------------
+ * crsp.stksecurityinfohist, not crsp.msenames: the legacy SIZ tables are frozen
+ * at 2024-12-31 and will never advance, so every year on them widens the gap
+ * against the CIZ tables the rest of the pipeline reads.
+ *
+ * DELIBERATELY UNFILTERED, as it was before. This map is cusip6 -> permno for
+ * Thomson S12 holdings, and narrowing it to NS/EQTY/COM/Y here would drop
+ * holdings rather than classify them. The cusip6 grain is itself coarse — it
+ * maps other share classes and preferreds onto the common permno, which is D9
+ * cause 2 and the reason leg 2 disables its cusip6 fallback. That is a
+ * pre-existing property of this leg, not something the CIZ swap introduces, and
+ * it is not changed here. */
 proc sql;
     create table cusip_permno as
-        select distinct substr(ncusip,1,6) as cusip6 length=6, permno
-        from crsp.msenames
-        where ncusip is not null;
+        select distinct substr(cusip,1,6) as cusip6 length=6, permno
+        from crsp.stksecurityinfohist
+        where cusip is not null;
 quit;
 
 /* --- Step 5: Map holdings to PERMNO --- */
@@ -211,17 +222,27 @@ data holdings_permno;
     index_shares = shares * pure_index;
 run;
 
-/* --- Step 6: Get shares outstanding from CRSP MSF --- */
+/* --- Step 6: Shares outstanding from CRSP monthly (CIZ) ---------------------
+ * crsp.msf_v2, not crsp.msf: the legacy monthly file is frozen at 2024-12-31, so
+ * on it every quarter after that silently produced NO tso row and the mutual-fund
+ * ownership percentages for those quarters came out null — the same failure leg 2
+ * hit, in the leg next door.
+ *
+ * `having date = max(date)` takes the LAST month in the quarter, which is the
+ * end-of-quarter snapshot this join wants. It is a correlated HAVING over the
+ * group, so it states the rule rather than relying on arrival order. */
 proc sql;
     create table msf_qtr as
         select permno,
-               intnx('quarter', date, 0, 'E') as qtr format yymmddn8.,
+               intnx('quarter', mthcaldt, 0, 'E') as qtr format yymmddn8.,
                shrout * 1000 as tso
-        from crsp.msf
-        where date between "01jan&year_start."d and "31dec&year_end."d
+        from crsp.msf_v2
+        where mthcaldt between "01jan&year_start."d and "31dec&year_end."d
         and shrout > 0
+        and sharetype = 'NS' and securitytype = 'EQTY'
+        and securitysubtype = 'COM' and usincflg = 'Y'
         group by permno, calculated qtr
-        having date = max(date);
+        having mthcaldt = max(mthcaldt);
 quit;
 
 /* --- Step 7: Aggregate to permno-quarter --- */


### PR DESCRIPTION
Legacy SIZ is frozen at 2024-12-31 and will never advance, so every additional year on it widens the seam. This moves **all four consumers** to CIZ at once.

## Why all four, not just leg 2

`crsp.msenames` was doing two jobs — **identifiers** *and* **the universe filter** (`shrcd IN (10,11)`) — and they ride the same join. The CIZ filter (`NS/EQTY/COM/Y`) is not the same universe. Measured on this vintage, distinct permnos:

| date | legacy | CIZ | |
|---|---|---|---|
| 2005-12-31 | 4,899 | 5,059 | +3.3% |
| 2010-12-31 | 4,031 | 4,161 | +3.2% |
| 2015-12-31 | 3,796 | 3,984 | **+5.0%** |
| 2020-12-31 | 3,767 | 3,957 | **+5.0%** |
| 2024-06-30 | 3,930 | 4,095 | +4.2% |

Converting leg 2 alone would have joined an ownership leg on the CIZ universe to a meetings leg on the legacy one — a 3–5% disagreement **inside a single panel**, strictly worse than either universe used consistently.

It also removes a break that was *already there*: under the splice, 2025 was measured on a universe 3–5% wider than every prior year. That is part of why the 2025 stratum reads as a different population — 4,059 permnos against 10,335 in 2024, with zero null denominators where every other year has many.

## A second live legacy query

`tfn_holdings_parallel.sas` pulled shares outstanding from `crsp.msf`, so **leg 1's mutual-fund percentages produced no `tso` row for any quarter after 2024-12-31** — the same failure leg 2 hit, in the leg next door. A leg-2-only refactor would have left it in place.

## What changed

| file | leg | |
|---|---|---|
| `build_inst_own.py` | 2 | `msf`+`msenames` → `msf_v2`; cusip map → `stksecurityinfohist` |
| `build_meetings.sas` | A | both permno joins → `stksecurityinfohist` (`tsymbol`→`tradingsymbol`) |
| `tfn_holdings_parallel.sas` | 1 | cusip6 map **and** shares-outstanding query → CIZ |
| `build_short_interest.py` | 5 | TSO units check → `msf_v2` |

**Deleted:** `LEGACY_NAMES_END`, `V2_NAMES_START`, the second names query, the clamp-to-the-day-after, and the collapse-to-one-window. All of it existed only to reconcile a frozen table with its successor.

Note `stksecurityinfohist` is the CRSP-built identifier history — the documented replacement for `msenames`/`stocknames` — not `stocknames_v2`, which is the WRDS convenience wrapper with legacy column names.

## The cliff moved; it did not go away

CIZ closes every interval at its vintage exactly as SIZ did: `stksecurityinfohist` has 191,048 rows and **zero** null `secinfoenddt`. So the `is_null → 29991231` branch has never fired on either product.

Leg 2 now adopts the rule `build_meetings.sas` already used — **read an interval ending at the vintage as open, not expired** — with the vintage read dynamically from the data rather than a constant somebody has to remember to bump. Same rule in both legs. The guards no longer prescribe a splice that no longer exists; they name the vintage boundary.

CIZ is also more granular: 191,048 intervals vs `msenames`' 117,830, because it splits on `exchangetier` changes SIZ ignored and emits a one-day delisting row. Adjacent intervals don't overlap, so a dated join still matches exactly one — and the `(permno, rdate, cik)` uniqueness assertion is what proves that rather than this paragraph.

## Expect all four digests to move — **including A**

The meetings leg's permno linkage changes, which no previous change touched. A has been stable across every run to date, so this is the first time its movement is expected rather than a finding.

Not yet run on the grid — that's the next step, with a full per-column decomposition.