### PR TITLE
fix(panel): %local is not valid in open code — #108 produced no panel

### DIFF
--- a/skills/npx-ownership-panel/scripts/merge_panel.sas
+++ b/skills/npx-ownership-panel/scripts/merge_panel.sas
@@ -334,7 +334,18 @@ run;
  * Emitted as a gate line so the same grep picks it up as PREREQ / UNIVERSE /
  * OPTIONAL / DQ / TURNOUT. A number that only reaches the .lst is a number
  * nobody reads. */
-%local n_dboth n_iss_hi n_iss_hi3 n_crsp_hi n_crsp_hi3;
+/* NOT %local: this is OPEN CODE, and `%LOCAL` is only valid inside a macro.
+ * Written as %local it raised "The %LOCAL statement is not valid in open
+ * code", the five macro variables were never created, every %put below
+ * printed &n_dboth. literally, and the cascade took out the UNIVERSE gate and
+ * out.pass_npx with it — a 32-minute run that produced no panel.
+ *
+ * Exactly the defect #100 fixed in import_inst_own.sas (`%abort cancel` in
+ * open code), reintroduced by me three PRs later. The tell is the same: SAS
+ * reports it as an ERROR and keeps going, so the log names the construct and
+ * the run continues into wreckage.
+ *
+ * I tested the SQL standalone and it passed. The SQL was never the risk. */
 proc sql noprint;
     select count(*),
            sum(case when tso > tso_crsp_inst * 1.10 then 1 else 0 end),


### PR DESCRIPTION
`%LOCAL` is only valid inside a macro. #108 put it in **open code**, and the run I launched to verify that change produced no panel at all.

```
ERROR: The %LOCAL statement is not valid in open code.
ERROR: File WORK._ORPHAN_ITEMS.DATA does not exist.
ERROR 161-185: No matching DO/SELECT statement.
ERROR: File OUT.PASS_NPX.DATA does not exist.
```

The five macro variables were never created, so every `%put` printed `&n_dboth.` literally, and the cascade took out the UNIVERSE gate and `out.pass_npx` with it. **32 minutes, 12 ERRORs, no output.**

## This is the same defect #100 fixed, reintroduced by me three PRs later

#100 fixed `%abort cancel` in open code in `import_inst_own.sas` — SAS reports it, refuses to act on it, and carries on. I then wrote `%local` in open code in `merge_panel.sas` and shipped it.

The tell is identical: **SAS reports the construct as an ERROR and keeps going**, so the log names it and the run continues into wreckage. A guard or a declaration that SAS declines to honour is worse than one that isn't there, because its name still appears.

## What I actually verified before shipping #108

The SQL — standalone, in its own file, against `out.pass`. It passed, which told me nothing: **the SQL was never the risk.** The patch was. Testing the query instead of the patch is how a 32-minute run gets spent proving something I already knew.

Fix is to drop the `%local` — at open-code level the variables are global, which is what they need to be for the `%put` lines that follow.
