### PR TITLE
fight: filter SharkRepellent tickers to -US, add fight_definitive, declare the workbook

### DIFF
--- a/skills/npx-ownership-panel/scripts/build_meetings.sas
+++ b/skills/npx-ownership-panel/scripts/build_meetings.sas
@@ -28,12 +28,24 @@
  */
 
 /* --- SharkRepellent campaign data (optional) --- */
-%let shark_file = /scratch/nyu/hue/SharkRepellent 5.21.24.xlsx;
+/* The path is DECLARED in pipeline_config.sas (%let SHARK_FILE), next to
+ * REQUIRE_OPTIONAL_INPUTS, because which workbook is staged changes the panel.
+ * This only forwards it. pipeline_config.sas is %included at line 15 above,
+ * unconditionally, so SHARK_FILE is always defined here — no %symexist guard,
+ * because an open-code %if is the exact shape of the last two macro bugs in this
+ * pipeline (#111 %local in open code, #112 bare semicolon in %put) and this file
+ * has no other open-code %if to lean on. */
+%let shark_file = &SHARK_FILE.;
 /* have_shark means USABLE, not merely PRESENT — see the validation below. */
-%global have_shark shark_pairs shark_max_yr;
+%global have_shark shark_pairs shark_max_yr has_def;
 %let have_shark = 0;
 %let shark_pairs = 0;
 %let shark_max_yr = .;
+/* has_def is GLOBAL, not %local to load_shark: the OPTIONAL NOTE that reports it
+ * is emitted in open code further down, where a %local would resolve to nothing —
+ * the same silent-empty-macro-var shape as #111/#112. Initialised so the NOTE is
+ * well-defined even when no workbook is staged. */
+%let has_def = 0;
 
 %macro load_shark;
     %if %sysfunc(fileexist("&shark_file.")) %then %do;
@@ -80,7 +92,7 @@
          *
          * So a workbook that cannot answer the question is treated as ABSENT,
          * and REQUIRE_OPTIONAL_INPUTS then decides whether that is fatal. */
-        %local has_tick has_date;
+        %local has_tick has_date;   /* has_def is %global — declared above */
         proc sql noprint;
             select count(*) into :has_tick trimmed from dictionary.columns
               where libname = "OUT" and memname = "SHARK"
@@ -88,6 +100,13 @@
             select count(*) into :has_date trimmed from dictionary.columns
               where libname = "OUT" and memname = "SHARK"
                 and upcase(name) = "CAMPAIGN_MEETING_DATE";
+            /* Proxy_Fight_Definitive is a BONUS column, not a usability
+             * requirement: a workbook without it still answers the `fight`
+             * question. Probed separately so its absence degrades ONE column
+             * instead of discarding the whole workbook. */
+            select count(*) into :has_def trimmed from dictionary.columns
+              where libname = "OUT" and memname = "SHARK"
+                and upcase(name) = "PROXY_FIGHT_DEFINITIVE";
         quit;
 
         %if &has_tick. = 0 or &has_date. = 0 %then %do;
@@ -100,9 +119,41 @@
         %else %do;
             data out.shark2;
                 set out.shark;
-                ticker=scan(scan(Company_Ticker,1,'-'),1,'.');
+                length _exch $8;
+
+                /* THE EXCHANGE SUFFIX IS LOAD-BEARING. FactSet writes tickers as
+                 * `AHT-US`, `S-CA`, `AGL-AU`. Stripping at the first '-' without
+                 * testing the suffix silently merges a foreign issuer into the US
+                 * issuer that shares the base symbol.
+                 *
+                 * Measured on the 1995-2024 extract: 12,785 US campaigns, 3,984
+                 * non-US, 700 with no suffix — and 279 distinct non-US base
+                 * tickers COLLIDE with a US base ticker (AAL, AGN, AGO, AEE, ...).
+                 * Each collision would attribute an Australian or Canadian proxy
+                 * fight to an unrelated US company's meeting.
+                 *
+                 * ISS `ticker` in turnout2 is US-listed, so a non-US row can only
+                 * ever produce a false positive. Blank the KEY rather than
+                 * subsetting, so the row still counts toward the coverage
+                 * diagnostics below and only the join is suppressed. */
+                _exch = upcase(scan(Company_Ticker, -1, '-'));
+                if _exch = 'US'
+                    then ticker = scan(scan(Company_Ticker,1,'-'),1,'.');
+                    else ticker = '';
+
                 meetingdate=input(Campaign_Meeting_Date,??anydtdte10.);
                 format meetingdate yymmddn8.;
+
+                %if &has_def. %then %do;
+                fight_definitive_src = (Proxy_Fight_Definitive = 1);
+                %end;
+                %else %do;
+                /* Column absent in this extract — the flag stays 0 and the
+                 * OPTIONAL NOTE reports shark_def=0, rather than the run failing
+                 * over a bonus column. */
+                fight_definitive_src = 0;
+                %end;
+                drop _exch;
             run;
 
             /* Rows that actually reach the join. Campaign_Meeting_Date is '@NA'
@@ -201,7 +252,11 @@
  * The NOTE prints unconditionally and in the same shape as the PREREQ/UNIVERSE
  * gates, so `grep -E 'PREREQ|UNIVERSE|OPTIONAL|ERROR'` says which panel this is.
  * Whether absence is fatal is REQUIRE_OPTIONAL_INPUTS in pipeline_config.sas. */
-%put NOTE: OPTIONAL shark=&have_shark. shark_pairs=&shark_pairs. shark_through=&shark_max_yr. recs=&have_recs.;
+/* shark_pairs counts US-listed pairs only — non-US tickers are blanked in the
+ * shark2 step, so this is smaller than it was before that fix and is the count
+ * that can actually join. shark_def=0 alongside shark=1 means the extract lacks
+ * Proxy_Fight_Definitive, so fight_definitive is 0 everywhere by absence. */
+%put NOTE: OPTIONAL shark=&have_shark. shark_pairs=&shark_pairs. shark_through=&shark_max_yr. shark_def=&has_def. recs=&have_recs.;
 
 %macro require_optional_inputs;
     %if &REQUIRE_OPTIONAL_INPUTS. = 1 %then %do;
@@ -357,16 +412,40 @@ proc sql;
             c.cik,
             %if &have_shark. %then %do;
             coalesce(b.fight,0) as fight,
+            coalesce(b.fight_definitive,0) as fight_definitive,
             %end;
             %else %do;
             0 as fight,
+            0 as fight_definitive,
             %end;
             year(a.meetingdate) as yyyy
         from turnout2 a
         %if &have_shark. %then %do;
+        /* TWO FLAGS, NOT ONE REDEFINED.
+         *
+         *   fight             any campaign whose Campaign_Meeting_Date equals
+         *                     this meeting date. The original definition.
+         *   fight_definitive  that campaign went to a definitive vote
+         *                     (Proxy_Fight_Definitive = 1). Strictly narrower.
+         *
+         * `fight` is NOT redefined in place because it is a named column in four
+         * frozen digests where "fight is 0 everywhere" is a DECLARED property
+         * (pipeline_config.sas). Changing what a name means, under a name that
+         * something else asserts a property about, is the exact failure that
+         * declaration block exists to prevent. A narrower definition is a NEW
+         * column; consumers opt in.
+         *
+         * Both use the same exact-meetingdate join. mirror's build_fight_flags.py
+         * instead matches announce-year +/-1 at meeting grain and propagates to
+         * every agenda item — a LOOSER match that would raise the hit rate. Not
+         * adopted here without a measurement of its false-positive cost. */
         left join
-            (select distinct ticker, meetingdate, 1 as fight from out.shark2
-             where meetingdate is not null) b
+            (select ticker, meetingdate,
+                    1 as fight,
+                    max(fight_definitive_src) as fight_definitive
+             from out.shark2
+             where meetingdate is not null and ticker ne ''
+             group by ticker, meetingdate) b
             on a.ticker=b.ticker and a.meetingdate=b.meetingdate
         %end;
         left join

--- a/skills/npx-ownership-panel/scripts/pipeline_config.sas
+++ b/skills/npx-ownership-panel/scripts/pipeline_config.sas
@@ -119,6 +119,40 @@
  */
 %let REQUIRE_OPTIONAL_INPUTS = 0;
 
+/* WHICH SharkRepellent workbook. Declared here, with the other optional inputs,
+ * rather than buried at line 31 of build_meetings.sas — the choice changes the
+ * panel, so it belongs where the panel-changing choices are stated.
+ *
+ * Two extracts exist and NEITHER is clean. Measured, not assumed:
+ *
+ *   A  `20240521 SharkRepellent.xlsx` (33.4 MB) — the one whose filename matched
+ *      the historical default (20240521 IS 5.21.24). Campaign Details has NO
+ *      header row: PROC IMPORT takes column 1's name from a banner cell and falls
+ *      back to B, C, D... for the rest. No Company_Ticker, no
+ *      Campaign_Meeting_Date. 16,658 rows, 0 parsed dates, 0 tickers. Useless,
+ *      and worse than absent because fileexist succeeds on it.
+ *
+ *   B  `SharkRepellent 1995-2024.xlsx` (64.9 MB) — parses. 12,785 US campaigns,
+ *      3,984 non-US, 700 with no exchange suffix. Campaign_Meeting_Date is '@NA'
+ *      for campaigns with no meeting (9,629 of 17,469), which is expected. Its
+ *      defect is the TAIL: 755 campaign-meetings in 2024 against 99 in 2025, so
+ *      it reaches year2=2025 while barely covering it — which is exactly what the
+ *      tail-volume check in build_meetings fires on.
+ *
+ * DEFAULT IS EMPTY — no workbook staged. That is deliberate, and it is what makes
+ * `fight = 0` a stated property of digests A-C rather than an accident. The
+ * previous default named a path that does not exist on the grid, which reached
+ * the same all-zero panel by accident while looking like a choice.
+ *
+ * Point this at B to populate `fight` / `fight_definitive`, expect the 2025
+ * coverage WARNING, and re-freeze afterwards — the digests change.
+ *
+ * Staged on the grid for comparison:
+ *   A  /scratch/nyu/hue/shark_eval/A_20240521.xlsx
+ *   B  /scratch/nyu/hue/shark_eval/B_1995_2024.xlsx
+ */
+%let SHARK_FILE = ;
+
 /* MEASURED EFFECT of these two filters on the item frame, 2005-2025 (2026-07-25):
  *
  *   filters            distinct items   raw rows   fanout


### PR DESCRIPTION
fight: filter SharkRepellent tickers to -US, add fight_definitive, declare the workbook

Three changes to leg A, none of which redefine an existing column.

1. THE -US FILTER IS A CORRECTNESS FIX, not tidying. FactSet writes tickers as
   `AHT-US`, `S-CA`, `AGL-AU`. build_meetings stripped at the first '-' with no
   suffix test, so a foreign issuer merged into the US issuer sharing the base
   symbol. Measured on the 1995-2024 extract: 12,785 US campaigns, 3,984 non-US,
   700 with no suffix — and 279 distinct non-US base tickers collide with a US
   base ticker (AAL, AGN, AGO, AEE...). ISS tickers are US-listed, so every one
   of those collisions could only ever be a false positive. The key is blanked
   rather than the row subset, so coverage diagnostics still see the row.

   This is latent today (no workbook staged) and fires the moment one is.

2. fight_definitive is a NEW column, not a redefinition of fight. mirror's
   build_fight_flags.py restricts to `Proxy Fight Definitive == 1`, which is the
   better-defined quantity. But `fight` is a named column in four frozen digests
   where "fight is 0 everywhere" is a DECLARED property, and changing what a name
   means under a name something else asserts a property about is precisely what
   the declaration block in pipeline_config.sas exists to prevent. So both ship
   and consumers opt in. The column is probed separately from the usability gate,
   so an extract lacking it degrades one column instead of being discarded.

   mirror's announce-year +/-1 meeting-grain match is deliberately NOT adopted:
   it is looser than the exact-meetingdate join and would raise the hit rate,
   and no measurement of its false-positive cost exists.

3. The workbook path moves to pipeline_config.sas next to
   REQUIRE_OPTIONAL_INPUTS, because which extract is staged changes the panel.
   The old default named /scratch/nyu/hue/SharkRepellent 5.21.24.xlsx, which
   does not exist on the grid — so the deployment reached its all-zero `fight`
   through the file-not-found branch while appearing to have chosen a file. The
   new default is empty, which reaches the same panel deliberately. Both staged
   extracts are documented with their measured defects.

has_def is %global because the OPTIONAL NOTE that reports it is emitted in open
code, where a %local resolves to nothing — the same shape as #111/#112.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0193ue9M5okF31PoPetXXBmL
