### PR TITLE
fix(inst_own): stop filtering the DENOMINATOR by the analysis universe

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_inst_own.py
+++ b/skills/npx-ownership-panel/scripts/build_inst_own.py
@@ -136,15 +136,38 @@ def quarter_index(rdate_int: pl.Expr) -> pl.Expr:
 # boundary differs ~0.5% (15,040,731 vs 15,115,823) — a vintage revision between
 # products, which is why crsp_src is still stamped on every row even though it
 # now carries one value.
+# NO SHARE-CLASS FILTER ON THE DENOMINATOR. This query used to carry
+# sharetype/securitytype/securitysubtype/usincflg = NS/EQTY/COM/Y, the same
+# predicate as the identifier pull below. That is the universe definition, and
+# applying it HERE conflated two different questions:
+#
+#   "is this security in the panel's universe?"   <- a scope question
+#   "how many shares does it have outstanding?"   <- a fact, true regardless
+#
+# The result was 300,515 permno-quarters (43.7% of leg 2) with tso NULL and
+# therefore ior NULL. Measured: CRSP has shrout for ALL 300,515 of them once the
+# filter is dropped — ZERO are genuinely absent. The denominator was never
+# missing; we declined to read it.
+#
+# AND THE FILTER WAS MOSTLY REDUNDANT ANYWAY. The panel is meetings-driven
+# (merge_panel MERGE_ASOFs out.meetings on the LEFT), so a permno with no ISS
+# meeting never reaches out.pass whatever leg 2 does. Of those 300,515 rows,
+# 226,604 (75.4%) are dropped at that join regardless — for them this filter only
+# manufactured nulls in an intermediate artifact.
+#
+# The remaining 73,911 rows on 1,657 permnos are the reason this is a fix rather
+# than a tidy-up: they DO reach the panel — they have ISS meetings, so the panel
+# says they are in scope — and leg 2 was refusing them a denominator anyway.
+# Dual-class share classes, foreign-incorporated issuers with US listings and
+# real proxy votes, units. The panel called them in scope; leg 2 called them out.
+#
+# Scope still gets decided, just once and in the right place: by the ISS meetings
+# join, and by the identifier query below, which keeps its filter.
 CRSP_MONTHLY_QUERY = """
 SELECT permno, mthcaldt AS date, mthprc AS prc, shrout,
        mthcumfacpr AS cfacpr, mthcumfacshr AS cfacshr, cusip AS ncusip
 FROM crsp.msf_v2
-WHERE sharetype = 'NS'
-  AND securitytype = 'EQTY'
-  AND securitysubtype = 'COM'
-  AND usincflg = 'Y'
-  AND mthcaldt BETWEEN %(start)s AND %(end)s
+WHERE mthcaldt BETWEEN %(start)s AND %(end)s
   AND shrout IS NOT NULL
 """
 

--- a/skills/npx-ownership-panel/scripts/dq_panel.py
+++ b/skills/npx-ownership-panel/scripts/dq_panel.py
@@ -265,30 +265,25 @@ def main() -> int:
         ),
         flush=True,
     )
-    # WHAT THE UNTESTABLE ROWS ACTUALLY ARE. Classified 2026-07-27 against
-    # crsp.stksecurityinfohist: of the 16,675 (permno, class) rows behind the
-    # unlinked population, ZERO are absent from the names table and only 278
-    # (1.7%) are in NS/EQTY/COM/Y — 98.3% are OUTSIDE the universe this panel
-    # measures. The top classes are ETFs (6,827 permnos), foreign-incorporated
-    # common (2,420), ADRs (1,029) and closed-end funds (1,039).
+    # WHAT THE UNTESTABLE ROWS ACTUALLY ARE.
     #
-    # So the missing denominators are overwhelmingly 13F filers holding things
-    # that are NOT US common stock, not CRSP failing to match. The bridge rate
-    # falls monotonically 74.1% (2005) -> 38.0% (2025), which is the secular rise
-    # of ETFs in institutional portfolios, not a degrading join.
+    # This used to report that 98.3% of them were out-of-universe holdings (ETF,
+    # ADR, foreign, CEF) and therefore not a defect. That was true of the DATA and
+    # false about the CAUSE: leg 2 was applying the universe filter to the
+    # DENOMINATOR pull, so those rows had no tso because we declined to read one,
+    # not because CRSP lacked it. Measured: CRSP had shrout for all 300,515 of
+    # them. The filter is gone from CRSP_MONTHLY_QUERY; scope is now decided once,
+    # by the ISS meetings join and by the identifier query.
     #
-    # This matters for how the number is read: "43.7% invisible" sounds like a
-    # data defect and is mostly a universe boundary. The ~1.7% residual is the
-    # part that would be a real gap.
+    # So an untestable row now means the denominator is GENUINELY absent — no
+    # crsp.msf_v2 row for that permno-quarter at all — which should be rare and is
+    # worth looking at rather than explaining away. If this count is large again,
+    # something reintroduced a filter upstream.
     print(
-        "NOTE: DQ untestable rows are OUT-OF-UNIVERSE holdings (ETF, ADR, foreign, "
-        "CEF), not failed matches. 98.3% of unlinked permnos are outside "
-        "NS/EQTY/COM/Y outright; of the 1.7% that look in-universe, 99.3% were in "
-        "it at a DIFFERENT DATE (share class is interval-based, the filter is "
-        "per-date). True residual: 47 rows, ONE permno, 0.0012% of panel 13F "
-        "shares. Bridge rate falls 74.1% (2005) to 38.0% (2025) as institutions "
-        "shift into ETFs. Classified 2026-07-27; re-derive against "
-        "crsp.stksecurityinfohist if the panel window moves.",
+        "NOTE: DQ untestable rows now mean the denominator is GENUINELY absent from "
+        "crsp.msf_v2, not filtered out — the share-class predicate was removed from "
+        "the denominator pull because it is the ISS meetings join, not leg 2, that "
+        "decides scope. A large count here means a filter came back.",
         flush=True,
     )
     return 0


### PR DESCRIPTION
`CRSP_MONTHLY_QUERY` carried the universe predicate `NS/EQTY/COM/Y` — the same one as the identifier pull. Applying it to the **denominator** conflated two different questions:

- *is this security in the panel's universe?* — a scope question
- *how many shares does it have outstanding?* — a fact, true regardless

The result was **300,515 permno-quarters (43.7% of leg 2)** with `tso` NULL and therefore `ior` NULL.

## The denominator was never missing

```
permno-quarters with no denominator                      : 300,515
  msf_v2 HAS shrout once the share-class filter is dropped : 300,515 (100.0%)
  genuinely absent from CRSP monthly                       :       0 (0.0%)
```

Every one of them. We declined to read it.

## And the filter was mostly redundant anyway

The panel is meetings-driven — `merge_panel` puts `out.meetings` on the LEFT of the `MERGE_ASOF` — so a permno with no ISS meeting never reaches `out.pass` whatever leg 2 does:

| | rows | |
|---|---|---|
| dropped at the ISS join regardless | 226,604 | 75.4% — filter only made nulls in an intermediate |
| **reach the panel and had no denominator** | **73,911** | **24.6% — on 1,657 permnos** |

That second row is why this is a fix and not a tidy-up. Those securities **have ISS meetings**, so the panel says they are in scope, and leg 2 was refusing them a denominator anyway — dual-class share classes, foreign-incorporated issuers with US listings and real proxy votes, units. The panel called them in; leg 2 called them out.

Scope still gets decided, just once and in the right place: the ISS meetings join, plus the identifier query, which keeps its filter.

## Corrects a claim I shipped this morning

`dq_panel.py` reported that 98.3% of untestable rows were out-of-universe holdings and therefore not a defect. True of the data, **false about the cause** — they had no `tso` because of this filter. An untestable row now means the denominator is genuinely absent from `crsp.msf_v2`, which should be rare; a large count means a filter came back.

## Digest impact

C and C2 move (leg 2 gains denominators on up to 300,515 rows). B moves on the 73,911 rows that reach the panel — `ior`, `ior_crsp`, `ior_raw` and derivatives. A should not move at all; the vote side is untouched.

`build_short_interest.py`'s `TSO_CHECK_QUERY` deliberately keeps its filter — it is a units sanity check, and holding its population fixed keeps the check comparable across runs.
