### PR TITLE
fix(look-at): repair both vision backends (v5.87.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.87.1"
+    "version": "5.87.2"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.87.1",
+      "version": "5.87.2",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.87.1",
+  "version": "5.87.2",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/skills/look-at/scripts/look_at.py
+++ b/skills/look-at/scripts/look_at.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env -S uv run python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["google-genai"]
+# ///
 """Analyze media files using Gemini 2.5 Flash Lite for fast, cost-effective interpretation.
 
 This script uploads a local file to Google's Gemini API and extracts specific information
@@ -38,7 +42,8 @@ try:
     from google.genai import types
 except ImportError:
     print("Error: google-genai package not installed", file=sys.stderr)
-    print("Install with: pip install google-genai", file=sys.stderr)
+    print("Run this script with `uv run --script look_at.py` so uv can", file=sys.stderr)
+    print("provision the inline PEP 723 dependencies automatically.", file=sys.stderr)
     sys.exit(1)
 
 

--- a/skills/look-at/scripts/look_at.sh
+++ b/skills/look-at/scripts/look_at.sh
@@ -53,9 +53,61 @@ FILE="$(cd "$(dirname "$FILE")" && pwd)/$(basename "$FILE")"
 IMAGE_DIR="$(dirname "$FILE")"
 FULL_PROMPT="Read the image at $FILE. $GOAL"
 
+# Resolve a Gemini API key from the usual places, in priority order.
+# Echoes the key, or nothing if none is available.
+resolve_gemini_key() {
+  if [[ -n "${GEMINI_API_KEY:-}" ]]; then
+    printf '%s' "$GEMINI_API_KEY"
+  elif [[ -n "${GOOGLE_API_KEY:-}" ]]; then
+    printf '%s' "$GOOGLE_API_KEY"
+  elif [[ -n "${GEMINI_API_KEY_FILE:-}" && -r "${GEMINI_API_KEY_FILE}" ]]; then
+    tr -d '\n' < "$GEMINI_API_KEY_FILE"
+  fi
+}
+
 run_gemini() {
   if $VERBOSE; then echo "[look-at] backend=gemini" >&2; fi
-  gemini -y --include-directories "$IMAGE_DIR" -p "$FULL_PROMPT"
+
+  # gemini-cli picks its auth method from GEMINI_API_KEY specifically; it does
+  # not accept GOOGLE_API_KEY as an auth *selector* (only as the key value once
+  # a method is chosen). Bridge whatever key we have into that variable.
+  local key
+  key="$(resolve_gemini_key)"
+  if [[ -z "$key" ]]; then
+    echo "Error: no Gemini API key found. Set GEMINI_API_KEY, GOOGLE_API_KEY, or GEMINI_API_KEY_FILE." >&2
+    return 1
+  fi
+
+  # gemini-cli cannot ingest PDFs -- it reliably dies with "Invalid stream: the
+  # model returned an empty response or malformed tool call". Rasterize to PNG
+  # first (poppler) and point it at those instead. The api backend needs no such
+  # help: it uploads PDFs natively.
+  local dir="$IMAGE_DIR" prompt="$FULL_PROMPT" tmpdir=""
+  if [[ "${FILE,,}" == *.pdf ]]; then
+    if command -v pdftoppm >/dev/null 2>&1; then
+      tmpdir="$(mktemp -d)"
+      # shellcheck disable=SC2064
+      trap "rm -rf '$tmpdir'" RETURN
+      if $VERBOSE; then echo "[look-at] rasterizing PDF -> PNG for gemini backend" >&2; fi
+      pdftoppm -r 200 -png "$FILE" "$tmpdir/page" >/dev/null 2>&1 || {
+        echo "Error: failed to rasterize PDF for the gemini backend." >&2
+        return 1
+      }
+      local pages=("$tmpdir"/page*.png)
+      [[ -e "${pages[0]}" ]] || { echo "Error: PDF produced no pages." >&2; return 1; }
+      dir="$tmpdir"
+      prompt="The document has been rendered to ${#pages[@]} page image(s): ${pages[*]}. Read them all. $GOAL"
+    else
+      echo "Warning: pdftoppm not found; the gemini backend cannot read PDFs." >&2
+      echo "Install poppler-utils, or use --backend api (handles PDFs natively)." >&2
+      return 1
+    fi
+  fi
+
+  # Non-interactive runs can't answer the trusted-folder prompt, which otherwise
+  # aborts the call in any directory the user hasn't trusted interactively.
+  GEMINI_API_KEY="$key" GEMINI_CLI_TRUST_WORKSPACE=true \
+    gemini -y --include-directories "$dir" -p "$prompt"
 }
 
 run_copilot() {
@@ -69,7 +121,9 @@ run_api() {
   [[ -n "$MODEL" ]] && args+=(--model "$MODEL")
   $AGENTIC && args+=(--agentic)
   $VERBOSE && args+=(--verbose)
-  uv run python3 "$SCRIPT_DIR/look_at.py" "${args[@]}"
+  # --script honors look_at.py's inline PEP 723 metadata, so uv provisions
+  # google-genai into an ephemeral env instead of relying on the ambient python.
+  uv run --script "$SCRIPT_DIR/look_at.py" "${args[@]}"
 }
 
 if $CONSENSUS; then


### PR DESCRIPTION
Both default `look-at` backends failed instantly on the Linux box (omarchy). Four distinct causes, all fixed here.

## Root causes

1. **`gemini` backend — auth.** gemini-cli selects its auth *method* from `GEMINI_API_KEY` specifically, and errors out when none of `GEMINI_API_KEY` / `GOOGLE_GENAI_USE_VERTEXAI` / `GOOGLE_GENAI_USE_GCA` is set. `GOOGLE_API_KEY` is only accepted as the key *value* once a method is chosen — exporting it alone is not enough. `run_gemini` now resolves a key from `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or `GEMINI_API_KEY_FILE` and bridges it into `GEMINI_API_KEY`.

2. **`gemini` backend — trusted folders.** Even with auth fixed, gemini-cli aborts non-interactively in any directory not trusted by hand. Set `GEMINI_CLI_TRUST_WORKSPACE=true`.

3. **`api` backend — missing dependency.** `uv run python3 look_at.py` does not read inline script metadata, so google-genai was never provisioned. `look_at.py` now carries PEP 723 metadata and the wrapper invokes it with `uv run --script`.

4. **`gemini` backend — PDFs.** gemini-cli cannot ingest PDFs at all: every attempt dies with `Invalid stream: The model returned an empty response or malformed tool call`, deterministically, while the same page as PNG works fine. `run_gemini` now rasterizes PDFs via `pdftoppm` first. The `api` backend needs no such help — it uploads PDFs natively.

## Verification

Ran end-to-end against a scanned (no text layer) lease worksheet with **both `GEMINI_API_KEY` and `GOOGLE_API_KEY` unset**, so the key resolved from `GEMINI_API_KEY_FILE` alone. Both backends returned identical figures, matching an independent `gemini-2.5-pro` read.

Pairs with edwinhu/nix#gemini-api-key-env, which exports the key from agenix so this works outside a Claude Code session too.

## Note

Version bumped to 5.87.2 so the plugin cache actually refreshes — the `api` backend stays broken in normal sessions until the cache picks up a new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F9Vo2SiKbJFqCXWWr85Tp