### PR TITLE
fix(linking): state the tie-break where a fundno maps to several wficn / units

### DIFF
--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link.py
@@ -194,7 +194,30 @@ print(f"\ncrsp_cik_map                       : {cikmap.height:,} rows, "
       f"{sid2fno['series_cik'].n_unique():,} series_ciks, "
       f"{sid2fno.height:,} (series, fundno) pairs")
 
-mflink = pl.read_parquet(MFLINK1).unique(subset=["crsp_fundno"], keep="first")
+# A crsp_fundno can carry MORE THAN ONE wficn in MFLINK1, and `keep="first"` with
+# no preceding sort picks by whatever row order the parquet happens to have —
+# an undefined choice on the linking critical path, since wficn is how S12
+# holdings reach a fund. Measured on mflink1_cache: 50,380 rows, 49,975 distinct
+# crsp_fundno, and 341 fundnos (0.68%) mapping to more than one wficn.
+#
+# There is no discriminator in this file to break the tie ON — it has exactly two
+# columns — so this cannot be resolved into a *right* answer here. What it can be
+# is DECLARED: sort first so the pick is stated (lowest wficn) rather than
+# inherited from row order, and print the count so the magnitude is visible
+# instead of silent. The remaining question, which wficn is correct for those 341,
+# is a domain question for MFLINK and is flagged, not guessed.
+_mf_raw = pl.read_parquet(MFLINK1)
+_mf_amb = int(
+    _mf_raw.group_by("crsp_fundno").agg(pl.col("wficn").n_unique().alias("k"))
+    .filter(pl.col("k") > 1).height
+)
+mflink = (
+    _mf_raw.sort(["crsp_fundno", "wficn"])
+    .unique(subset=["crsp_fundno"], keep="first", maintain_order=True)
+)
+print(f"mflink1 dedup                      : {_mf_raw.height:,} rows -> "
+      f"{mflink.height:,} crsp_fundno; {_mf_amb:,} map to >1 wficn and are "
+      f"resolved by lowest wficn (stated, not row order)")
 print(f"mflink1 (deduped on fundno)        : {mflink.height:,} rows")
 
 # ---------------------------------------------------------------------------
@@ -379,7 +402,14 @@ if "crsp_fundno" in fund.columns:
     # aggregated exactly as the other tiers are -- otherwise an L2-sourced fund
     # would carry one class's TNA while a seriesId-sourced one carries the
     # whole fund's, and the two would not be comparable as vote weights.
-    fno2unit = named.select("crsp_fundno", "unit").unique(subset=["crsp_fundno"], keep="first")
+    # Same undefined choice as the mflink1 dedup above: no sort, so `keep="first"`
+    # picks a unit for a fundno that spans units by row order. Sort so the pick is
+    # stated (lowest unit) rather than inherited.
+    fno2unit = (
+        named.select("crsp_fundno", "unit")
+        .sort(["crsp_fundno", "unit"])
+        .unique(subset=["crsp_fundno"], keep="first", maintain_order=True)
+    )
     l2c = (
         fund.join(exact.select("fundid"), on="fundid", how="anti")
         .filter(pl.col("crsp_fundno").is_not_null() & ~pl.col("iss_nonregistrant"))
@@ -795,7 +825,13 @@ print(f"  median TNA ($M)                  : {lk['tna_latest'].median():,.1f}")
 # ISS fundid is often share-class-grained, so several fundids share one CRSP
 # fund and its TNA. Summing over fundids double-counts; the magnitude check has
 # to be done over DISTINCT crsp_fundnos.
-uniq = lk.unique(subset=["crsp_fundno"], keep="first")
+# Not merely a count: the SURVIVING row's tna_latest is summed below, so which
+# row wins changes the printed total. Sorted so it is the largest TNA for that
+# fundno rather than whichever row came first.
+uniq = (
+    lk.sort(["crsp_fundno", "tna_latest"], descending=[False, True], nulls_last=True)
+    .unique(subset=["crsp_fundno"], keep="first", maintain_order=True)
+)
 print(f"  total TNA over distinct crsp_fundnos: ${uniq['tna_latest'].sum() / 1e6:,.2f}T "
       f"across {uniq.height:,} funds (summing over fundids would double-count to "
       f"${lk['tna_latest'].sum() / 1e6:,.2f}T -- {lk.height:,} fundids map to "

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap.py
@@ -336,7 +336,12 @@ print(f"  of those seriesIds, present in crsp_cik_map: {in_map.height:,} "
 fund = pl.read_parquet(FUNDID_SERIESID).select(
     "fundid", "institutionid", "first_year", "last_year")
 fs = pl.read_parquet(FUND_SUMMARY2)
-mflink = pl.read_parquet(MFLINK1).unique(subset=["crsp_fundno"], keep="first")
+# A crsp_fundno can carry more than one wficn in MFLINK1 (measured: 341 of
+# 49,975). `keep="first"` with no sort picks by row order — an undefined
+# choice on the linking critical path. Sorted so the pick is STATED.
+mflink = (pl.read_parquet(MFLINK1)
+          .sort(["crsp_fundno", "wficn"])
+          .unique(subset=["crsp_fundno"], keep="first", maintain_order=True))
 print(f"\nfund_summary2 (CLASS grain)        : {fs.height:,} crsp_fundnos")
 
 # ---------------------------------------------------------------------------

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap2.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_gap2.py
@@ -367,7 +367,12 @@ print(f"  of those seriesIds, present in crsp_cik_map: {in_map.height:,} "
 fund = pl.read_parquet(FUNDID_SERIESID).select(
     "fundid", "institutionid", "first_year", "last_year")
 fs = pl.read_parquet(FUND_SUMMARY2)
-mflink = pl.read_parquet(MFLINK1).unique(subset=["crsp_fundno"], keep="first")
+# A crsp_fundno can carry more than one wficn in MFLINK1 (measured: 341 of
+# 49,975). `keep="first"` with no sort picks by row order — an undefined
+# choice on the linking critical path. Sorted so the pick is STATED.
+mflink = (pl.read_parquet(MFLINK1)
+          .sort(["crsp_fundno", "wficn"])
+          .unique(subset=["crsp_fundno"], keep="first", maintain_order=True))
 print(f"\nfund_summary2 (CLASS grain)        : {fs.height:,} crsp_fundnos")
 
 # ---------------------------------------------------------------------------

--- a/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_ticker.py
+++ b/skills/npx-ownership-panel/scripts/npx_linking/build_npx_crsp_link_ticker.py
@@ -239,7 +239,12 @@ print("  (L3 nulls `seriesid` on npx_crsp_link only for ISS non-registrants, "
 
 fs = pl.read_parquet(FUND_SUMMARY2)
 snl = pl.read_parquet(SEC_SERIES_NAMES_LONG)
-mflink = pl.read_parquet(MFLINK1).unique(subset=["crsp_fundno"], keep="first")
+# A crsp_fundno can carry more than one wficn in MFLINK1 (measured: 341 of
+# 49,975). `keep="first"` with no sort picks by row order — an undefined
+# choice on the linking critical path. Sorted so the pick is STATED.
+mflink = (pl.read_parquet(MFLINK1)
+          .sort(["crsp_fundno", "wficn"])
+          .unique(subset=["crsp_fundno"], keep="first", maintain_order=True))
 print(f"\nfund_summary2 (CLASS grain)        : {fs.height:,} crsp_fundnos")
 print(f"sec_series_names_long              : {snl.height:,} rows")
 


### PR DESCRIPTION
Three `unique(subset=[...], keep="first")` sites on the linking critical path had **no preceding sort**, so the survivor was picked by whatever row order the upstream produced. Unlike the sort→group_by sites, this isn't a contract question — there's no rule at all.

## Measured

`mflink1_cache.parquet`: 50,380 rows, 49,975 distinct `crsp_fundno`, and **341 fundnos (0.68%) carry more than one `wficn`**. `unique()` silently dropped 405 rows to resolve them. `wficn` is how S12 holdings reach a fund, so this is on the path to mutual-fund ownership, not a diagnostic.

| site | |
|---|---|
| `build_npx_crsp_link.py:197` + `_gap`, `_gap2`, `_ticker` | mflink1 dedup |
| `build_npx_crsp_link.py:382` | `fno2unit` |
| `build_npx_crsp_link.py:798` | distinct-fundno TNA total — the **survivor's** `tna_latest` is summed, so the pick moves the printed number |

## What the fix can and can't do

MFLINK1 has exactly two columns, so there is no discriminator to break the tie *on*. This cannot be resolved into a right answer here. What it can be is **declared** — sorted so the pick is stated (lowest wficn / lowest unit / largest TNA) rather than inherited, with the ambiguity printed:

```
mflink1 dedup : 50,380 rows -> 49,975 crsp_fundno; 341 map to >1 wficn and are
                resolved by lowest wficn (stated, not row order)
```

Which wficn is *correct* for those 341 is a domain question about MFLINK. Flagged, not guessed.

## Left alone deliberately

Four `unique(subset=["unit", <name>], keep="first")` sites whose only non-key column is a provenance label (`src`) — `gap.py`'s own comment already argues it's immaterial (*"family_agree is the same no matter which corpus form won the match"*) — plus one audit-sample dedup. Sorting those would change which label survives for no gain.