### PR TITLE
feat(dq): split the impossible ratio into lending-explainable and arithmetically impossible

### DIFF
--- a/skills/npx-ownership-panel/scripts/dq_panel.py
+++ b/skills/npx-ownership-panel/scripts/dq_panel.py
@@ -227,6 +227,32 @@ def main() -> int:
     net_pct = (100.0 * n_net_imp / net.height) if net.height else 0.0
     n_si_missing = int(d.select(pl.col("si_missing").sum()).item()) if "si_missing" in d.columns else 0
 
+    # SPLIT THE FLAGS: LENDING-EXPLAINABLE vs ARITHMETICALLY IMPOSSIBLE.
+    #
+    # Everything above 1.02 used to be one bucket, under a message telling you to
+    # triage against short interest. That is the right advice at 1.05x and useless
+    # at 1,141x, and the two were indistinguishable in the output.
+    #
+    # 5x is the line because lending genuinely CAN exceed 100% — a lent share sits
+    # in the borrower's account and still appears in the lender's 13F, and
+    # re-lending compounds it. Utilisation that high is unusual but real to roughly
+    # 2-3x. Past 5x there is no lending story left.
+    #
+    # TRACED 2026-07-27, and deliberately NOT fixed:
+    #   1,114 rows / 3,034 filing lines out of 172.9M holdings lines (0.0018%)
+    #   633 filers, no concentration; large filers are BETTER than average
+    #     (>=100k lines: 0.0016%) and small ones 7.8x worse (<1k lines: 0.0124%)
+    #   value/shares corroborates the share counts once 13F's $000s convention is
+    #     applied, so the numerator is correctly reported and correctly parsed
+    #   a permco (issuer-level) denominator would fix 365 of them and BREAK
+    #     138,024 correctly-measured multi-class rows — measured, not assumed
+    # What is left is cusip8->permno attachment: real positions on the wrong
+    # security. Surfaced rather than filtered, because dropping them would improve
+    # the coverage statistic by deleting the evidence.
+    extreme = ir.filter((pl.col("io_total") / pl.col("tso")) > 5.0)
+    n_extreme = extreme.height
+    ext_pct = (100.0 * n_extreme / n_testable) if n_testable else 0.0
+
     print(flush=True)
     print(
         "NOTE: DQ rows={:,} coverage_end={} duplicate_grain={} join_coverage_tail={} "
@@ -255,6 +281,15 @@ def main() -> int:
         "share is in the borrower's account AND the lender's 13F, so gross "
         "exceedance is expected; lending explains {:,} of the {:,} gross flags".format(
             n_net_imp, net.height, net_pct, max(n_imp - n_net_imp, 0), n_imp
+        ),
+        flush=True,
+    )
+    print(
+        "NOTE: DQ impossible_ratio_EXTREME={:,}/{:,}={:.3f}% (>5x shares outstanding) "
+        "— lending cannot explain these; the other {:,} of the {:,} gross flags are "
+        "within a range lending can reach. Traced to cusip8->permno attachment on "
+        "3,034 filing lines of 172.9M; won't-fix, surfaced not filtered.".format(
+            n_extreme, n_testable, ext_pct, max(n_imp - n_extreme, 0), n_imp
         ),
         flush=True,
     )


### PR DESCRIPTION
Everything above 1.02x was one bucket, under a message telling you to triage against short interest. That is the right advice at 1.05x and useless at 1,141x, and the two were indistinguishable in the output.

```
NOTE: DQ impossible_ratio=23,319/692,826=3.366% testable=98.9%_of_panel
NOTE: DQ impossible_ratio_NET=13,770/692,826=1.988% — lending explains 9,549 of 23,319
NOTE: DQ impossible_ratio_EXTREME=1,114/692,826=0.161% (>5x shares outstanding)
      — lending cannot explain these; the other 22,205 of the 23,319 gross flags
      are within a range lending can reach. Traced to cusip8->permno attachment on
      3,034 filing lines of 172.9M; won't-fix, surfaced not filtered.
```

**Why 5x.** Lending genuinely can exceed 100% — a lent share sits in the borrower's account and still appears in the lender's 13F, and re-lending compounds it. Utilisation that high is unusual but real to roughly 2-3x. Past 5x there is no lending story left, so it is a conservative line: above it, the message the current output gives you is definitionally wrong.

**Won't-fix, and the comment records why** so nobody re-derives it:

| hypothesis | verdict |
|---|---|
| denominator is the wrong grain | **ruled out** — permco fixes 365 rows and breaks 138,024 correctly-measured multi-class rows |
| parser bug | **ruled out** — `value/shares` corroborates the share counts once 13F's `$000s` convention is applied |
| a few bad filers | **ruled out** — 633 filers, no concentration; filers with >=100k lines run 0.0016%, filers with <1k lines 0.0124%, i.e. **large filers are better than average** |

What is left is cusip8→permno attachment: real, correctly-reported positions landing on the wrong security. 3,034 filing lines out of 172.9M (0.0018%).

**Surfaced rather than filtered.** Dropping them would improve the coverage statistic by deleting the evidence — the same move as the cusip6 filter earlier today, which raised `testable` from 56% to 98.9% by removing the rows it could not measure.

Reporting only: no schema change, no digest movement. Verified against the current panel.
