### PR TITLE
fix(npx-panel): CIZ fallout — a broken query, a filter I should not have added, and a gate that let both through

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_inst_own.py
+++ b/skills/npx-ownership-panel/scripts/build_inst_own.py
@@ -168,15 +168,23 @@ WHERE sharetype = 'NS'
 # Same shape as every other defect in this file: a join that silently
 # over-matches and returns plausible numbers. Note the CRSP monthly query above
 # ALREADY does the dated join correctly -- it was simply never propagated here.
+# DELIBERATELY UNFILTERED, as the msenames version was. This map answers "which
+# permno did this cusip8 belong to on this date", and a 13F position in a
+# security that is not NS/EQTY/COM/Y still has an answer. The universe filter
+# belongs on the CRSP monthly join, which is where it is: filtering here does not
+# reclassify those holdings, it makes them UNRESOLVABLE and drops them.
+#
+# Measured cost of getting this wrong: adding the share-class filter here cut the
+# map from 191,048 windows to 109,273 and took leg 2 from 675,639 rows to 396,771
+# — a 41% loss that read like an improvement, because the DQ line then reported
+# `testable=98.9%_of_panel` against 56.0%. The unknown-denominator rows had not
+# acquired denominators; they had been deleted. A coverage statistic rising
+# because the uncovered rows left is the most flattering possible way to lose data.
 CUSIP8_PERMNO_QUERY = """
 SELECT DISTINCT cusip AS ncusip, permno,
        secinfostartdt AS namedt, secinfoenddt AS nameendt
 FROM crsp.stksecurityinfohist
 WHERE cusip IS NOT NULL AND cusip != ''
-  AND sharetype = 'NS'
-  AND securitytype = 'EQTY'
-  AND securitysubtype = 'COM'
-  AND usincflg = 'Y'
 """
 
 # crsp.stksecurityinfohist IS the CIZ replacement for msenames/stocknames — the

--- a/skills/npx-ownership-panel/scripts/build_short_interest.py
+++ b/skills/npx-ownership-panel/scripts/build_short_interest.py
@@ -92,7 +92,7 @@ WHERE sharetype = 'NS'
   AND usincflg = 'Y'
   AND mthcaldt BETWEEN %(start)s AND %(end)s
   AND shrout IS NOT NULL
-  AND EXTRACT(MONTH FROM a.date) IN (3, 6, 9, 12)
+  AND EXTRACT(MONTH FROM mthcaldt) IN (3, 6, 9, 12)
 """
 
 

--- a/skills/npx-ownership-panel/scripts/import_inst_own.sas
+++ b/skills/npx-ownership-panel/scripts/import_inst_own.sas
@@ -21,18 +21,36 @@
  * Read the header and abort on mismatch rather than trust it. */
 %let expected = permno,rdate,numowners,io_total,ioc_hhi,dbreadth,ior,tso,me,p,cfacshr,io_missing,io_g1,split_quarter,split_adjacent,shortint,si_missing,shortint_adj,io_total_net,si_frac,ior_net,net_clamped;
 
-data _null_;
-    infile "&csv." obs=1 truncover lrecl=32767;
-    input hdr $32767.;
-    call symputx("got", strip(hdr));
-run;
-
+/* EXISTENCE FIRST, THEN THE HEADER. This used to read the header in open code
+ * and check afterwards. When the CSV was absent the infile failed, `got` was
+ * never set, and the comparison then died with "A character operand was found in
+ * the %EVAL function" -> "The macro CHECK_HEADER will stop executing" — so the
+ * guard reported neither a missing file nor a header mismatch. It just stopped,
+ * and the run continued past it into an empty out.inst_own.
+ *
+ * A guard that fails to run is worse than no guard, because its name still
+ * appears in the log. Order matters: check the file is there, THEN read it.
+ * %superq compares the raw text without re-scanning it for macro triggers. */
 %macro check_header;
-    %if %quote(&got.) ne %quote(&expected.) %then %do;
+    %if not %sysfunc(fileexist("&csv.")) %then %do;
+        %put ERROR: inst_own.csv not found at &csv.;
+        %put ERROR- build_inst_own.py did not write it. Its schema guard refuses;
+        %put ERROR- to emit a CSV whose columns disagree with SAS_COLUMNS, so the;
+        %put ERROR- cause is upstream in leg 2, not here.;
+        data _null_; abort abend; run;
+    %end;
+
+    data _null_;
+        infile "&csv." obs=1 truncover lrecl=32767;
+        input hdr $32767.;
+        call symputx("got", strip(hdr));
+    run;
+
+    %if %superq(got) ne %superq(expected) %then %do;
         %put ERROR: inst_own.csv header does not match the expected column order.;
-        %put ERROR- expected: &expected.;
-        %put ERROR- got     : &got.;
-        %abort cancel;
+        %put ERROR- expected: %superq(expected);
+        %put ERROR- got     : %superq(got);
+        data _null_; abort abend; run;
     %end;
     %else %put NOTE: IMPORT header OK (22 columns, order verified);
 %mend;
@@ -60,7 +78,25 @@ proc sql noprint;
 quit;
 %put NOTE: IMPORTSTAT out.inst_own rows=&n. permnos=&np. rdate=&d1.-&d2.;
 
-%if &n. = 0 %then %do;
-    %put ERROR: out.inst_own imported 0 rows.;
-    %abort cancel;
-%end;
+/* `%if` / `%abort cancel` IN OPEN CODE DOES NOT WORK, and this is what that
+ * costs. Observed 2026-07-27: the CSV was absent, this check fired and printed
+ * its ERROR — and then SAS said "ERROR: The %ABORT statement is not valid in
+ * open code", carried on, and left out.inst_own existing with ZERO rows.
+ * merge_panel's gate saw a dataset that existed and built a full panel with no
+ * institutional ownership in it.
+ *
+ * So the detection was right and only the stopping was broken, which is the
+ * worst version: a check that reports a fatal condition and then does not stop
+ * is indistinguishable in a log from a check that passed. Wrapped in a macro so
+ * %if and %abort are in macro context, and `abort abend` in a data step is what
+ * actually returns non-zero to SGE. */
+%macro _require_rows;
+    %if &n. = 0 %then %do;
+        %put ERROR: out.inst_own imported 0 rows.;
+        %put ERROR- The CSV was missing or empty. build_inst_own.py refuses to;
+        %put ERROR- write it when its own schema guard fails, so look THERE first;
+        %put ERROR- rather than at this step.;
+        data _null_; abort abend; run;
+    %end;
+%mend;
+%_require_rows

--- a/skills/npx-ownership-panel/scripts/merge_panel.sas
+++ b/skills/npx-ownership-panel/scripts/merge_panel.sas
@@ -61,9 +61,42 @@
     %local missing;
     %let missing = ;
 
-    %if not %sysfunc(exist(out.meetings)) %then %let missing = &missing. out.meetings;
-    %if not %sysfunc(exist(out.inst_own)) %then %let missing = &missing. out.inst_own;
-    %if not %sysfunc(exist(out.npx_items)) %then %let missing = &missing. out.npx_items;
+    /* EXISTENCE IS NOT CONTENT. This gate checked exist() alone, and an EMPTY
+     * dataset exists. Observed 2026-07-27: leg 5 died on a SQL error, so leg 2's
+     * own guard correctly refused to write its CSV, so import_inst_own created
+     * out.inst_own with ZERO rows — and this gate passed it. merge_panel then
+     * built a complete-looking 2,019,563 x 81 panel with NO institutional
+     * ownership in it, and every gate line in the run reported clean:
+     *
+     *     PREREQ   mf_own_chunks=9 npx_cell_years=21/21 s12_partitions=9/9
+     *     UNIVERSE meetings_items=624,162 npx_items=712,466 orphans=0
+     *
+     * That is precisely the failure this gate exists to prevent, one level down:
+     * `hold_jid` releases on COMPLETION not success, so the gate has to check
+     * what arrived — and "it is there" was never the question. Row counts are the
+     * question. */
+    %local n_meet_rows n_io_rows n_item_rows;
+    %macro _rows(ds, into);
+        %if %sysfunc(exist(&ds.)) %then %do;
+            %local dsid;
+            %let dsid = %sysfunc(open(&ds.));
+            %let &into. = %sysfunc(attrn(&dsid., nlobs));
+            %let dsid = %sysfunc(close(&dsid.));
+        %end;
+        %else %let &into. = -1;
+    %mend;
+    %_rows(out.meetings,  n_meet_rows)
+    %_rows(out.inst_own,  n_io_rows)
+    %_rows(out.npx_items, n_item_rows)
+
+    %if &n_meet_rows. < 0 %then %let missing = &missing. out.meetings(absent);
+    %else %if &n_meet_rows. = 0 %then %let missing = &missing. out.meetings(EMPTY);
+    %if &n_io_rows. < 0 %then %let missing = &missing. out.inst_own(absent);
+    %else %if &n_io_rows. = 0 %then %let missing = &missing. out.inst_own(EMPTY);
+    %if &n_item_rows. < 0 %then %let missing = &missing. out.npx_items(absent);
+    %else %if &n_item_rows. = 0 %then %let missing = &missing. out.npx_items(EMPTY);
+
+    %put NOTE: PREREQ rows meetings=&n_meet_rows. inst_own=&n_io_rows. npx_items=&n_item_rows.;
 
     /* At least one mutual-fund ownership chunk from tfn_holdings_parallel. */
     %local n_mf;


### PR DESCRIPTION
The CIZ run produced a complete-looking panel with **no institutional ownership in it**, and every gate reported clean. Three defects.

## 1. Leg 5 SQL — mine

Replacing the `msf`+`msenames` join left a predicate referencing the old alias:

```sql
AND EXTRACT(MONTH FROM a.date) IN (3, 6, 9, 12)   -- "a" no longer exists
```

Leg 5 died; `short_interest.parquet` was never written. I edited a query without reading past the lines I was replacing.

## 2. Cusip map filter — also mine

I added the share-class filter to the cusip8→permno map. The `msenames` version had none, and shouldn't: the map answers *which permno did this cusip8 belong to on this date*, and a 13F position outside `NS/EQTY/COM/Y` still has an answer. The universe filter belongs on the CRSP monthly join, where it already is.

| map | windows |
|---|---|
| CIZ unfiltered (correct) | 155,771 |
| legacy `msenames` | 112,372 |
| **CIZ + my filter** | **109,273** — narrower than what it replaced |

Leg 2 fell **675,639 → 396,771 rows (−41%)**, and it read as an *improvement* because the DQ line then said `testable=98.9%_of_panel` against 56.0%. The unknown-denominator rows hadn't acquired denominators — they'd been deleted.

## 3. The gate — not mine, and the real finding

Leg 2's schema guard worked perfectly and refused to write a bad CSV. Then everything downstream failed to stop:

- `import_inst_own`'s 0-row check **fired and could not stop** — `%abort cancel` in open code is invalid, so SAS printed *"The %ABORT statement is not valid in open code"* and carried on.
- its header guard **never ran** — the infile failed first, `got` was unset, and the comparison died in `%EVAL`, taking the macro with it.
- `merge_panel`'s PREREQ gate checks `exist()`. **An empty dataset exists.** It passed.

A guard that detects a fatal condition and then doesn't stop is worse than no guard, because its name still appears in the log.

Fixed: existence checked **before** the header is read; both aborts are `abort abend` in macro context so they return non-zero to SGE; and the PREREQ gate now reads and reports row counts:

```
NOTE: PREREQ rows meetings=<n> inst_own=<n> npx_items=<n>
```

## The check I should have run before #99

Every SQL literal in both builders is now executed against WRDS as `SELECT * FROM (...) LIMIT 1` before deploy. All four pass. **A syntax error in a query string cannot be caught by `py_compile`** — which is the only verification #99 got.