### PR TITLE
ds: universe questions, DQ checks in scaffolding, CANNOT-FIX loop

### DIFF
--- a/skills/ds-implement/SKILL.md
+++ b/skills/ds-implement/SKILL.md
@@ -91,6 +91,33 @@ This applies even when YOU think:
 - "The code is straightforward"
 
 **If you're about to write code without outputting results, STOP.**
+
+### The step's output MUST include its DQ line
+
+"Visible output" means the numbers a reader needs to judge the step, not just
+that it ran. Every step that filters, joins or aggregates emits the checks from
+`references/ds-checks.md` that apply to it — **inline, as the step runs** — not
+deferred to a validation phase that may never reference them.
+
+```python
+# after every filter / join / aggregate:
+print(f"[DQ] {name}: {n_before:,} -> {n_after:,} rows ({100*(n_after-n_before)/n_before:+.1f}%)")
+print(f"[DEN] rate={n_flag:,}/{n_base:,}={100*n_flag/n_base:.3f}%  base={100*n_base/n_total:.1f}% of rows")
+print(f"[ENUM] ran: DQ1 DQ3 DQ4 UNI  |  N/A: DQ6 (no before/after shape here)")
+```
+
+**A check that exists but is never invoked is worth nothing.** The failure this
+prevents is not a missing check — it is a documented one that nothing calls:
+
+> A pipeline's own SKILL.md instructed that timed runs include the detector sweep.
+> No script referenced the detector module, so every runtime ever published
+> described a dataset of unmeasured quality. When finally wired, the sweep ran 7
+> of 17 available detectors; four of the remaining ten fired on first execution,
+> one of which had been diagnosed by hand, days earlier, as a novel finding.
+
+So the scaffold **generates the invocation**, not a note asking someone to add it.
+If a step cannot emit a DQ line, say which check is N/A and why (see ENUM) —
+silence is indistinguishable from a pass.
 </EXTREMELY-IMPORTANT>
 
 ## Delegation

--- a/skills/ds-implement/references/ds-checks.md
+++ b/skills/ds-implement/references/ds-checks.md
@@ -17,6 +17,10 @@ Shared check definitions for data quality verification. Referenced by ds-validat
 | COV | Sample-period coverage (each windowed source spans its Required window) | ✅ | ✅ | ✅ | ✅ |
 | R1 | Reproducibility (same inputs → same outputs) | ❌ | ❌ | ❌ | ✅ |
 | M1 | Spec compliance (all SPEC.md objectives addressed) | ✅ | ✅ | ✅ | ✅ |
+| UNI | Universe agreement (every source admits the SAME entities) | ✅ | ✅ | ✅ | ✅ |
+| DEN | Every reported rate states its denominator | ✅ | ✅ | ✅ | ✅ |
+| DEL | Coverage improved because the BASE shrank | ✅ | ✅ | ✅ | ✅ |
+| ENUM | Every check above RUN, or marked N/A with a reason | ✅ | ✅ | ✅ | ✅ |
 
 ## Data Quality Checks (DQ1-DQ6)
 
@@ -187,3 +191,113 @@ Report any WARNING as confidence >= 80."
 ```
 
 This ensures both ds-review and ds-fix run identical checks from a single source of truth.
+
+---
+
+## UNI: Universe Agreement Across Sources
+
+Every source must admit the **same entities**. `COV` asks whether each source spans
+the window; `UNI` asks whether they agree about who is in it.
+
+A universe predicate applied independently in more than one place is the defect.
+It looks like local correctness and produces a global disagreement no single
+script can see.
+
+```python
+# The universe is ONE declared object (PLAN.md), read by every leg.
+UNIVERSE = {"start": "2003-01-01", "end": "2025-12-31",
+            "entity_filter": "sharetype='NS' AND securitytype='EQTY' ..."}
+
+# Then assert the legs agree, per source, on ENTITIES not just rows:
+for name, src in sources.items():
+    extra = set(src.entities) - set(primary.entities)
+    missing = set(primary.entities) - set(src.entities)
+    print(f"[UNI] {name}: +{len(extra):,} not in primary, -{len(missing):,} absent")
+```
+
+**Apply the filter where scope is decided, ONCE — not everywhere it is available.**
+A filter on a *lookup* (a denominator, a crosswalk) is not scope, it is data loss.
+
+> Measured instance: an ownership panel applied its universe predicate to the
+> share-count lookup as well as the entity selection. 300,515 rows (43.7%) carried
+> a null denominator. CRSP held a value for **all 300,515** — none were missing.
+> 75% of them were discarded later by the primary join anyway; the filter only
+> manufactured nulls. The remaining 25% were entities the panel *did* include and
+> had silently refused to measure.
+
+**Confidence if sources disagree:** >= 85
+
+---
+
+## DEN: Every Rate States Its Denominator
+
+A percentage whose base is not printed beside it is not a finding. Report
+`numerator/denominator = rate`, and state what the base excludes.
+
+```python
+n_flag, n_base, n_total = flagged.height, testable.height, df.height
+print(f"[DEN] rate={n_flag:,}/{n_base:,}={100*n_flag/n_base:.3f}%")
+if n_base < n_total:
+    print(f"[DEN] base is {100*n_base/n_total:.1f}% of rows — "
+          f"{n_total-n_base:,} are INVISIBLE to this check, not passing it")
+```
+
+**Also state the GROUPING KEY.** A rate computed at the wrong grain is not a
+smaller error than a wrong numerator; it is a different statistic wearing the
+right name.
+
+> Measured instance: an ambiguity rate published as 0.010% was computed at
+> `fundno`; the pipeline grouped at `wficn`. At the correct key the same quantity
+> was ~180x larger. Two offsetting errors made the wrong number look like an
+> independent reproduction of the right one.
+
+**Confidence if a rate is reported without its base:** >= 80
+
+---
+
+## DEL: Coverage That Improved By Deletion
+
+**A coverage metric can improve because the uncovered rows left.** This is the
+most flattering possible way to lose data and reads as progress in every summary.
+
+Any favourable move in a coverage/quality metric MUST be reported with the change
+in its base:
+
+```python
+print(f"[DEL] coverage {before_pct:.1f}% -> {after_pct:.1f}%   "
+      f"base {n_before:,} -> {n_after:,} ({100*(n_after-n_before)/n_before:+.1f}%)")
+if after_pct > before_pct and n_after < n_before:
+    print("[DEL] WARNING: coverage rose while the base SHRANK — "
+          "confirm rows were fixed, not dropped")
+```
+
+> Measured instance: adding a share-class filter to a crosswalk raised
+> "testable" from 56.0% to 98.9% — by deleting 41% of the rows. The uncovered
+> rows had not acquired the missing field; they had been removed. The metric that
+> caught it was the one printing its own denominator.
+
+**Confidence if coverage rises while base falls:** >= 90
+
+---
+
+## ENUM: Every Check Run, Or Explicitly Not Applicable
+
+Silence is indistinguishable from a pass. A check that is simply absent from the
+output looks exactly like one that ran clean.
+
+Emit a line for **every** check in the matrix. A check with no applicable input
+says so, and why:
+
+```
+[ENUM] DQ1 run  DQ2 run  DQ3 run  DQ4 run  DQ5 run  COV run  UNI run
+[ENUM] N/A: DQ6 (no before/after shape — single-pass build)
+[ENUM] N/A: R1  (reproducibility is a verify-phase check)
+```
+
+> Measured instance: a pipeline's own SKILL.md said timed runs should include the
+> detector sweep. Nothing referenced the detector module at all, so every runtime
+> ever quoted described a dataset of unmeasured quality. Once wired, the sweep ran
+> 7 of 17 available detectors — the seven that happened to be familiar. Four of
+> the other ten fired immediately.
+
+**Confidence if a matrix check produced no line:** >= 85

--- a/skills/ds-validate/SKILL.md
+++ b/skills/ds-validate/SKILL.md
@@ -217,7 +217,7 @@ Each requirement is validated at four levels, in order:
 |-------|-------|---------|
 | 1. Exists | Output file/variable present | `output/results.csv` exists |
 | 2. Substantive | Real data, not empty | >0 rows, expected columns present |
-| 3. DQ Passes | DQ1-DQ5 pass | No dupes on key, nulls handled, row counts trace |
+| 3. DQ Passes | DQ1-DQ5 + UNI/DEN/DEL/ENUM pass | No dupes on key, nulls handled, row counts trace, sources agree on the universe, every rate carries its base |
 | 4. Answers Question | Addresses SPEC.md requirement | Table includes specified variables |
 
 ## Classification
@@ -229,6 +229,38 @@ For each requirement, assign a classification:
 | **COVERED** | All 4 validation levels pass |
 | **PARTIAL** | Output exists but DQ issues found or doesn't fully address requirement |
 | **MISSING** | No output found for this requirement |
+| **CANNOT-FIX** | A real defect, investigated, with the remedies eliminated by measurement |
+
+## CANNOT-FIX Is A Result, And It Must Be Recorded
+
+The loop is *fix until fixed, or until shown unfixable* — and "unfixable" is a
+finding with evidence, not a place to stop trying. A defect closed this way is
+re-opened by the next person unless the eliminations are written down **with
+their numbers**.
+
+A CANNOT-FIX entry must carry, for each candidate remedy, what was measured and
+why it was rejected:
+
+```markdown
+### CF-1: <defect>, <size> (<share of the data>)
+
+| candidate remedy | verdict | measurement |
+|---|---|---|
+| <remedy A> | ruled out | fixes 365 rows, BREAKS 138,024 |
+| <remedy B> | ruled out | source has no rows before 2006-07; 36% of the gap |
+| <remedy C> | ruled out | 633 entities, no concentration; large ones cleaner |
+
+**Left in place, not filtered.** Removing the rows would improve the coverage
+statistic by deleting the evidence (see DEL).
+```
+
+**Rejecting a remedy requires a measurement, not an argument.** Every remedy
+rejected on reasoning alone in the source session was later found to be wrong in
+one direction or the other — including three of the assistant's own.
+
+**Prefer surfacing to filtering.** A known-bad row that is visible is worth more
+than a clean statistic that hides it, and the honest move when a defect resists
+repair is a separate reporting tier, not a `WHERE` clause.
 
 ## VALIDATION.md Template
 
@@ -319,7 +351,13 @@ last_gaps: [REQ-ID, ...]  # requirement IDs still PARTIAL/MISSING
 ```
 
 - On each re-validate, increment `iteration`.
-- **After 3 cycles still in `gaps_found`, STOP looping.** Escalate to the user with a structured choice (AskUserQuestion): **fix again** (override the cap with explicit instruction), **accept remaining gaps** (flip to validated + Accepted Gaps), or **rethink** (return to /ds for re-planning). Do not silently start a 4th fix cycle — repeated failure to close the same gap is a signal the plan or data is wrong, not that one more pass will help.
+- **After 3 cycles still in `gaps_found`, STOP looping.** Escalate to the user with a structured choice (AskUserQuestion): **fix again** (override the cap with explicit instruction), **accept remaining gaps** (flip to validated + Accepted Gaps), **record CANNOT-FIX** (see below — requires eliminations), or **rethink** (return to /ds for re-planning). Do not silently start a 4th fix cycle — repeated failure to close the same gap is a signal the plan or data is wrong, not that one more pass will help.
+
+- **`accept remaining gaps` and `CANNOT-FIX` are not the same option.** "Accepted" means the gap is
+  tolerable and nobody looked further. CANNOT-FIX means the gap was *investigated* and each candidate
+  remedy was **rejected by a measurement**. Only the second closes the question; the first leaves it
+  open under a friendlier name. If the loop is terminating because remedies were tried and failed,
+  record CANNOT-FIX — otherwise the next session re-opens it from scratch, having lost the reason.
 
 <EXTREMELY-IMPORTANT>
 **Do NOT auto-fill gaps. Do NOT silently proceed past gaps. Present them and wait for user decision.**

--- a/skills/ds/SKILL.md
+++ b/skills/ds/SKILL.md
@@ -15,6 +15,7 @@ hooks:
 - [The Iron Law of DS Brainstorming](#the-iron-law-of-ds-brainstorming)
 - [What Brainstorm Does](#what-brainstorm-does)
 - [Critical Questions to Ask](#critical-questions-to-ask)
+  - [Universe Questions](#universe-questions--ask-these-do-not-infer-them)
 - [Process](#process)
 - [Output](#output)
 
@@ -87,6 +88,29 @@ Before loading data, before exploring, before proposing approaches, you MUST:
 - Where is the data located (files, database, API)?
 - What time period does the data cover?
 - How frequently is the data updated?
+
+### Universe Questions — ask these, do not infer them
+
+The sample period and the entity universe are **elicited**, never assumed from
+whatever the first query happened to return. They go into PLAN.md as ONE declared
+object that every later step reads.
+
+- What is the sample period, and **what bounds it** — a research choice, or the
+  earliest date some source happens to carry? (These have different consequences
+  when a source is later replaced.)
+- What is the unit of observation, and what is its **key**? Rates computed at the
+  wrong grain are a different statistic wearing the right name.
+- Which entities are IN the universe, by what predicate?
+- **Where is that predicate applied?** It belongs at the one place scope is
+  decided. Applying it again to a lookup — a denominator, a crosswalk, a
+  reference join — is not scope, it is silent data loss, and it looks like local
+  correctness at every individual site.
+- If two sources disagree about who is in the universe, which one decides?
+
+> A panel applied its universe predicate to both the entity selection and the
+> share-count lookup. 43.7% of rows carried a null denominator; the source held a
+> value for every one of them. It survived a full day of plausible explanations
+> before anyone asked whether the data was actually missing.
 
 ### Objective Questions
 - What question are you trying to answer?


### PR DESCRIPTION
## Why

Distilled from a long cold-start build of an N-PX × ownership panel. Every real defect in that run was found **late, by hand, after the pipeline had already reported success** — digests froze cleanly, row counts looked fine, and the errors were still there. Three of them were structural enough to be worth encoding in the skill rather than fixed once and forgotten.

## What changed

### 1. Sample period / universe — `skills/ds/SKILL.md` (+24)

New section, **"Universe Questions — ask these, do not infer them"**, after Data Source Questions.

The two costliest bugs of that run were both universe mismatches nobody had stated up front:

- a share-class filter applied to a **denominator** that never had one in the source — the numerator and denominator were counting different things
- two sources admitting different entity sets, so an inner join silently redefined the sample

Both *looked like improvements*: one metric went 56% → 98.9% testable. It went up because the base shrank.

### 2. DQ checks as scaffolding, not advice — `ds-implement/SKILL.md` (+27), `references/ds-checks.md` (+114)

Four new checks in the matrix, with full definitions:

| Check | Catches |
|---|---|
| `UNI` | Universe agreement — every source admits the SAME entities |
| `DEN` | Every reported rate states its denominator |
| `DEL` | Coverage "improved" because the BASE shrank |
| `ENUM` | Every check above RAN, or is marked N/A with a reason |

`ENUM` is the one that makes the rest real. The Iron Law in `ds-implement` now requires each step to **emit** its DQ line — the scaffold generates the invocation, it does not leave a note asking someone to add one:

```python
# after every filter / join / aggregate:
print(f"[DQ] {name}: {n_before:,} -> {n_after:,} rows ({100*(n_after-n_before)/n_before:+.1f}%)")
print(f"[DEN] rate={n_flag:,}/{n_base:,}={100*n_flag/n_base:.3f}%  base={100*n_base/n_total:.1f}% of rows")
print(f"[ENUM] ran: DQ1 DQ3 DQ4 UNI  |  N/A: DQ6 (no before/after shape here)")
```

> A check that exists but is never invoked is worth nothing.

### 3. Loop until fixed or provably unfixable — `ds-validate/SKILL.md` (+42)

The 3-cycle escalation loop already existed (`/goal`, `VALIDATE_STATE.md`, `AskUserQuestion`). What was missing was that its **`accept remaining gaps`** exit let a gap through with no evidence behind it.

Adds a `CANNOT-FIX` classification, a register template, and wires `record CANNOT-FIX` in as a fourth escalation option:

> **`accept remaining gaps` and `CANNOT-FIX` are not the same option.** "Accepted" means the gap is tolerable and nobody looked further. CANNOT-FIX means the gap was *investigated* and each candidate remedy was **rejected by a measurement**.

In the source run, four candidate remedies were killed this way — vendor backfill (survivorship bias), a permco-level denominator (365 fixed, 138,024 broken), two commercial feeds (unlicensed). Each rejection is a number, not a judgement call, and the register is where it lives.

## Scope

Documentation only — 205 lines across four skill files. No executable code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qhs1YZ8bYj6zVwfC6omb8
