### PR TITLE
chore(release): v5.87.3 — bump bmll submodule to the US @SIP findings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.87.2"
+    "version": "5.87.3"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.87.2",
+      "version": "5.87.3",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.87.2",
+  "version": "5.87.3",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"


### PR DESCRIPTION
Points `skills/bmll` at edwinhu/bmll-skill@8c3693a (bmll-skill#2).

That PR documents the US `@SIP` Trades Plus divergences: `Printable` is absent on that feed (pre-filtered, so an unconditional filter `KeyError`s) while negative-`Size` cancellations remain, so `printable_only()` now guards `Size > 0` in both branches; consolidated quote sizes convert by the instrument's `ROUND_LOT` rather than a flat 100; `...AtVenue` must be joined on exchange sequence numbers rather than timestamps; and `...AtPrimary` is odd-lot-inclusive, giving an odd-lot benchmark without rebuilding an L3 book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F9Vo2SiKbJFqCXWWr85Tp