### PR TITLE
fix(dq): the 1.7% in-universe gap was 99.3% my own classification error

### DIFF
--- a/skills/npx-ownership-panel/scripts/dq_panel.py
+++ b/skills/npx-ownership-panel/scripts/dq_panel.py
@@ -281,10 +281,13 @@ def main() -> int:
     # data defect and is mostly a universe boundary. The ~1.7% residual is the
     # part that would be a real gap.
     print(
-        "NOTE: DQ untestable rows are 98.3% OUT-OF-UNIVERSE holdings (ETF, ADR, "
-        "foreign, CEF), not failed matches — only ~1.7% of the unlinked permnos "
-        "are NS/EQTY/COM/Y. Bridge rate falls 74.1% (2005) to 38.0% (2025) as "
-        "institutions shift into ETFs. Classified 2026-07-27; re-derive against "
+        "NOTE: DQ untestable rows are OUT-OF-UNIVERSE holdings (ETF, ADR, foreign, "
+        "CEF), not failed matches. 98.3% of unlinked permnos are outside "
+        "NS/EQTY/COM/Y outright; of the 1.7% that look in-universe, 99.3% were in "
+        "it at a DIFFERENT DATE (share class is interval-based, the filter is "
+        "per-date). True residual: 47 rows, ONE permno, 0.0012% of panel 13F "
+        "shares. Bridge rate falls 74.1% (2005) to 38.0% (2025) as institutions "
+        "shift into ETFs. Classified 2026-07-27; re-derive against "
         "crsp.stksecurityinfohist if the panel window moves.",
         flush=True,
     )


### PR DESCRIPTION
The note I added in #105 said *"only ~1.7% of the unlinked permnos are NS/EQTY/COM/Y"* and left that 1.7% as an unexplained residual. Investigated it; **99.3% of it was my own classification error.**

## The confound

I classified a permno as in-universe if **any** interval in `stksecurityinfohist` qualified. But that table is **interval-based** and the monthly filter applies **per date**. A permno that was US common stock in 2012 and something else in 2020 counted as in-universe for all its rows.

Re-tested with the date bound:

```
in-universe-EVER unlinked rows      : 6,376  (278 permnos)
...still in-universe ON THAT DATE   :    47  <- the true residual
explained by time-varying class     : 6,329  (99.3%)

TRUE residual: 47 rows, 1 permno, 0.0012% of panel 13F shares
```

## The one permno

**12350** — Cazador Acquisition Corp → Net Element International → Net Element → Mullen Automotive → Bollinger Innovations. **26 identity intervals**, including a stretch as a foreign issuer (`usincflg='N'`) before becoming US common stock. It has 181 `msf_v2` rows, 157 passing the leg-2 filter.

A serial reverse-merger shell that changed what it is 26 times is exactly where an interval join produces edge cases, and 47 quarter-ends across 20 years is a proportionate amount of damage for it to do.

## Why this matters beyond the number

The 43.7% untestable population is now fully accounted for: **98.3% out-of-universe outright, 1.7% in-universe at a different date, 47 rows genuinely unexplained.** No part of it is a broken join.

It is also the third time today a number I published needed correcting after someone asked for the decomposition rather than the headline — and each time the correction went the same way: the alarming figure was an artifact of how I had grouped or classified, not a property of the data.
