### PR TITLE
docs(lseg-data): short-interest coverage cliff, session quota, and a symbol type that can't work

### DIFF
--- a/skills/lseg-data/SKILL.md
+++ b/skills/lseg-data/SKILL.md
@@ -367,6 +367,13 @@ First load spawns the server ("Preparing your CodeBook environment", a minute or
 two) and the URL sits at `/hub/spawn-pending/<user>` until ready. Shut the kernel
 down (`DELETE api/kernels/<id>`) when finished; the server itself idle-culls.
 
+`amers1` is the Americas region — read it from `cfg.wsUrl`, never hardcode it.
+
+The full copy-pasteable recipe lives in **`references/codebook.md`** (added by
+PR #95), together with the spawn/XSRF gotchas and why this failure mode is so
+easy to misread: the wrong host returns *no* handshake response at all, which is
+indistinguishable from a proxy blocking the upgrade.
+
 ## Date Awareness
 
 When querying market data, account for current date context and market data lag.

--- a/skills/lseg-data/SKILL.md
+++ b/skills/lseg-data/SKILL.md
@@ -152,6 +152,38 @@ ld.session.set_default(s)
 `platform` exports exactly three names — `ClientCredentials`, `Definition`,
 `GrantPassword`. Check `dir()` before trusting a class name from the docs.
 
+### ONE concurrent platform session — pass `signon_control=True`
+
+The machine ID allows a single concurrent platform session, and the library
+default is `signon_control=False`, which does not queue — it fails:
+
+```
+LDError: You authorised with signon_control=False. Session quota is reached.
+If you want to open session close the previous opened.
+```
+
+Any earlier session that was not closed cleanly (a crashed script, another shell,
+a background job) holds the quota until it times out. Pass `signon_control=True`
+to take the signon over instead:
+
+```python
+s = platform.Definition(
+        app_key=os.environ["LSEG_APP_KEY"],
+        grant=platform.GrantPassword(username=os.environ["LSEG_USERNAME"],
+                                     password=os.environ["LSEG_PASSWORD"]),
+        signon_control=True,          # <- take over rather than fail
+    ).get_session()
+s.open()
+if str(s.open_state) != "OpenState.Opened":     # open() does not raise; see above
+    raise RuntimeError(f"session failed: {s.open_state}")
+ld.session.set_default(s)
+```
+
+Corollary: **two local scripts cannot query at once.** If you need a second
+concurrent path — an interactive query while a long batch runs — use Codebook,
+which authenticates as a separate `DesktopSession` and does not draw on this
+quota (see Refinitiv Codebook below).
+
 ### `open_session()` DOES NOT RAISE ON FAILURE
 
 With no config and no credentials it falls back to a **desktop** session, tries
@@ -245,6 +277,7 @@ export RDP_APP_KEY=”YOUR_APP_KEY”
 - **`references/fundamentals.md`** - Financial statement fields, ratios, estimates
 - **`references/esg.md`** - ESG scores, pillars, controversies
 - **`references/symbology.md`** - RIC/ISIN/CUSIP conversion
+- **`references/short-interest.md`** - `TR.ShortInterest`: the only working field, the delisted-instrument coverage cliff, and the gap vs Compustat
 - **`references/pricing.md`** - Historical prices, real-time data
 - **`references/screening.md`** - Stock screening with Screener object
 - **`references/fscreen.md`** - Fund screening (ETFs, mutual funds) with FSCREEN app
@@ -297,6 +330,42 @@ df = rd.news.get_headlines(‘R:AAPL.O AND SUGGAC’, count=10)
 ```
 
 **Note**: Codebook uses `refinitiv.data` (older name) rather than `lseg.data`. Both APIs are equivalent.
+
+**Confirmed working 2026-07-27.** `rd.open_session()` there returns a
+**`DesktopSession` named `codebook`** — a different session class from the
+`PlatformSession` a local `lseg-data` script opens against the RDP machine ID.
+Two practical consequences:
+
+- **It does not consume the one-session platform quota** (see Authentication
+  above), so Codebook can be queried while a local batch is running.
+- **It is not better entitled.** Same user, different auth path, but identical
+  content: spot-checked on short interest, where Codebook returned IBM
+  33,088,057 and TXN 2025-03-31 16,647,062 — the same values to the digit as the
+  platform session — and returned empty for the same delisted RICs. Do not reach
+  for Codebook expecting data the API refuses; see `references/short-interest.md`.
+
+### Driving Codebook programmatically (CDP)
+
+Codebook is a JupyterLab in the browser, so it can be driven over CDP without
+clicking, via the Jupyter REST + WebSocket API. One trap makes this fail
+silently on the first try:
+
+**The kernel WebSocket host is NOT the page host.** Read `wsUrl` from the
+`jupyter-config-data` element rather than assuming `location.host` — it points at
+`wss://amers1-streaming-io.platform.refinitiv.com/...`, and connecting to
+`workspace.refinitiv.com` just errors with no message. The same element carries
+the `token` the socket needs as a `?token=` query param.
+
+```js
+const cfg = JSON.parse(document.getElementById('jupyter-config-data').textContent);
+// POST {name:'python3'} to cfg.baseUrl + 'api/kernels' with X-XSRFToken from the _xsrf cookie,
+// then open:  `${cfg.wsUrl}api/kernels/${kernelId}/channels?token=${cfg.token}`
+// send an execute_request on channel 'shell'; collect 'stream' msgs until status.execution_state === 'idle'
+```
+
+First load spawns the server ("Preparing your CodeBook environment", a minute or
+two) and the URL sits at `/hub/spawn-pending/<user>` until ready. Shut the kernel
+down (`DELETE api/kernels/<id>`) when finished; the server itself idle-culls.
 
 ## Date Awareness
 

--- a/skills/lseg-data/references/short-interest.md
+++ b/skills/lseg-data/references/short-interest.md
@@ -1,0 +1,129 @@
+# Short Interest
+
+Measured 2026-07-27 while backfilling a 2003–2025 CRSP/Compustat panel. The
+headline is a coverage boundary that is invisible from the API surface: **LSEG
+serves short interest only for still-listed instruments.**
+
+## Contents
+
+- [The only field that works](#the-only-field-that-works)
+- [Delisted instruments have no short interest](#delisted-instruments-have-no-short-interest)
+- [History depth and frequency](#history-depth-and-frequency)
+- [It disagrees with Compustat by a lot](#it-disagrees-with-compustat-by-a-lot)
+- [Batching](#batching)
+
+## The only field that works
+
+`TR.ShortInterest` — in **shares**, at the observation date, on the security's own
+share basis. Every plausible sibling fails field resolution on this entitlement:
+
+| field | result |
+|---|---|
+| `TR.ShortInterest` | **works** — shares |
+| `TR.SIShortInterest` | works, but it is a **percentage** (`Short Interest %`), not shares |
+| `TR.ShortInterestValue` | `Unable to resolve all requested fields` |
+| `TR.ShortInterestPctFloat` | `Unable to resolve all requested fields` |
+| `TR.ShortInterestPctOfFloat` | `Unable to resolve all requested fields` |
+| `TR.ShortInterestDaysToCover` | `Unable to resolve all requested fields` |
+| `TR.SecuritiesLendingQuantityOnLoan` | `Unable to resolve all requested fields` |
+
+The `SI` app in Workspace *displays* Days to Cover, % of Float and 52w ranges, but
+those are StarMine model outputs on the app surface — they are not retrievable as
+`TR.` fields here.
+
+Values are not always integers (~6% carry a fractional part), so do not cast to
+int and do not treat a fraction as a parsing bug.
+
+## Delisted instruments have no short interest
+
+A delisted RIC resolves normally and returns other `TR.` fields, but its short
+interest series is **not retained**. Verified on mega-caps, so it is not a
+size or liquidity effect:
+
+| security | RIC | `TR.PriceClose` | `TR.ShortInterest` |
+|---|---|---|---|
+| Lehman Brothers | `LEH.N^I08` | 24/24 rows | **0 rows** |
+| Wachovia | `WB^A09` | ✓ | **0 rows** |
+| Compaq | `CPQ^E02` | ✓ | **0 rows** |
+| Gillette | `G^J05` | ✓ | **0 rows** |
+| Anheuser-Busch | `BUD^K08` | ✓ | **0 rows** |
+| Wyeth | `WYE^J09` | ✓ | **0 rows** |
+| EMC | `EMC^I16` | ✓ | **0 rows** |
+| IBM (live control) | `IBM` | ✓ | 307 monthly obs |
+
+Checked every way available and the answer does not change:
+
+- both call paths — `get_history(interval=...)` and
+  `get_data("TR.ShortInterest(SDate=…,EDate=…,Frq=M)")`;
+- both session classes — `PlatformSession` (RDP machine ID) and Codebook's
+  `DesktopSession`;
+- **and in the Workspace UI**, which is the useful confirmation: the `SI` app
+  renders for IBM but is not offered for the delisted instrument. Requesting
+  `view=ShortInterest` falls back to Overview, and the Price & Charts menu drops
+  the Short Interest entry. The delisted company page is otherwise well populated
+  (debt by maturity, ratings history, filings, 2008-era news), so this is
+  selective removal on delisting, not archival deletion.
+
+**Consequence for historical work: any panel built from this is survivorship-
+biased, and worst in the earliest years.** Backfilling a 2003–2025 panel, the fill
+rate ran 17.4% for 2003–2006 against 91.7% for 2025 — entirely delisting attrition,
+not a mapping defect. A probe on one surviving mega-cap (IBM reaches back to
+2000-06) will look like full early coverage and does not generalise.
+
+There is no workaround inside LSEG. If delisted-name short interest is required,
+the source has to be FINRA or Markit.
+
+## History depth and frequency
+
+- Starts **2000-06-30** for long-lived US names; earlier dates return nothing.
+- Monthly series is dense from then on (307 non-null months to 2025-12, no gaps).
+- Instrument lifecycle is respected: Philip Morris International starts 2008-03,
+  its spin-off date, rather than back-filling the parent.
+- ETFs start later and vary by fund — QQQ from 2004-12, SPY only from 2008-12.
+- `interval="quarterly"` returns calendar quarter-end bars (3/31, 6/30, 9/30,
+  12/31), which is usually what a quarterly panel wants — no resampling needed.
+
+## It disagrees with Compustat by a lot
+
+Compared against `comp.sec_shortint` on 149,887 overlapping permno-quarters:
+
+```
+corr(log SI)              0.9254     <- same underlying quantity
+median LSEG/Compustat     1.6491     <- systematic 65% level gap
+within +/- 5%             5.38%
+within +/- 20%            20.67%
+```
+
+Not a units or split-adjustment artifact (`cfacshr` is 1.0 at the median;
+adjusting moves the median ratio only 1.69 → 1.56), and not confined to small
+names (large US common still 1.43).
+
+Which is right is genuinely unresolved. LSEG's median SI/shares-outstanding of
+2.84% sits closer to the published 2–4% norm than Compustat's 1.60%, and spot
+checks favour it (TXN 2025Q1: LSEG 16.6M vs Compustat 3.84M on ~910M shares).
+But LSEG breaches SI > shares outstanding 230× more often (0.2976% vs 0.0013%) —
+the signature of aggregation across venues or share classes.
+
+**Do not splice the two series together.** Filling Compustat's gaps with LSEG puts
+a ~65% level step inside the merged column, correlated with year and security
+type. Use LSEG as a robustness check computed on the overlap instead.
+
+## Batching
+
+`get_history` caps at **3,000 rows** per request, counted across the whole
+universe. Quarterly over 2003–2025 is 92 rows per RIC, so **30 RICs per request**
+fits with headroom; monthly is 276 rows, so ~10.
+
+One unresolvable RIC rejects the **entire chunk** with `Unable to resolve all
+requested identifiers`, not just the bad symbol. Retry the chunk one RIC at a time
+so the good ones survive, or the failure silently costs 29 valid securities.
+
+Rate limit is 500 requests/minute per session. ~19,500 RICs at 30 per request is
+~650 requests, which runs in about 30 minutes single-threaded — and it must be
+single-threaded, because of the one-session quota.
+
+## See Also
+
+- [SKILL.md](../SKILL.md) — session setup, `signon_control`, Codebook
+- [symbology.md](symbology.md) — CUSIP → RIC, and the `'TickerSymbol'` trap
+- [wrds-comparison.md](wrds-comparison.md) — LSEG vs WRDS data mapping

--- a/skills/lseg-data/references/symbology.md
+++ b/skills/lseg-data/references/symbology.md
@@ -70,6 +70,43 @@ For `symbol_conversion.Definition()`:
 | `from_symbol_type` | Source identifier type | `'RIC'`, `'ISIN'`, `'CUSIP'` |
 | `to_symbol_types` | Target identifier types | `['ISIN', 'CUSIP', 'SEDOL']` |
 
+### `'Ticker'` is not a valid symbol type — it is `'TickerSymbol'`
+
+The parser accepts either the enum **name** or its **value**, which is why
+`'ISIN'` works even though the wire value is `'IssueISIN'`. But there is no member
+named `TICKER`, so the natural guess `'Ticker'` raises at construction time:
+
+```
+AttributeError: Value 'Ticker' must be in
+['RIC', 'IssueISIN', 'CUSIP', 'SEDOL', 'TickerSymbol', 'IssuerOAPermID', 'FundClassLipperID']
+```
+
+Verified against `SymbolTypes` in `lseg-data` 2.1.1:
+
+| enum member | accepted name | wire value |
+|---|---|---|
+| `SymbolTypes.RIC` | `'RIC'` | `RIC` |
+| `SymbolTypes.ISIN` | `'ISIN'` | `IssueISIN` |
+| `SymbolTypes.CUSIP` | `'CUSIP'` | `CUSIP` |
+| `SymbolTypes.SEDOL` | `'SEDOL'` | `SEDOL` |
+| `SymbolTypes.TICKER_SYMBOL` | **`'TickerSymbol'`** (not `'Ticker'`) | `TickerSymbol` |
+| `SymbolTypes.OA_PERM_ID` | `'IssuerOAPermID'` | `IssuerOAPermID` |
+| `SymbolTypes.LIPPER_ID` | `'FundClassLipperID'` | `FundClassLipperID` |
+
+Passing the enum avoids the guessing entirely, and is what to prefer:
+
+```python
+from lseg.data.content.symbol_conversion import Definition, SymbolTypes
+
+Definition(symbols=cusips, from_symbol_type=SymbolTypes.CUSIP,
+           to_symbol_types=[SymbolTypes.RIC, SymbolTypes.ISIN,
+                            SymbolTypes.TICKER_SYMBOL])
+```
+
+This fails at `Definition(...)` construction, before any network call — so it is a
+loud error rather than a silent one. It is listed here because two examples below
+carried `'Ticker'` and could never have run.
+
 ## RIC Exchange Suffixes
 
 ### Major US Exchanges
@@ -139,7 +176,7 @@ result = symbol_conversion.Definition(
         'US02079K3059'   # Alphabet
     ],
     from_symbol_type='ISIN',
-    to_symbol_types=['RIC', 'Ticker', 'CUSIP']
+    to_symbol_types=['RIC', 'TickerSymbol', 'CUSIP']
 ).get_data()
 
 print(result.data.df)
@@ -159,7 +196,7 @@ ld.open_session()
 result = symbol_conversion.Definition(
     symbols=['037833100', '594918104'],  # Apple, Microsoft
     from_symbol_type='CUSIP',
-    to_symbol_types=['RIC', 'ISIN', 'SEDOL', 'Ticker']
+    to_symbol_types=['RIC', 'ISIN', 'SEDOL', 'TickerSymbol']
 ).get_data()
 
 print(result.data.df)


### PR DESCRIPTION
Measured while backfilling a 2003–2025 short-interest panel. Each item cost time because the skill did not say it.

### 1. `'Ticker'` is not a valid symbol type (`references/symbology.md`)

Two examples passed `'Ticker'` to `to_symbol_types` and could never have run — the enum member is `TICKER_SYMBOL`, so it must be `'TickerSymbol'`. Fixed both, and documented the full enum.

Worth the precision: the parser accepts enum **names** as well as values, so the neighbouring `'ISIN'` is fine despite the wire value being `IssueISIN`. Only the `Ticker` guess fails. It raises at `Definition(...)` construction, so it is loud rather than silent.

### 2. One concurrent platform session (`SKILL.md`)

The machine ID allows a single platform session and the library default `signon_control=False` does not queue — it fails with `Session quota is reached`. A crashed script holds the quota until timeout. Documents `signon_control=True`.

### 3. New `references/short-interest.md`

The headline is a coverage boundary invisible from the API surface: **short interest is served only for still-listed instruments.**

A delisted RIC resolves and returns `TR.PriceClose`, but zero short interest — verified on Lehman, Wachovia, Compaq, Gillette, Anheuser-Busch, Wyeth and EMC, so not a size effect. Confirmed via both call paths, both session classes, and in the Workspace UI, where the `SI` app is not offered for a delisted name while the rest of that company page stays populated (debt, ratings, filings, news). Selective removal on delisting, not archival deletion.

Consequence: any historical panel built on this is survivorship-biased, worst in the earliest years — 17.4% fill for 2003–2006 against 91.7% for 2025. A probe on one surviving mega-cap (IBM reaches back to 2000-06) looks like full early coverage and does not generalise.

Also records that only `TR.ShortInterest` resolves (every plausible sibling fails field resolution), that `TR.SIShortInterest` is a percentage rather than shares, the 3,000-row batching arithmetic, that one bad RIC rejects a whole chunk, and that the series runs ~65% above `comp.sec_shortint` across 149,887 overlapping permno-quarters — so the two must not be spliced.

### 4. Codebook works, and is a different session class

Confirmed 2026-07-27. `rd.open_session()` there returns a `DesktopSession`, not a `PlatformSession`. It does **not** consume the one-session quota, so it can run alongside a local batch — but it is **not** better entitled: same values to the digit, same emptiness on delisted names. Adds the CDP recipe for driving it headlessly, including the trap that the kernel WebSocket host is not the page host.

## Verification

Every claim was executed against the live API rather than inferred; the enum behaviour was re-tested after drafting, which is how the `'ISIN'` half of the original claim got corrected before it shipped.