### PR TITLE
fix(look-at): correct 82 unrunnable invocations — `uv run python3` never reads PEP 723 (v5.87.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Development, data science, and writing workflows for Claude Code",
-    "version": "5.87.3"
+    "version": "5.87.4"
   },
   "plugins": [
     {
       "name": "workflows",
       "source": "./",
       "description": "Unified development, data science, and writing workflows with TDD enforcement, output-first verification, GSD-style deviation rules, test gap validation, and session handoff",
-      "version": "5.87.3",
+      "version": "5.87.4",
       "category": "development",
       "tags": [
         "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflows",
-  "version": "5.87.3",
+  "version": "5.87.4",
   "description": "Development, data science, writing, and workshop presentation workflows with TDD enforcement, output-first verification, agent team parallelization, and GSD-style deviation rules, test gap validation, and session handoff.",
   "author": {
     "name": "edwinhu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [5.87.4] - 2026-07-27
+
+### Fixed
+- **Every documented `look-at` invocation in the repo was unrunnable — 82 call sites across 10 files.** v5.87.2 repaired both vision backends but left the callers on `uv run python3 look_at.py`, the exact form that release's own commit message identifies as broken: passing `python3` as the command makes uv provision the ambient environment, so the script's inline PEP 723 metadata is never read and `google-genai` is never installed. Every one of them died with `google-genai package not installed` — a message that reads like an unauthenticated backend and is actually the wrong launcher. All corrected to `uv run --script`, which is what `scripts/look_at.sh` already used, with a comment explaining why.
+  - **Two of the ten are not documentation.** `hooks/image-read-guard.py` denies every `Read` of an image and hands the agent a replacement command to run; `workflows/workshop-verify.js` tells its visual-verify agents how to inspect diagrams. Both emitted a command that could not succeed, so the guard sent agents into a dead end and workshop-verify's visual leg had no working path — which is the likely origin of its `look_at.py not resolved → visual-verify skipped` degradation.
+  - Remaining eight are docs and examples: `skills/look-at/references/use-cases.md` (50), `skills/using-skills/SKILL.md` (6), `skills/look-at/README.md` (5), the three `skills/look-at/examples/*.sh` (4 each), `skills/look-at/scripts/look_at.py`'s own docstring and error text (4), `skills/workshop/SKILL.md` (3).
+  - **`uv run python3 X.py` and `uv run --script X.py` are not interchangeable**, and the failure is silent until the import. Only `--script` honours PEP 723. Verified after the change: the corrected form and `look_at.sh --backend api` both return correct output from a 46-page PDF; all four edited code files pass `ast.parse` / `node --check` / `bash -n`.
+
 ## [Unreleased]
 
 > Version files are deliberately **not** bumped in this entry. The concurrent

--- a/hooks/image-read-guard.py
+++ b/hooks/image-read-guard.py
@@ -49,7 +49,7 @@ def main():
                 "Reading images directly wastes context tokens. "
                 "Use the look-at skill to extract only relevant information:\n\n"
                 "```bash\n"
-                f"uv run python3 {look_at_script} \\\n"
+                f"uv run --script {look_at_script} \\\n"
                 f'    --file "{tool_input.get("file_path", "")}" \\\n'
                 '    --goal "Describe what is in this image"\n'
                 "```\n\n"

--- a/skills/look-at/README.md
+++ b/skills/look-at/README.md
@@ -38,7 +38,7 @@ echo 'export GOOGLE_API_KEY="your-api-key-here"' >> ~/.bashrc
 ### 3. Use the Skill
 
 ```bash
-uv run python3 scripts/look_at.py \
+uv run --script scripts/look_at.py \
     --file "/path/to/file.pdf" \
     --goal "Extract the title and date"
 ```
@@ -81,28 +81,28 @@ look-at/
 
 ### Extract from PDF
 ```bash
-uv run python3 scripts/look_at.py \
+uv run --script scripts/look_at.py \
     --file "/home/user/report.pdf" \
     --goal "Extract the executive summary section"
 ```
 
 ### Describe Image
 ```bash
-uv run python3 scripts/look_at.py \
+uv run --script scripts/look_at.py \
     --file "/home/user/diagram.png" \
     --goal "Describe the system architecture and data flow"
 ```
 
 ### Extract Table Data
 ```bash
-uv run python3 scripts/look_at.py \
+uv run --script scripts/look_at.py \
     --file "/home/user/data.pdf" \
     --goal "Extract the table as JSON: {name, value, date}"
 ```
 
 ### With Custom Model
 ```bash
-uv run python3 scripts/look_at.py \
+uv run --script scripts/look_at.py \
     --file "/home/user/complex_doc.pdf" \
     --goal "Extract methodology section" \
     --model "gemini-2.5-flash"

--- a/skills/look-at/examples/analyze_pdf.sh
+++ b/skills/look-at/examples/analyze_pdf.sh
@@ -4,21 +4,21 @@
 SCRIPT_DIR="../scripts"
 
 # Example 1: Extract title and date
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/report.pdf" \
     --goal "Extract the document title and publication date"
 
 # Example 2: Extract executive summary
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/report.pdf" \
     --goal "Extract the executive summary section"
 
 # Example 3: Extract specific data points
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/financial_report.pdf" \
     --goal "Extract the revenue, profit, and employee count figures"
 
 # Example 4: Extract table as structured data
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/data_table.pdf" \
     --goal "Extract the table data as JSON with columns: name, value, date"

--- a/skills/look-at/examples/describe_image.sh
+++ b/skills/look-at/examples/describe_image.sh
@@ -4,21 +4,21 @@
 SCRIPT_DIR="../scripts"
 
 # Example 1: Describe UI elements
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/screenshot.png" \
     --goal "List all UI elements and their positions in the layout"
 
 # Example 2: Analyze diagram
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/architecture_diagram.png" \
     --goal "Explain the component relationships and data flow shown in the diagram"
 
 # Example 3: Extract text from image
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/whiteboard.jpg" \
     --goal "Extract all text visible in this image"
 
 # Example 4: Describe chart
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/chart.png" \
     --goal "Describe the chart type, axes, and key trends shown"

--- a/skills/look-at/examples/extract_table.sh
+++ b/skills/look-at/examples/extract_table.sh
@@ -4,21 +4,21 @@
 SCRIPT_DIR="../scripts"
 
 # Example 1: Extract as JSON
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/data_table.pdf" \
     --goal "Extract the table as JSON array with fields: product, quantity, price, total"
 
 # Example 2: Extract as CSV-formatted text
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/spreadsheet_screenshot.png" \
     --goal "Extract the table data as CSV format"
 
 # Example 3: Extract specific columns
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/report.pdf" \
     --goal "Extract only the 'Date' and 'Amount' columns from the financial table"
 
 # Example 4: Summarize table
-uv run python3 "${SCRIPT_DIR}/look_at.py" \
+uv run --script "${SCRIPT_DIR}/look_at.py" \
     --file "/path/to/complex_table.pdf" \
     --goal "Summarize the key statistics: total, average, min, max values"

--- a/skills/look-at/references/use-cases.md
+++ b/skills/look-at/references/use-cases.md
@@ -21,45 +21,45 @@
 ### Research Papers
 ```bash
 # Extract methodology section
-uv run python3 look_at.py --file paper.pdf \
+uv run --script look_at.py --file paper.pdf \
     --goal "Extract the methodology section, including sample size and statistical methods"
 
 # Extract findings
-uv run python3 look_at.py --file paper.pdf \
+uv run --script look_at.py --file paper.pdf \
     --goal "List the main findings and conclusions"
 
 # Extract citations for a specific topic
-uv run python3 look_at.py --file paper.pdf \
+uv run --script look_at.py --file paper.pdf \
     --goal "List all citations related to machine learning methods"
 ```
 
 ### Financial Reports
 ```bash
 # Extract key metrics
-uv run python3 look_at.py --file quarterly_report.pdf \
+uv run --script look_at.py --file quarterly_report.pdf \
     --goal "Extract revenue, profit margin, and YoY growth percentages"
 
 # Summarize risks
-uv run python3 look_at.py --file 10k_filing.pdf \
+uv run --script look_at.py --file 10k_filing.pdf \
     --goal "Summarize the top 3 risk factors mentioned"
 
 # Extract balance sheet data
-uv run python3 look_at.py --file financial_statements.pdf \
+uv run --script look_at.py --file financial_statements.pdf \
     --goal "Extract total assets, liabilities, and equity as JSON"
 ```
 
 ### Contracts and Legal Documents
 ```bash
 # Extract key terms
-uv run python3 look_at.py --file contract.pdf \
+uv run --script look_at.py --file contract.pdf \
     --goal "Extract payment terms, termination clause, and effective date"
 
 # Identify obligations
-uv run python3 look_at.py --file agreement.pdf \
+uv run --script look_at.py --file agreement.pdf \
     --goal "List all obligations for Party A"
 
 # Extract definitions
-uv run python3 look_at.py --file legal_doc.pdf \
+uv run --script look_at.py --file legal_doc.pdf \
     --goal "Extract all defined terms and their definitions"
 ```
 
@@ -68,45 +68,45 @@ uv run python3 look_at.py --file legal_doc.pdf \
 ### UI/UX Screenshots
 ```bash
 # Inventory UI elements
-uv run python3 look_at.py --file app_screenshot.png \
+uv run --script look_at.py --file app_screenshot.png \
     --goal "List all buttons, text fields, and navigation elements with their labels"
 
 # Describe layout
-uv run python3 look_at.py --file wireframe.png \
+uv run --script look_at.py --file wireframe.png \
     --goal "Describe the layout structure: header, sidebar, main content, footer"
 
 # Identify accessibility issues
-uv run python3 look_at.py --file interface.png \
+uv run --script look_at.py --file interface.png \
     --goal "Identify potential accessibility issues: contrast, button sizes, text legibility"
 ```
 
 ### Architecture Diagrams
 ```bash
 # Explain system design
-uv run python3 look_at.py --file system_diagram.png \
+uv run --script look_at.py --file system_diagram.png \
     --goal "Explain the data flow between components and their relationships"
 
 # List components
-uv run python3 look_at.py --file architecture.png \
+uv run --script look_at.py --file architecture.png \
     --goal "List all components/services shown and their responsibilities"
 
 # Identify bottlenecks
-uv run python3 look_at.py --file performance_diagram.png \
+uv run --script look_at.py --file performance_diagram.png \
     --goal "Identify potential bottlenecks or single points of failure"
 ```
 
 ### Charts and Graphs
 ```bash
 # Extract data points
-uv run python3 look_at.py --file line_chart.png \
+uv run --script look_at.py --file line_chart.png \
     --goal "Extract the data points for each line series as JSON"
 
 # Describe trends
-uv run python3 look_at.py --file sales_chart.png \
+uv run --script look_at.py --file sales_chart.png \
     --goal "Describe the main trends and any notable patterns or anomalies"
 
 # Extract legend
-uv run python3 look_at.py --file complex_chart.png \
+uv run --script look_at.py --file complex_chart.png \
     --goal "List what each color/line represents according to the legend"
 ```
 
@@ -115,30 +115,30 @@ uv run python3 look_at.py --file complex_chart.png \
 ### Tables
 ```bash
 # Full table extraction
-uv run python3 look_at.py --file data_table.pdf \
+uv run --script look_at.py --file data_table.pdf \
     --goal "Extract the entire table as JSON array with all columns preserved"
 
 # Filtered extraction
-uv run python3 look_at.py --file large_table.pdf \
+uv run --script look_at.py --file large_table.pdf \
     --goal "Extract only rows where Status = 'Active' as CSV"
 
 # Summary statistics
-uv run python3 look_at.py --file spreadsheet.png \
+uv run --script look_at.py --file spreadsheet.png \
     --goal "Calculate and report: sum, average, min, max for the 'Amount' column"
 ```
 
 ### Forms
 ```bash
 # Extract filled values
-uv run python3 look_at.py --file filled_form.pdf \
+uv run --script look_at.py --file filled_form.pdf \
     --goal "Extract all filled-in values with their corresponding field labels"
 
 # Identify missing fields
-uv run python3 look_at.py --file incomplete_form.pdf \
+uv run --script look_at.py --file incomplete_form.pdf \
     --goal "List all empty/unfilled fields"
 
 # Convert to structured data
-uv run python3 look_at.py --file application_form.pdf \
+uv run --script look_at.py --file application_form.pdf \
     --goal "Extract as JSON: {name, email, phone, address, date_submitted}"
 ```
 
@@ -147,33 +147,33 @@ uv run python3 look_at.py --file application_form.pdf \
 ### API Documentation Screenshots
 ```bash
 # Extract endpoint details
-uv run python3 look_at.py --file api_docs.png \
+uv run --script look_at.py --file api_docs.png \
     --goal "Extract all API endpoints with their methods, paths, and descriptions"
 
 # Extract request/response examples
-uv run python3 look_at.py --file api_example.png \
+uv run --script look_at.py --file api_example.png \
     --goal "Extract the request and response JSON examples shown"
 ```
 
 ### Whiteboards and Sketches
 ```bash
 # Transcribe whiteboard session
-uv run python3 look_at.py --file whiteboard.jpg \
+uv run --script look_at.py --file whiteboard.jpg \
     --goal "Transcribe all text and describe any diagrams or sketches"
 
 # Extract action items
-uv run python3 look_at.py --file meeting_notes.jpg \
+uv run --script look_at.py --file meeting_notes.jpg \
     --goal "Extract all action items with assigned owners if visible"
 ```
 
 ### Database Schemas
 ```bash
 # Extract table definitions
-uv run python3 look_at.py --file db_schema.png \
+uv run --script look_at.py --file db_schema.png \
     --goal "List all tables with their columns, types, and relationships"
 
 # Identify relationships
-uv run python3 look_at.py --file erd_diagram.png \
+uv run --script look_at.py --file erd_diagram.png \
     --goal "Describe all foreign key relationships and their cardinality"
 ```
 
@@ -182,22 +182,22 @@ uv run python3 look_at.py --file erd_diagram.png \
 ### Video Frames
 ```bash
 # Analyze key frame
-uv run python3 look_at.py --file video_frame.jpg \
+uv run --script look_at.py --file video_frame.jpg \
     --goal "Describe what's happening in this frame: people, actions, objects"
 
 # Extract visible text
-uv run python3 look_at.py --file presentation_slide.mp4 \
+uv run --script look_at.py --file presentation_slide.mp4 \
     --goal "Extract all text visible on the slide"
 ```
 
 ### Presentations
 ```bash
 # Extract slide content
-uv run python3 look_at.py --file slide_deck.pdf \
+uv run --script look_at.py --file slide_deck.pdf \
     --goal "Extract title and main points from slides 5-10"
 
 # Create outline
-uv run python3 look_at.py --file presentation.pdf \
+uv run --script look_at.py --file presentation.pdf \
     --goal "Create an outline of the entire presentation with section headings"
 ```
 
@@ -206,10 +206,10 @@ uv run python3 look_at.py --file presentation.pdf \
 ### Comparative Analysis
 ```bash
 # Compare two diagrams
-uv run python3 look_at.py --file version1.png \
+uv run --script look_at.py --file version1.png \
     --goal "List all components and connections"
 
-uv run python3 look_at.py --file version2.png \
+uv run --script look_at.py --file version2.png \
     --goal "List all components and connections"
 
 # Then use Claude to compare the extracted information
@@ -218,22 +218,22 @@ uv run python3 look_at.py --file version2.png \
 ### Multi-step Extraction
 ```bash
 # Step 1: Identify sections
-uv run python3 look_at.py --file document.pdf \
+uv run --script look_at.py --file document.pdf \
     --goal "List all section headings with page numbers"
 
 # Step 2: Extract specific section
-uv run python3 look_at.py --file document.pdf \
+uv run --script look_at.py --file document.pdf \
     --goal "Extract only the 'Results' section on pages 12-15"
 ```
 
 ### Validation
 ```bash
 # Verify data quality
-uv run python3 look_at.py --file data_report.pdf \
+uv run --script look_at.py --file data_report.pdf \
     --goal "Check if all required fields are present: date, amount, signature"
 
 # Cross-reference
-uv run python3 look_at.py --file invoice.pdf \
+uv run --script look_at.py --file invoice.pdf \
     --goal "Extract invoice number and total amount for verification"
 ```
 
@@ -242,25 +242,25 @@ uv run python3 look_at.py --file invoice.pdf \
 ### ❌ Too Vague
 ```bash
 # Bad: Too general
-uv run python3 look_at.py --file doc.pdf --goal "Tell me about this document"
+uv run --script look_at.py --file doc.pdf --goal "Tell me about this document"
 
 # Good: Specific request
-uv run python3 look_at.py --file doc.pdf --goal "Extract the author, date, and main conclusion"
+uv run --script look_at.py --file doc.pdf --goal "Extract the author, date, and main conclusion"
 ```
 
 ### ❌ Asking for Everything
 ```bash
 # Bad: Requesting full content
-uv run python3 look_at.py --file book.pdf --goal "Extract all text from this book"
+uv run --script look_at.py --file book.pdf --goal "Extract all text from this book"
 
 # Good: Extract what you need
-uv run python3 look_at.py --file book.pdf --goal "Extract the table of contents"
+uv run --script look_at.py --file book.pdf --goal "Extract the table of contents"
 ```
 
 ### ❌ Using for Plain Text
 ```bash
 # Bad: Using look_at for source code
-uv run python3 look_at.py --file script.py --goal "Show me the code"
+uv run --script look_at.py --file script.py --goal "Show me the code"
 
 # Good: Use Read tool instead
 cat script.py
@@ -269,10 +269,10 @@ cat script.py
 ### ❌ Relative Paths
 ```bash
 # Bad: Relative path
-uv run python3 look_at.py --file ../docs/report.pdf --goal "Extract title"
+uv run --script look_at.py --file ../docs/report.pdf --goal "Extract title"
 
 # Good: Absolute path
-uv run python3 look_at.py --file /home/user/docs/report.pdf --goal "Extract title"
+uv run --script look_at.py --file /home/user/docs/report.pdf --goal "Extract title"
 ```
 
 ## Cost Optimization Tips
@@ -288,20 +288,20 @@ uv run python3 look_at.py --file /home/user/docs/report.pdf --goal "Extract titl
 ### Data Science Workflow
 ```bash
 # In exploration phase, analyze data documentation
-uv run python3 look_at.py --file data_dictionary.pdf \
+uv run --script look_at.py --file data_dictionary.pdf \
     --goal "Extract all column names, types, and descriptions as JSON"
 ```
 
 ### Development Workflow
 ```bash
 # Analyze design mockups
-uv run python3 look_at.py --file mockup.png \
+uv run --script look_at.py --file mockup.png \
     --goal "List all UI components that need to be implemented"
 ```
 
 ### Writing Workflow
 ```bash
 # Extract quotes from source material
-uv run python3 look_at.py --file research_paper.pdf \
+uv run --script look_at.py --file research_paper.pdf \
     --goal "Extract all quotes related to climate change impacts"
 ```

--- a/skills/look-at/scripts/look_at.py
+++ b/skills/look-at/scripts/look_at.py
@@ -10,17 +10,17 @@ based on the provided goal. It's designed to be used by Claude Code as a tool fo
 files that require interpretation beyond raw text.
 
 Usage:
-    uv run python3 look_at.py --file <path> --goal "<what to extract>" [--model <model_name>]
+    uv run --script look_at.py --file <path> --goal "<what to extract>" [--model <model_name>]
 
 Examples:
     # Extract title from PDF
-    uv run python3 look_at.py --file report.pdf --goal "Extract the title and date"
+    uv run --script look_at.py --file report.pdf --goal "Extract the title and date"
 
     # Describe diagram
-    uv run python3 look_at.py --file diagram.png --goal "Explain the architecture shown"
+    uv run --script look_at.py --file diagram.png --goal "Explain the architecture shown"
 
     # Extract table data
-    uv run python3 look_at.py --file data.pdf --goal "Extract the table as JSON"
+    uv run --script look_at.py --file data.pdf --goal "Extract the table as JSON"
 
 Environment (checked in order):
     GOOGLE_API_KEY: Google API key for Gemini access.

--- a/skills/using-skills/SKILL.md
+++ b/skills/using-skills/SKILL.md
@@ -184,7 +184,7 @@ NO  → Use Read tool for source code/text
 **Pattern:**
 ```bash
 # look-at: Extract information from media file with specific goal
-uv run python3 "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
+uv run --script "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
     --file "/absolute/path/to/file" \
     --goal "What specific information to extract"
 ```
@@ -217,17 +217,17 @@ uv run python3 "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
 
 ```bash
 # look-at: Extract specific information from image file
-uv run python3 "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
+uv run --script "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
     --file "$HOME/Downloads/screenshot.png" \
     --goal "List all buttons and their labels"
 
 # look-at: Analyze diagram to understand data flow
-uv run python3 "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
+uv run --script "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
     --file "$HOME/Documents/architecture.png" \
     --goal "Explain the data flow between components"
 
 # look-at: Extract information from PDF document
-uv run python3 "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
+uv run --script "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
     --file "$HOME/Downloads/report.pdf" \
     --goal "Extract the executive summary section"
 ```
@@ -272,13 +272,13 @@ When a skill requires `description` parameter on Bash calls (like look-at), you 
 
 ```bash
 # ❌ WRONG: No description parameter
-uv run python3 "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
+uv run --script "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" \
     --file "/path/to/file.pdf" \
     --goal "Extract title"
 
 # ✅ CORRECT: With description parameter as skill requires
 Bash(
-    command='uv run python3 "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" --file "/path/to/file.pdf" --goal "Extract title"',
+    command='uv run --script "${CLAUDE_PLUGIN_ROOT}/skills/look-at/scripts/look_at.py" --file "/path/to/file.pdf" --goal "Extract title"',
     description="look-at: Extract title"
 )
 ```

--- a/skills/workshop/SKILL.md
+++ b/skills/workshop/SKILL.md
@@ -206,7 +206,7 @@ Inferring metadata from filenames is fabrication. The user got burned by halluci
 
 2. **Extract metadata** using look-at:
    ```bash
-   uv run python3 "${CLAUDE_SKILL_DIR}/../look-at/scripts/look_at.py" \
+   uv run --script "${CLAUDE_SKILL_DIR}/../look-at/scripts/look_at.py" \
        --file "/path/to/paper.pdf" \
        --goal "Extract: (1) full title, (2) subtitle if any, (3) all author names, (4) each author's affiliation/institution, (5) abstract summary in 2-3 sentences"
    ```
@@ -238,7 +238,7 @@ Inferring metadata from filenames is fabrication. The user got burned by halluci
 
 7. **Inventory the paper's figures, tables, and key results:**
    ```bash
-   uv run python3 "${CLAUDE_SKILL_DIR}/../look-at/scripts/look_at.py" \
+   uv run --script "${CLAUDE_SKILL_DIR}/../look-at/scripts/look_at.py" \
        --file "/path/to/paper.pdf" \
        --goal "List ALL: (1) figures with figure numbers and captions, (2) tables with table numbers and captions, (3) key empirical results with specific numbers (coefficients, percentages, sample sizes), (4) main theoretical propositions or hypotheses"
    ```
@@ -371,7 +371,7 @@ Sources gathered and verified. Paper metadata extracted from source document.
 
 2. **Read the paper's structure** — use look-at to get the table of contents / section headings:
    ```bash
-   uv run python3 "${CLAUDE_SKILL_DIR}/../look-at/scripts/look_at.py" \
+   uv run --script "${CLAUDE_SKILL_DIR}/../look-at/scripts/look_at.py" \
        --file "/path/to/paper.pdf" \
        --goal "List all section headings and subheadings in order"
    ```

--- a/workflows/workshop-verify.js
+++ b/workflows/workshop-verify.js
@@ -300,7 +300,7 @@ if (diagramsToReview.length && disc.lookAtPath) {
   diagramReviews = (await parallel(diagramsToReview.map(d => () =>
     agent(
       `You are a READ-ONLY visual reviewer. Do NOT edit files. Render the slides.pdf page containing the diagram on slide "${d.slideTitle}" and score it for visual defects.
-Use: \`uv run python3 ${disc.lookAtPath} --file ${disc.presentationDir}/slides.pdf --goal "Inspect the ${d.kind} diagram on the slide titled '${d.slideTitle}' for: clipped/cut-off text, overlapping elements, bad arrow routing, label anchoring, cramped spacing, illegible text size"\`.
+Use: \`uv run --script ${disc.lookAtPath} --file ${disc.presentationDir}/slides.pdf --goal "Inspect the ${d.kind} diagram on the slide titled '${d.slideTitle}' for: clipped/cut-off text, overlapping elements, bad arrow routing, label anchoring, cramped spacing, illegible text size"\`.
 Set diagram="${d.id}". defectsFound = count of distinct visual defects. Each defect is a finding (severity major) with a short description. Return VISUAL_SCHEMA.`,
       { label: `${d.id}:visual`, phase: 'Review', schema: VISUAL_SCHEMA, model: 'sonnet' }
     )


### PR DESCRIPTION
## The gap

**v5.87.2 (#101) repaired both vision backends but left every caller on the broken launcher.** Its own commit message says it:

> `uv run python3 look_at.py` does not read inline script metadata, so google-genai was never provisioned and the api backend died

That fix went into `scripts/look_at.sh`. The **82 other invocations across the repo** were not updated, so every documented way to call look-at still fails with `google-genai package not installed` — a message that reads like an unauthenticated backend and is actually the wrong launcher.

`uv run python3 X.py` and `uv run --script X.py` are **not interchangeable**. Passing `python3` as the command makes uv provision the ambient/project environment; only `--script` honours the script's inline PEP 723 metadata. The failure is silent until the import.

## What changed

All 82 sites corrected to `uv run --script`.

**Two of the ten files are not documentation** — these are the ones that matter:

| File | Why it matters |
|---|---|
| `hooks/image-read-guard.py` | Denies **every** `Read` of an image and hands the agent a replacement command to run. That command could not succeed, so the guard sent agents into a dead end. |
| `workflows/workshop-verify.js` | Tells visual-verify agents how to inspect diagrams. Its `look_at.py not resolved → visual-verify skipped` degradation path plausibly traces here. |

Remaining eight are docs and examples:

| File | Fixes |
|---|---|
| `skills/look-at/references/use-cases.md` | 50 |
| `skills/using-skills/SKILL.md` | 6 |
| `skills/look-at/README.md` | 5 |
| `skills/look-at/examples/*.sh` (×3) | 4 each |
| `skills/look-at/scripts/look_at.py` (docstring + error text) | 4 |
| `skills/workshop/SKILL.md` | 3 |

## Verification

- Corrected `uv run --script` form returns correct output from a 46-page PDF.
- `look_at.sh --backend api` (unchanged, already correct) returns the same.
- Reproduced the failure on `uv run python3` before and after, to confirm the diagnosis rather than assume it.
- `ast.parse` (2 files), `node --check` (1), `bash -n` (3) all pass; both JSON version files parse.

## Notes

Version bumped 5.87.3 → 5.87.4 in `plugin.json` and `marketplace.json`. CHANGELOG entry added above `[Unreleased]`, which is left untouched — it carries an explicit note about deliberately not bumping version files due to the concurrent `npx-parallel-pull` branch.

Found while adding a workshop paper to the reading list: `reading-add` documented the bare `python3` form, which failed the same way. That skill is a user-level skill outside this repo and was fixed separately (it now prefers `pdftotext` for text-layer PDFs and escalates to look-at only for scanned documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EdLsxueFfhjom9kS5sK4S