### PR TITLE
fix(inst_own): impossible ratio NET of lending, and stop the zero clamp swallowing nulls

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_inst_own.py
+++ b/skills/npx-ownership-panel/scripts/build_inst_own.py
@@ -1328,10 +1328,28 @@ def add_net_of_lending(panel: pl.DataFrame) -> pl.DataFrame:
         # institutional holdings, which happens when a large share of the lendable
         # supply is retail or non-13F. That is informative about the assumption, not
         # about the firm, so it is flagged rather than propagated as a negative block.
-        pl.max_horizontal(
-            pl.col("io_total") - pl.col("shortint_adj").fill_null(0.0),
-            pl.lit(0.0),
-        ).alias("io_total_net"),
+        #
+        # THE CLAMP MUST NOT SWALLOW A NULL. `max_horizontal` IGNORES nulls, so
+        # `max_horizontal(null, 0.0)` returns 0.0 — and with io_total null that
+        # made io_total_net = 0.0, asserting ZERO net institutional ownership on a
+        # firm-quarter whose GROSS ownership is unknown. Measured on the CIZ
+        # panel: 4,331 rows of 697,239 (0.62%), and 647 of them have a KNOWN
+        # short interest, so the row claimed a net computed from a real lending
+        # figure and an absent holdings figure.
+        #
+        # Same defect as `ior = 0.0` on an unknown denominator, one column over:
+        # unknown rendered as zero, with the missingness flag (io_missing) correct
+        # beside it and the VALUE contradicting it. The zero floor applies to the
+        # arithmetic, not to the question of whether there is any arithmetic to do.
+        pl.when(pl.col("io_total").is_null())
+        .then(pl.lit(None, dtype=pl.Float64))
+        .otherwise(
+            pl.max_horizontal(
+                pl.col("io_total") - pl.col("shortint_adj").fill_null(0.0),
+                pl.lit(0.0),
+            )
+        )
+        .alias("io_total_net"),
         pl.when(pl.col("tso") > 0)
         .then(pl.col("shortint_adj") / pl.col("tso"))
         .otherwise(None)

--- a/skills/npx-ownership-panel/scripts/dq_panel.py
+++ b/skills/npx-ownership-panel/scripts/dq_panel.py
@@ -145,6 +145,24 @@ def main() -> int:
     pct = (100.0 * n_imp / n_testable) if n_testable else 0.0
     cov = (100.0 * n_testable / d.height) if d.height else 0.0
 
+    # NET OF LENDING, because most of the gross exceedance is not a defect.
+    # A lent share sits in the borrower's account and STILL appears in the
+    # lender's 13F, so gross institutional holdings legitimately exceed shares
+    # outstanding. detect_impossible_ratio's own docstring says to "triage
+    # against short interest ... before treating as" a defect — leg 2 already
+    # computes io_total_net, so the sweep was reporting the untriaged number.
+    #
+    # Measured on the CIZ panel: gross 12,950/392,393 = 3.300%, net
+    # 4,266/392,393 = 1.087%. Lending accounts for 8,684 of the 12,950 — 67.1%.
+    # p99 falls from 1.134 to 1.026. The gross figure is a triage signal that is
+    # two-thirds false alarm; the net figure is the one worth acting on.
+    net = ir.filter(pl.col("io_total_net").is_not_null())
+    n_net_imp = int(
+        (net["io_total_net"] / net["tso"] > 1.02).sum()
+    ) if net.height else 0
+    net_pct = (100.0 * n_net_imp / net.height) if net.height else 0.0
+    n_si_missing = int(d.select(pl.col("si_missing").sum()).item()) if "si_missing" in d.columns else 0
+
     print(flush=True)
     print(
         "NOTE: DQ rows={:,} coverage_end={} duplicate_grain={} join_coverage_tail={} "
@@ -165,6 +183,21 @@ def main() -> int:
         "NOTE: DQ the impossible_ratio denominator is rows with BOTH io_total and "
         "tso>0, not the panel; {:,} rows ({:.1f}%) are invisible to it".format(
             d.height - n_testable, 100.0 - cov
+        ),
+        flush=True,
+    )
+    print(
+        "NOTE: DQ impossible_ratio_NET={:,}/{:,}={:.3f}% (io_total_net/tso) — a lent "
+        "share is in the borrower's account AND the lender's 13F, so gross "
+        "exceedance is expected; lending explains {:,} of the {:,} gross flags".format(
+            n_net_imp, net.height, net_pct, max(n_imp - n_net_imp, 0), n_imp
+        ),
+        flush=True,
+    )
+    print(
+        "NOTE: DQ si_missing={:,} of {:,} ({:.1f}%) — no lending figure there, so the "
+        "NET ratio cannot be formed and those rows fall back to gross".format(
+            n_si_missing, d.height, 100.0 * n_si_missing / d.height if d.height else 0.0
         ),
         flush=True,
     )


### PR DESCRIPTION
Two things, from one question: *should the impossible ratio be net of share lending?*

## It should — and the detector already said so

A lent share sits in the borrower's account **and still appears in the lender's 13F**, so gross institutional holdings legitimately exceed shares outstanding. `detect_impossible_ratio`'s own docstring says to *"triage against short interest and filer concentration before treating as"* a defect. Leg 2 already computes `io_total_net` — the sweep has been reporting the untriaged number all along.

| | flags | base | rate |
|---|---|---|---|
| gross `io_total/tso` | 12,950 | 392,393 | **3.300%** |
| net `io_total_net/tso` | 4,266 | 392,393 | **1.087%** |

**Lending explains 8,684 of the 12,950 — 67.1%.** p99 falls from 1.1339 to 1.0261. The headline 3.300% is a triage signal that's two-thirds false alarm.

`dq_panel.py` now prints both, plus `si_missing` (264,767 of 697,239 = 38.0%) — where there's no lending figure the net ratio can't be formed at all.

## And measuring it surfaced a null bug

The zero floor on `io_total_net` was:

```python
max_horizontal(io_total - shortint_adj.fill_null(0.0), 0.0)
```

`max_horizontal` **ignores nulls**, so with `io_total` null it returns `0.0` — asserting *zero net institutional ownership* on firm-quarters whose **gross** ownership is unknown.

**4,331 rows of 697,239 (0.62%)**, of which **647 have a known short interest** — those carried a "net" computed from a real lending figure and an absent holdings figure. `io_missing` was correctly `True` on all 4,331; the value contradicted the flag beside it.

Same defect as `ior = 0.0` on an unknown denominator, one column over. The zero floor belongs to the arithmetic, not to whether there's any arithmetic to do. Also removes 4,331 spurious zeros from the net ratio's base.

## Digest impact

C, C2 and B move — scoped to `io_total_net`, `ior_net`, `si_frac`, `net_clamped`, `inst_pivotal_net`.