### PR TITLE
fix(meetings): keep the turnout evidence that the clip destroys

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_meetings.sas
+++ b/skills/npx-ownership-panel/scripts/build_meetings.sas
@@ -272,6 +272,40 @@ data turnout;
     mgmt_for = (mgmtrec = 'For');
 run;
 
+/* TURNOUT IS THE ONLY INDEPENDENT AUDIT OF ISS `tso`, AND THE STEP ABOVE
+ * DESTROYS IT. turnout = votes cast / tso is computed from ISS votes over ISS
+ * shares outstanding — no 13F, no CRSP — so it is the one number here that can
+ * say whether the ISS denominator is right. But rows above 120 are DELETED and
+ * the rest CLIPPED to 100, so by the time anyone looks turnout reads a clean
+ * max of 100.0% with 0.00% above, on a panel whose denominators are
+ * demonstrably broken on 6.8% of rows.
+ *
+ * The delete and the clip both stay — a 300% turnout is not usable as a turnout
+ * and downstream expects [0,100]. What changes is that the EVIDENCE SURVIVES.
+ * Measured on turnout_raw, before either, and printed as a gate line. A clipped
+ * value with no record of what was clipped is indistinguishable from one that
+ * never needed clipping.
+ *
+ * Deliberately NOT a new column: out.meetings feeds digests A and B, and a
+ * diagnostic is not worth moving a frozen schema for. */
+proc sql noprint;
+    select sum(case when outstandingshare > 0 and 100*sum(votedabstain,votedagainst,votedfor,
+                                             brokernonvote,votedwithheld)/outstandingshare > 100
+                    then 1 else 0 end),
+           sum(case when outstandingshare > 0 and 100*sum(votedabstain,votedagainst,votedfor,
+                                             brokernonvote,votedwithheld)/outstandingshare > 120
+                    then 1 else 0 end),
+           count(*),
+           max(case when outstandingshare > 0 then 100*sum(votedabstain,votedagainst,votedfor,
+                                              brokernonvote,votedwithheld)/outstandingshare end)
+      into :n_to100 trimmed, :n_to120 trimmed, :n_torows trimmed, :max_to trimmed
+      from turnout_raw;
+quit;
+%put NOTE: TURNOUT rows=&n_torows. over100=&n_to100. over120=&n_to120. max_raw=&max_to.;
+%put NOTE- TURNOUT over120 are DELETED and 100-120 are CLIPPED, so the panel max reads 100.0;
+%put NOTE- TURNOUT this is the only ISS-only check on ISS tso — a rising over100 count;
+%put NOTE- TURNOUT means the ISS denominator is drifting, and nothing else here can see it.;
+
 /* --- Join ISS/GL recommendations (if available) --- */
 %macro build_turnout;
     %if &have_recs. %then %do;


### PR DESCRIPTION
`turnout = votes cast / tso` is computed from ISS votes over ISS shares outstanding — no 13F, no CRSP. It is the **only** number in this pipeline that can independently say whether the ISS denominator is right.

And the panel destroys it: rows above 120 are **deleted**, the rest **clipped** to 100. So turnout reads a clean max of 100.0% with 0.00% above — on a panel whose denominators are demonstrably broken on 6.8% of rows.

## Measured before the delete and the clip

```
NOTE: TURNOUT rows=712477 over100=3304 over120=930 max_raw=2.7831E8
```

- **3,304 items (0.46%)** exceed 100% turnout and are clipped
- **930 (0.13%)** exceed 120% and are deleted
- **maximum raw turnout is 2.78e8 percent** — an item whose recorded votes are 2.8 million times its shares outstanding, which can only be a broken ISS `outstandingshare`

The panel reports **100.0**.

## What changes

The delete and the clip both **stay** — a 278-million-percent turnout isn't usable as a turnout and everything downstream expects [0,100]. What changes is that the count and the magnitude survive in the log, beside the PREREQ / UNIVERSE / OPTIONAL / DQ gates, so a rising `over100` count is visible as the ISS denominator drifting. Nothing else in the pipeline can see that.

Deliberately **not** a new column: `out.meetings` feeds digests A and B, and a diagnostic isn't worth moving a frozen schema for. Pure addition, no schema change, 0 ERRORs on the grid.