### PR TITLE
docs(lseg-data): the three things that actually block a working session

### DIFF
--- a/skills/lseg-data/SKILL.md
+++ b/skills/lseg-data/SKILL.md
@@ -111,6 +111,60 @@ ld.close_session()
 
 ## Authentication
 
+### On this setup: use the agenix secret
+
+Credentials live in agenix as `lseg-credentials`, decrypted to
+`$LSEG_CREDENTIALS_FILE` (mode 400). It is a shell-sourceable file, so **source
+it, do not `cat` it into a variable**:
+
+```bash
+set -a; . "$LSEG_CREDENTIALS_FILE"; set +a   # exports LSEG_APP_KEY / LSEG_USERNAME / LSEG_PASSWORD
+```
+
+**THE VARIABLE NAMES DO NOT MATCH THE LIBRARY'S.** The secret exports `LSEG_*`;
+everything below documents `RDP_*`. You must map them at the call site. Reading
+this section and exporting `RDP_APP_KEY` from a file that defines `LSEG_APP_KEY`
+gets you an empty environment and a session that fails on first query.
+
+Before 2026-07-27 these existed only as plaintext in `mbp:~/projects/svb/.envrc`,
+so anything running on another machine had no credentials at all. If a lookup
+comes back empty, check that host's rebuild is current before concluding the
+account is unentitled.
+
+### `platform.Password` DOES NOT EXIST
+
+The config-file example below hides the programmatic form, and the obvious guess
+is wrong. In `lseg-data` 2.1.1 the class is **`GrantPassword`**:
+
+```python
+import lseg.data as ld
+from lseg.data.session import platform
+
+s = platform.Definition(
+        app_key=os.environ["LSEG_APP_KEY"],
+        grant=platform.GrantPassword(username=os.environ["LSEG_USERNAME"],
+                                     password=os.environ["LSEG_PASSWORD"]),
+    ).get_session()
+s.open()
+ld.session.set_default(s)
+```
+
+`platform` exports exactly three names — `ClientCredentials`, `Definition`,
+`GrantPassword`. Check `dir()` before trusting a class name from the docs.
+
+### `open_session()` DOES NOT RAISE ON FAILURE
+
+With no config and no credentials it falls back to a **desktop** session, tries
+`http://localhost:9000/api/handshake` (LSEG Workspace running locally), logs the
+connection failure, and **returns normally**. The error only surfaces on the
+first query as `ValueError: Session is not opened`.
+
+So `open_session()` returning is NOT evidence of a session. This is the same
+silent-failure shape as the Iron Law above, one layer earlier: verify by issuing
+a cheap query (`TR.PriceClose` on a liquid RIC) and inspecting the value.
+
+### Config file / environment variables (upstream documentation)
+
 Configure LSEG authentication using either a config file or environment variables.
 
 ### Config File Method


### PR DESCRIPTION
Three things cost real time getting a working LSEG session today, and none of them were discoverable from the skill as written.

## 1. The credential variable names don't match the library's

The agenix secret exports `LSEG_APP_KEY` / `LSEG_USERNAME` / `LSEG_PASSWORD`. The skill documents `RDP_APP_KEY` / `RDP_USERNAME` / `RDP_PASSWORD`. Following the skill against the actual secret gets you an empty environment and a session that fails on first query.

Now documented, with the agenix path (`$LSEG_CREDENTIALS_FILE`, source it rather than `cat` it) as the setup-specific answer ahead of the upstream config-file docs.

Also worth recording: before today these existed **only** as plaintext in `mbp:~/projects/svb/.envrc`, so anything on another machine had no credentials at all. That's a plausible cause of a "not entitled" conclusion that is really "not provisioned" — now called out explicitly.

## 2. `platform.Password` does not exist

It's the obvious guess and it's wrong. In 2.1.1 the class is **`GrantPassword`** — `platform` exports exactly three names: `ClientCredentials`, `Definition`, `GrantPassword`. The skill only showed the config-file form, which hides the programmatic one entirely. A working snippet is now inline.

## 3. `open_session()` does not raise on failure

With no credentials it silently falls back to a **desktop** session, tries `localhost:9000/api/handshake` (Workspace running locally), logs the failure, and **returns normally**. The error surfaces later as `ValueError: Session is not opened`.

So `open_session()` returning is not evidence of a session. This is the same silent-failure shape the skill's own Iron Law already warns about for field names — one layer earlier, in session setup, where nobody was looking for it. The fix is the same: verify with a cheap query and inspect the value.

---

Verified end-to-end while writing this: session opens, `TR.ShortInterest` returns 33,088,057 for `IBM.N`, with history back to 2003-01 and ETF coverage (SPY, QQQ).
