### PR TITLE
fix(panel): a bare semicolon inside %put ends the statement

### DIFF
--- a/skills/npx-ownership-panel/scripts/merge_panel.sas
+++ b/skills/npx-ownership-panel/scripts/merge_panel.sas
@@ -247,7 +247,12 @@ quit;
 %put NOTE: D5 s12_pre2017Q4 rows=&d5_pre_rows. permnos=&d5_pre_permno. | post rows=&d5_post_rows. permnos=&d5_post_permno.;
 %put NOTE- D5 the S12 feed changed at 2017Q4 (legacy SP -> strategic collection);
 %put NOTE- D5 a coverage EXPANSION, so any mf-ownership LEVEL comparison spanning;
-%put NOTE- D5 2017Q4 is invalid; MFLINKS was not backfilled 2017Q4-2020Q2 either.;
+/* No bare `;` inside a %put — it TERMINATES the statement, and everything
+ * after it parses as a stray statement. That is what broke this file: the
+ * semicolon in "2017Q4 is invalid; MFLINKS..." ended the %put, the rest
+ * raised ERROR 180-322, and the cascade emptied out.pass_npx (0 obs, 17
+ * vars) while the log still showed the D5 gate printing correctly. */
+%put NOTE- D5 2017Q4 is invalid. MFLINKS was not backfilled 2017Q4-2020Q2 either.;
 
 /* --- Sort inputs for MERGE_ASOF --- */
 proc sort data=out.inst_own;  by permno rdate;                     run;


### PR DESCRIPTION
A bare `;` inside a `%put` **terminates the statement**. Everything after it parses as a stray statement.

```sas
%put NOTE- D5 2017Q4 is invalid; MFLINKS was not backfilled 2017Q4-2020Q2 either.;
                                ^ ends the %put here
```

`ERROR 180-322: Statement is not valid or it is used out of proper order`, cascading through the UNIVERSE gate and leaving **`out.pass_npx` with 0 observations and 17 variables** — while the log showed the D5 gate itself printing perfectly.

## Third self-inflicted SAS syntax bug in a row

`%abort cancel` in open code (#100, not mine), `%local` in open code (#111, mine), and now this. All three share a signature: **SAS reports the problem, declines to honour the construct, and carries on** — so the log names it and the run continues into wreckage.

## What changed in how I verified it

For #108 I tested the SQL standalone. It passed and told me nothing, because the SQL was never the risk — the patch was. A 32-minute run then proved something I already knew.

This time I ran `merge_panel.sas` **alone** against the out library left over from the failed run, which still had every input. Three minutes, and it caught both this and the `%local` bug before either reached a full DAG.

Verified after the fix:

```
ERRORs: 0
PREREQ rows meetings=624,162 inst_own=697,239 npx_items=712,466
D5     s12_pre2017Q4 rows=227,225 permnos=7,918 | post rows=116,066 permnos=5,818
DENOM  rows_with_both=565,417 iss_gt_crsp_10pct=107,306 iss_gt_crsp_3x=71,847
UNIVERSE meetings_items=624,162 npx_items=712,466 orphans=0
OUT.PASS_NPX has 2,019,563 observations and 81 variables
```

Swept the rest of the tree: this was the only `%put` in any `.sas` with an embedded semicolon.
