### PR TITLE
fix(legs 1,A): match on cusip8, not issuer-level cusip6

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_meetings.sas
+++ b/skills/npx-ownership-panel/scripts/build_meetings.sas
@@ -404,7 +404,14 @@ proc sql;
     create table meetings2 as
         select distinct b.permno, a.*
         from meetings1 a, crsp.stksecurityinfohist b
-        where substr(a.cusip,1,6)=substr(b.cusip,1,6)
+        /* CUSIP8, NOT CUSIP6. cusip6 is issuer-level and maps preferreds and
+         * other share classes onto the common permno — D9 cause 2, which leg 2
+         * disables in its own fallback. ISS `cusip` is uniformly 9 characters
+         * (886,995 of 886,995), so substr(,1,8) is a real cusip8 and not a
+         * truncation artefact. Measured cost of tightening across the S12 leg:
+         * 1.69pp of matched rows, against fan-out risk on 5.87%. The ticker
+         * fallback in meetings3 below still catches items this drops. */
+        where substr(a.cusip,1,8)=substr(b.cusip,1,8)
         and a.meetingdate >= b.secinfostartdt
         and (a.meetingdate <= b.secinfoenddt or b.secinfoenddt >= "&crsp_vintage"d);
     create table meetings3 as

--- a/skills/npx-ownership-panel/scripts/tfn_holdings_parallel.sas
+++ b/skills/npx-ownership-panel/scripts/tfn_holdings_parallel.sas
@@ -192,16 +192,37 @@ run;
  * at 2024-12-31 and will never advance, so every year on them widens the gap
  * against the CIZ tables the rest of the pipeline reads.
  *
- * DELIBERATELY UNFILTERED, as it was before. This map is cusip6 -> permno for
- * Thomson S12 holdings, and narrowing it to NS/EQTY/COM/Y here would drop
- * holdings rather than classify them. The cusip6 grain is itself coarse — it
- * maps other share classes and preferreds onto the common permno, which is D9
- * cause 2 and the reason leg 2 disables its cusip6 fallback. That is a
- * pre-existing property of this leg, not something the CIZ swap introduces, and
- * it is not changed here. */
+ * DELIBERATELY UNFILTERED. Narrowing this to NS/EQTY/COM/Y would drop holdings
+ * rather than classify them — the universe filter belongs on the CRSP monthly
+ * join, not here.
+ *
+ * CUSIP8, NOT CUSIP6. cusip6 is ISSUER-level: it maps preferreds and other share
+ * classes onto the common permno, which is D9 cause 2 and the reason leg 2
+ * disables its own cusip6 fallback. This leg used it anyway, so the three legs
+ * did not agree about what a security is.
+ *
+ * Measured before changing it:
+ *   1,047 of 41,348 cusip6 values (2.53%) map to MORE THAN ONE permno
+ *   538,703 of 9,170,717 S12 holdings rows in 2020 (5.87%) sit on one
+ *   tightening to cusip8 costs 155,259 of those rows — 1.69pp of matched rows
+ *
+ * So 1.7 points of coverage buys the removal of fan-out risk on 5.9%. It also
+ * removes an UNDEFINED CHOICE that was invisible: the hash below takes one
+ * permno per key, so every one of those 1,047 collisions was resolved by
+ * whichever row the hash happened to load first from an unordered SELECT
+ * DISTINCT. Not a tie-break — a coin flip, silently, on 5.87% of holdings.
+ *
+ * THE MAP IS UNDATED, WHICH AT THIS KEY TURNS OUT NOT TO MATTER. An undated
+ * cusip->permno map is what manufactured the duplicates leg 2 had to fix with a
+ * dated join, so the same worry applies here — except it is empirically empty:
+ * ZERO of 55,046 cusip8 values in crsp.stksecurityinfohist map to more than one
+ * permno. A cusip8 identifies a security, and CRSP does not reuse one across
+ * permnos. At cusip6 the same count was 1,047. So narrowing the key does not
+ * merely shrink the ambiguity, it removes it, and dating this join would buy
+ * nothing. Measured rather than assumed, in both directions. */
 proc sql;
     create table cusip_permno as
-        select distinct substr(cusip,1,6) as cusip6 length=6, permno
+        select distinct substr(cusip,1,8) as cusip8 length=8, permno
         from crsp.stksecurityinfohist
         where cusip is not null;
 quit;
@@ -210,13 +231,12 @@ quit;
 data holdings_permno;
     if _n_ = 1 then do;
         declare hash hc(dataset: "cusip_permno");
-        hc.defineKey("cusip6");
+        hc.defineKey("cusip8");
         hc.defineData("permno");
         hc.defineDone();
         call missing(permno);
     end;
     set tfn_holdings;
-    cusip6 = substr(cusip8, 1, 6);
     if hc.find() = 0;
     passive_shares = shares * passive;
     index_shares = shares * pure_index;


### PR DESCRIPTION
Legs 1 and A matched securities on **cusip6**, which is issuer-level: it maps preferreds and other share classes onto the common permno. That is D9 cause 2 — the exact thing leg 2 disables in its own fallback. So the three legs did not agree about what a security is.

## Measured before changing anything

```
cusip6 -> permno : 1,047 of 41,348 (2.53%) map to MORE THAN ONE permno
S12 2020 rows on an ambiguous cusip6 : 538,703 of 9,170,717 (5.87%)
cost of tightening to cusip8         : 155,259 rows = 1.69pp of matched rows
```

**1.7 points of coverage buys the removal of fan-out risk on 5.9%.**

## It also removes an undefined choice nobody could see

`tfn_holdings_parallel.sas` loads the map into a SAS hash and does `hc.defineKey("cusip6")`. A hash holds **one** value per key, so each of those 1,047 collisions was resolved by whichever row happened to load first from an unordered `SELECT DISTINCT`. Not a tie-break — a coin flip, silently, on 5.87% of holdings.

## And the undated-map worry is empirically empty

An undated cusip→permno map is what manufactured the duplicates leg 2 had to fix with a dated join, so the same concern applies here. It does not bite:

| key | values | mapping to >1 permno |
|---|---|---|
| cusip6 | 41,348 | 1,047 |
| **cusip8** | **55,046** | **0** |

A cusip8 identifies a security and CRSP does not reuse one across permnos. Narrowing the key does not merely shrink the ambiguity, it removes it — dating this join would buy nothing. Measured in both directions rather than assumed.

## Notes

ISS `cusip` is uniformly 9 characters (886,995 of 886,995), so `substr(,1,8)` is a real cusip8, not a truncation artefact. The ticker fallback in `meetings3` still catches items the tighter CUSIP join drops.

**All digests move.** Legs 1 and A both change which securities they resolve.
