### PR TITLE
quorum: port the DEF 14A bylaw-threshold parser to a scan_covers profile

### DIFF
--- a/skills/wrds/references/edgar.md
+++ b/skills/wrds/references/edgar.md
@@ -932,8 +932,19 @@ qsub -t 1-20 \
 
 | Parser | Source | Extracts | Input | Accuracy |
 |--------|--------|----------|-------|----------|
-| `parse_quorum` | `mirror/scripts/bylaw_quorum/parse_quorum_go/` | Quorum threshold from DEF 14A | DEF 14A filings | Per-firm bylaw thresholds |
-| `state_incorp` (profile) | `workflows/wrds/scripts/scan_covers/profiles_state_incorp.go` | State of incorp + HQ state from 10-K SGML header | 10-K filings | 98.4% vs Barzuza et al. |
-| `parse_state_incorp` (standalone) | `mirror/scripts/state_incorp_go/` | Same as above (original version) | 10-K filings | 98.4% vs Barzuza et al. |
+| `quorum` (profile) | `scan_covers/profiles_quorum.go` + `profiles/quorum/` | Bylaw quorum threshold from DEF 14A | DEF 14A, DEFM14A | 96.6% explicit parse |
+| `state_incorp` (profile) | `scan_covers/profiles_state_incorp.go` | State of incorp + HQ state from 10-K SGML header | 10-K filings | 98.4% vs Barzuza et al. |
+| `blockholders_13dg` (profile) | `scan_covers/profiles_blockholders_13dg.go` | Item 12 + max ownership % | SC 13D/G | — |
+| `proxy_advisors` (profile) | `scan_covers/profiles_proxy_advisors.go` | ISS/GL/EJ mentions | 485BPOS/APOS | — |
+| `tender_sc_to` (profile) | `scan_covers/profiles_tender_sc_to.go` | Tender offer cover fields | SC TO-* | — |
 
-**Prefer `scan_covers -profile state_incorp`** over the standalone parser. The scan_covers framework handles SGE sharding, path construction, and concurrency generically.
+**Everything is a profile now.** Two rows here previously pointed into
+`~/projects/mirror` — `bylaw_quorum/parse_quorum_go/` and `state_incorp_go/` — and
+the second was already dead (that directory does not exist). The quorum parser has
+been ported to `-profile quorum`, verified identical to the standalone on fixtures
+covering every confidence tier; see `profiles/quorum/README.md`.
+
+Reaching for a standalone binary is the documented Red Flag: `scan_covers` handles
+SGE sharding, path construction and concurrency generically, so a new extraction is
+a `profiles_*.go` file plus a `profiles/<name>/` directory for staging and panel
+building.

--- a/skills/wrds/scripts/scan_covers/extractors_quorum.go
+++ b/skills/wrds/scripts/scan_covers/extractors_quorum.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Bylaw quorum-threshold extraction from DEF 14A proxy statements.
+//
+// WHY THIS EXISTS. ISS Voting Analytics carries the PASS-vote mechanics (`base`,
+// `voterequirement`) but not the QUORUM threshold, and no WRDS table has a
+// quorum column at all — `iss_va_shareholder.chars`, `risk.chars` and
+// `risk.chars_us` all return zero rows for `%quorum%`. The only source is the
+// proxy text itself.
+//
+// PORTED, NOT REWRITTEN, from mirror `scripts/bylaw_quorum/parse_quorum_go/`,
+// which is where the 96.6% explicit-parse-coverage figure was measured. It
+// arrives here as a scan_covers profile rather than a fourth standalone binary
+// because this skill's own Red Flags section says so: "Create a new standalone
+// Go binary for EDGAR extraction -> STOP. scan_covers is a generic
+// profile-based framework. Add a profiles_*.go file, not a new binary."
+//
+// The behaviour is deliberately unchanged from the standalone. If you tune a
+// pattern here, mirror's copy and the published coverage number are both stale.
+
+var (
+	// <[^>]+> would span newlines when brackets are unbalanced (e.g. math
+	// comparisons like "<=-500 bps" and "> 500 bps" on separate lines), eating
+	// huge text spans. Restricting to a single line leaves unbalanced brackets
+	// as literal text, which the proximity checks tolerate fine.
+	reQTag        = regexp.MustCompile(`<[^>\n]+>`)
+	reQEntity     = regexp.MustCompile(`&(?:nbsp|amp|lt|gt|quot|#\d+);`)
+	reQWhitespace = regexp.MustCompile(`\s+`)
+	reQuorumWord  = regexp.MustCompile(`(?i)quorum`)
+
+	// Threshold patterns, ordered by specificity. Per DGCL §216 the only legal
+	// quorum values for public-company bylaws are in [0.333, 0.50] — one-third
+	// statutory floor, majority default. Higher values are recognised in order
+	// to FLAG oddities, not to accept them silently.
+	quorumThresholds = []struct {
+		rx    *regexp.Regexp
+		value float64
+		conf  string
+		label string
+	}{
+		{regexp.MustCompile(`(?i)\b(?:one[-\s]third|1/3|33[-\s]*1/3[-\s]*%|33\.?3[3]?\s*%|33\s*(?:%|percent)|thirty[-\s]three\s+(?:percent|and\s+(?:one[-\s]third|a\s+third)))`),
+			0.3333, "high", "one-third"},
+		{regexp.MustCompile(`(?i)\b(?:two[-\s]fifths|40\s*%|forty\s+percent)`),
+			0.40, "high", "two-fifths"},
+		{regexp.MustCompile(`(?i)\b(?:45\s*%|forty[-\s]five\s+percent)`),
+			0.45, "high", "45-percent"},
+		// Non-Delaware: Canadian CBCA and some state defaults.
+		{regexp.MustCompile(`(?i)\b(?:one[-\s]quarter|1/4|25\s*%|twenty[-\s]five\s+percent)`),
+			0.25, "high", "one-quarter"},
+		// DGCL default. "med" not "high" — boilerplate majority is the most
+		// easily confused with the PASS rule.
+		{regexp.MustCompile(`(?i)\b(?:a\s+(?:simple\s+)?majority|(?:simple\s+)?majority\s+of\s+the|one[-\s]half|1/2|50\s*%|fifty\s+percent)`),
+			0.50, "med", "majority"},
+	}
+
+	// Tier-1 anchor. The text must reference shares OUTSTANDING (or equivalently
+	// voting power / entitled to vote) — this is what discriminates the QUORUM
+	// rule from the PASS rule ("majority of votes cast", "majority of shares
+	// present and voting"). Loose on purpose, because proxy templates vary:
+	// "a majority of the outstanding shares", "...of the shares outstanding",
+	// "...of the shares of common stock outstanding", "...of the voting power".
+	// False positives from unrelated uses ("outstanding performance") are killed
+	// downstream by the 150-char proximity check plus the quorum-context bound.
+	reQOutstanding = regexp.MustCompile(`(?i)\b(?:outstanding|entitled\s+to\s+(?:vote|cast|be\s+cast)|voting\s+power|issued\s+and\s+outstanding|possible\s+votes|votes\s+that\s+(?:may|can)\s+be\s+cast|votes\s+(?:that\s+)?may\s+be\s+cast|total\s+(?:number\s+of\s+)?votes|number\s+of\s+votes\s+entitled)\b`)
+
+	// Tier-2 anchor. Canonical quorum verbs, for thresholds stated without an
+	// explicit "outstanding" qualifier ("a majority of common stock will
+	// constitute a quorum"). Capped at "med" confidence, because the missing
+	// outstanding signal is exactly the ambiguity tier-1 resolves.
+	reQVerb = regexp.MustCompile(`(?i)\b(?:constitute[s]?\s+a\s+quorum|will\s+be\s+a\s+quorum|necessary\s+(?:for|to\s+(?:constitute|have))\s+a\s+quorum|quorum\s+(?:will\s+exist|is\s+met|exists|consisting\s+of|consists\s+of|requires|at\s+(?:all\s+)?meetings)|have\s+a\s+quorum|for\s+there\s+to\s+be\s+a\s+quorum|is\s+required\s+for\s+a\s+quorum)\b`)
+
+	// Pass-rule phrases. If one appears inside the threshold+anchor clause, the
+	// match is pass-rule context and is discarded. `plurality` is here because
+	// it is a DIRECTOR-vote rule, never a meeting quorum.
+	reQReject = regexp.MustCompile(`(?i)\b(?:plurality|vote[s]?\s+(?:cast|properly\s+cast)|shares\s+present\s+and\s+voting|present\s+in\s+person\s+or\s+by\s+proxy\s+and\s+entitled\s+to\s+vote\s+on\s+the\s+matter)`)
+)
+
+func quorumStripHTML(s string) string {
+	s = reQTag.ReplaceAllString(s, " ")
+	s = reQEntity.ReplaceAllString(s, " ")
+	s = reQWhitespace.ReplaceAllString(s, " ")
+	return s
+}
+
+func quorumAbs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// extractQuorum returns "threshold|confidence|match_text".
+//
+// THREE VALUES IN ONE FIELD, deliberately. The Field.Custom contract returns a
+// single string, and this is one expensive extraction (a full-body proximity
+// scan) that yields three correlated outputs — registering three Custom fields
+// would run it three times. profiles/quorum/build_panel.py splits on the first
+// two pipes; the snippet is pipe-sanitised so the split is unambiguous.
+//
+// Confidence ladder, most to least trustworthy:
+//
+//	high              explicit fraction/percent, anchored to an "outstanding" qualifier
+//	med               boilerplate majority, or a high pattern reached only via tier-2
+//	default           filing mentions quorum but no threshold parsed -> DGCL §216 0.50
+//	default-noquorum  filing contains NO quorum text at all -> DGCL §216 0.50
+//	low               nothing usable
+//
+// The two `default*` tiers return the same 0.50 and are kept separate on
+// purpose: "we read it and could not find a threshold" and "there was nothing
+// to read" are different claims, and collapsing them would hide which.
+func extractQuorum(buf []byte) string {
+	text := quorumStripHTML(string(buf))
+
+	hits := reQuorumWord.FindAllStringIndex(text, -1)
+	if len(hits) == 0 {
+		// Likely a supplemental / notice-only DEF 14A that references an earlier
+		// filing. DGCL §216 majority is the legal baseline absent an explicit bylaw.
+		return quorumOut(0.50, "default-noquorum",
+			"(default: filing contains no quorum text; DGCL 216 majority applied)")
+	}
+
+	// Scan 250 chars BOTH SIDES of each "quorum" hit — proxies phrase it either
+	// direction:
+	//   forward:  "quorum. This means a majority of outstanding shares..."
+	//   backward: "a majority of outstanding shares must be present ... to have a quorum"
+	// The threshold and its anchor must co-occur within 150 chars (same
+	// sentence); the closest pairing across all hits wins.
+	bestVal, bestConf, bestMatch := 0.0, "", ""
+	bestDist := 1 << 30
+	found := false
+
+	for _, h := range hits {
+		lo, hi := h[0]-250, h[1]+250
+		if lo < 0 {
+			lo = 0
+		}
+		if hi > len(text) {
+			hi = len(text)
+		}
+		ctx := text[lo:hi]
+		quorumLocal := h[0] - lo
+
+		outAll := reQOutstanding.FindAllStringIndex(ctx, -1)
+		verbAll := reQVerb.FindAllStringIndex(ctx, -1)
+		if len(outAll) == 0 && len(verbAll) == 0 {
+			continue
+		}
+
+		for _, p := range quorumThresholds {
+			// ALL occurrences, not the first. A proxy typically carries several
+			// "majority"s — "majority of votes cast" (pass rule, rejected) and
+			// "majority of outstanding shares" (quorum rule, accepted) — and
+			// stopping at the first misses the real definition whenever the pass
+			// rule is stated earlier.
+			for _, m := range p.rx.FindAllStringIndex(ctx, -1) {
+				var anchor []int
+				anchorDist := 1 << 30
+				for _, o := range outAll {
+					if d := quorumAbs(m[0] - o[0]); d < anchorDist {
+						anchorDist, anchor = d, o
+					}
+				}
+				conf := p.conf
+				if anchor == nil || anchorDist > 150 {
+					// Tier-2 fallback, tighter window.
+					anchor, anchorDist = nil, 1<<30
+					for _, v := range verbAll {
+						if d := quorumAbs(m[0] - v[0]); d < anchorDist {
+							anchorDist, anchor = d, v
+						}
+					}
+					if anchor == nil || anchorDist > 100 {
+						continue
+					}
+					if conf == "high" {
+						conf = "med"
+					}
+				}
+
+				clauseLo := m[0]
+				if anchor[0] < clauseLo {
+					clauseLo = anchor[0]
+				}
+				clauseHi := m[1]
+				if anchor[1] > clauseHi {
+					clauseHi = anchor[1]
+				}
+				if clauseHi+40 < len(ctx) {
+					clauseHi += 40
+				} else {
+					clauseHi = len(ctx)
+				}
+				if reQReject.MatchString(ctx[clauseLo:clauseHi]) {
+					continue
+				}
+
+				dist := quorumAbs(m[0] - quorumLocal)
+				if !found || dist < bestDist || (dist == bestDist && conf == "high" && bestConf != "high") {
+					sLo := clauseLo - 60
+					if sLo < 0 {
+						sLo = 0
+					}
+					sHi := clauseHi + 100
+					if sHi > len(ctx) {
+						sHi = len(ctx)
+					}
+					snippet := strings.TrimSpace(ctx[sLo:sHi])
+					if len(snippet) > 300 {
+						snippet = snippet[:300]
+					}
+					bestVal, bestConf, bestMatch = p.value, conf, snippet
+					bestDist = dist
+					found = true
+				}
+			}
+		}
+	}
+
+	if found {
+		return quorumOut(bestVal, bestConf, bestMatch)
+	}
+	// Mentions quorum but no threshold was extractable. Labelled `default` so
+	// downstream can see the value is inferred rather than read.
+	return quorumOut(0.50, "default",
+		"(default: DGCL 216 / most state-law default - filing mentions quorum but no explicit threshold found)")
+}
+
+// quorumOut joins the triple, stripping pipes and tabs from the snippet so the
+// field survives both the TSV writer and the downstream split.
+func quorumOut(v float64, conf, match string) string {
+	match = strings.NewReplacer("|", "/", "\t", " ", "\r", " ", "\n", " ").Replace(match)
+	return fmt.Sprintf("%.4f|%s|%s", v, conf, match)
+}

--- a/skills/wrds/scripts/scan_covers/profiles/quorum/README.md
+++ b/skills/wrds/scripts/scan_covers/profiles/quorum/README.md
@@ -1,0 +1,110 @@
+# quorum — bylaw quorum thresholds from DEF 14A proxies
+
+## Why
+
+ISS Voting Analytics carries the **pass**-vote mechanics (`base`, `voterequirement`)
+but not the **quorum** threshold, and no WRDS table has one: `iss_va_shareholder.chars`,
+`risk.chars` and `risk.chars_us` all return zero rows for `%quorum%`. The only
+source is the proxy text.
+
+Needed for any counterfactual where a block abstains rather than votes — full
+abstention can break quorum, and whether it does depends on the firm's bylaw, not
+on the pass rule.
+
+## Pipeline
+
+```bash
+# 1. stage the index (local or grid; hits WRDS PostgreSQL)
+python stage.py --start-year 2005 --end-year 2025 --out .
+
+# 2. scan (grid — this reads whole filings, do NOT run it on the login node)
+qsub ../../sge/submit_array.sh          # or, serially:
+scan_covers -profile quorum -files-from quorum_files.txt \
+    -root /wrds/sec/wrds_clean_filings > quorum_raw.tsv
+
+# 3. reduce to one row per (cik, meeting_year)
+python build_panel.py --scan quorum_raw.tsv --index quorum_filings.tsv \
+    --out data/processed
+```
+
+Output `quorum_bylaws.parquet`: `cik, meeting_year, threshold, confidence,
+accession, filing_date, match_text`.
+
+## How the threshold is found
+
+Per DGCL §216 the only legal quorum values for public-company bylaws are in
+[0.333, 0.50] — the one-third statutory floor and the majority default. Higher
+values are recognised to **flag** oddities, not to accept them.
+
+Around every occurrence of "quorum", a ±250-char window is scanned for a
+threshold phrase, which must then be anchored:
+
+| Tier | Anchor | Window | Confidence |
+|---|---|---|---|
+| 1 | an **outstanding** qualifier (`outstanding`, `entitled to vote`, `voting power`, …) | 150 chars | as labelled |
+| 2 | a canonical **quorum verb** (`constitutes a quorum`, `necessary for a quorum`, …) | 100 chars | capped at `med` |
+
+The anchor is what separates the quorum rule from the pass rule. "A majority of
+the **outstanding shares**" is a quorum; "a majority of the **votes cast**" is
+not, and the reject list kills the second — including `plurality`, which is a
+director-vote rule and never a meeting quorum.
+
+All occurrences of each pattern are tried, not the first. A proxy typically
+states the pass rule *before* the quorum rule, so first-match would
+systematically pick the wrong one.
+
+### Confidence ladder
+
+| | Meaning |
+|---|---|
+| `high` | explicit fraction/percent, tier-1 anchored |
+| `med` | boilerplate majority, or a `high` pattern that only reached tier 2 |
+| `default` | filing discusses quorum, no threshold extractable → DGCL §216 0.50 |
+| `default-noquorum` | filing contains **no** quorum text at all → DGCL §216 0.50 |
+| `low` | nothing usable |
+
+**`default` and `default-noquorum` both return 0.50 and are deliberately not
+merged.** "We read it and found no number" and "there was nothing to read" are
+different claims about the same value, and the dedup ranking prefers the first.
+Collapsing them would let an absence pass as a reading.
+
+## Measured
+
+From `mirror/docs/investigations/2026-04-22_bylaw_quorum.md`, on the Russell 3000
+scope: **96.6% explicit parse coverage**. Full abstention fails quorum for
+**12.82%** of index-block item-rows (79,502 / 619,991), against 13.70% under a
+flat DGCL ½ and 4.27% under a flat ⅓ — i.e. the firm-specific threshold matters,
+and both flat assumptions are wrong in opposite directions.
+
+## Provenance
+
+Ported from mirror `scripts/bylaw_quorum/parse_quorum_go/`, which is where the
+coverage figure was measured. It is a scan_covers **profile** rather than a
+fourth standalone binary because this skill's Red Flags section requires it:
+*"Create a new standalone Go binary for EDGAR extraction → STOP. `scan_covers` is
+a generic profile-based framework. Add a `profiles_*.go` file, not a new binary."*
+
+**Parity verified** against the standalone on fixtures covering every confidence
+tier (`high` one-third, `high` one-quarter, `med` majority-outstanding,
+`default`, `default-noquorum` ×2) — identical threshold and confidence on all six.
+
+If you tune a pattern here, mirror's copy and the published 96.6% are both stale.
+
+`merge_v12.py` did **not** come across: it joins to mirror's counterfactuals panel
+on `(cik, meeting_year)` with a ±5-year asof fallback, which is that paper's
+analysis rather than general capability.
+
+## Traps
+
+- **`FullBody`, not a head window.** Quorum text sits in the "Questions and
+  Answers About the Meeting" section, anywhere from a few KB into a proxy to most
+  of the way through several hundred KB. `HeadBytes` is only the form-type
+  pre-filter here.
+- **Never run the scan on the login node.** It reads whole filings off NFS.
+- **The HTML strip is single-line-restricted** (`<[^>\n]+>`). A multiline tag
+  regex ate huge spans when brackets were unbalanced — e.g. `"<=-500 bps"` and
+  `"> 500 bps"` on separate lines — silently deleting the text the match needed.
+- **The `quorum` column packs three values** as `threshold|confidence|match_text`.
+  One full-body scan, three correlated outputs; three `Custom` fields would run it
+  three times. `build_panel.py` splits on the first two pipes and the snippet is
+  pipe-sanitised in Go.

--- a/skills/wrds/scripts/scan_covers/profiles/quorum/build_panel.py
+++ b/skills/wrds/scripts/scan_covers/profiles/quorum/build_panel.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Reduce scan_covers `quorum` output to one threshold per (cik, meeting_year).
+
+Reads:  the scan_covers TSV (filepath, accession, form_type, filed_date, cik,
+        company_name, quorum) plus the staging index written by stage.py, which
+        carries meeting_year — the scanner sees only the filing, not the meeting
+        it belongs to.
+Writes: <out>/quorum_bylaws.parquet
+          cik, meeting_year, threshold, confidence, accession, filing_date, match_text
+
+Usage:
+    python build_panel.py --scan quorum_raw.tsv --index quorum_filings.tsv \
+                          --out data/processed
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+# Dedup ranking, best first. A firm can file several proxies for one meeting
+# year (definitive plus a supplement), and they will not agree: the supplement
+# usually has no quorum text at all and lands on `default-noquorum`.
+#
+# ORDER MATTERS AND IT IS NOT THE THRESHOLD ORDER. `default` outranks
+# `default-noquorum` because "we read the proxy, it discussed quorum, we could
+# not extract a number" is better evidence than "there was no quorum text to
+# read" — both return 0.50, but only the first one looked. Collapsing them
+# would make an absence look like a reading.
+CONF_ORDER = {"high": 0, "med": 1, "default": 2, "default-noquorum": 3,
+              "low": 4, "none": 5}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scan", required=True, help="scan_covers profile=quorum TSV")
+    ap.add_argument("--index", required=True, help="stage.py index TSV (has meeting_year)")
+    ap.add_argument("--out", default="data/processed")
+    args = ap.parse_args()
+
+    # scan_covers writes NO header row — the first line is data. Supplying names
+    # is required, not defensive: with header inference the first filing is
+    # silently consumed as column labels and the panel comes out one row short
+    # with garbage column names.
+    # Order must match the Fields list in profiles_quorum.go; `scan_covers -list`
+    # prints it.
+    SCAN_COLS = ["filepath", "accession", "form_type", "filed_date", "cik",
+                 "company_name", "quorum"]
+    scan = pd.read_csv(args.scan, sep="\t", dtype=str, header=None,
+                       names=SCAN_COLS).fillna("")
+    idx = pd.read_csv(args.index, sep="\t", dtype=str).fillna("")
+    print(f"[scan]  {len(scan):,} rows")
+    print(f"[index] {len(idx):,} staged filings")
+
+    # The Custom field packs three correlated outputs into one column, because it
+    # is one full-body proximity scan and three Custom fields would run it three
+    # times. Split on the FIRST TWO pipes only — the snippet is pipe-sanitised in
+    # Go, but n=2 makes that belt-and-braces rather than load-bearing.
+    parts = scan["quorum"].str.split("|", n=2, expand=True)
+    if parts.shape[1] != 3:
+        raise SystemExit(
+            f"quorum column did not split into 3 parts (got {parts.shape[1]}). "
+            "Expected 'threshold|confidence|match_text' from extractQuorum.")
+    scan["threshold"] = pd.to_numeric(parts[0], errors="coerce")
+    scan["confidence"] = parts[1]
+    scan["match_text"] = parts[2]
+
+    bad = scan["threshold"].isna().sum()
+    if bad:
+        print(f"[warn] {bad:,} rows have an unparseable threshold — dropped")
+        scan = scan[scan["threshold"].notna()]
+
+    # meeting_year comes from the staging index, joined on the path the scanner
+    # echoes back. Left join, so a staged filing the scanner skipped (wrong form
+    # type) simply drops out rather than silently becoming year-less.
+    key = "filepath" if "filepath" in scan.columns else scan.columns[0]
+    df = scan.merge(idx[["path", "meeting_year"]], left_on=key, right_on="path",
+                    how="inner")
+    print(f"[join]  {len(df):,} rows carry a meeting_year")
+    if len(df) < len(scan):
+        print(f"        ({len(scan) - len(df):,} scanned rows had no index match)")
+
+    n_before = len(df)
+    df["conf_rank"] = df["confidence"].map(CONF_ORDER).fillna(99)
+    df = (df.sort_values(["cik", "meeting_year", "conf_rank", "threshold", "filed_date"],
+                         ascending=[True, True, True, False, False])
+            .drop_duplicates(["cik", "meeting_year"], keep="first")
+            .drop(columns=["conf_rank"]))
+    print(f"[dedup] {n_before:,} -> {len(df):,} (cik, meeting_year) rows "
+          f"({100*(len(df)-n_before)/max(n_before,1):+.1f}%)")
+
+    df = df.rename(columns={"filed_date": "filing_date"})
+    df = df[["cik", "meeting_year", "threshold", "confidence",
+             "accession", "filing_date", "match_text"]]
+
+    # DEN: every rate printed with its base, so a coverage claim cannot be read
+    # off a shrinking denominator.
+    n = len(df)
+    explicit = df["confidence"].isin(["high", "med"]).sum()
+    print(f"\n[DEN] explicit parse = {explicit:,}/{n:,} = {100*explicit/max(n,1):.1f}%")
+    print("[DQ] confidence mix:")
+    print(df["confidence"].value_counts().to_string())
+    print("[DQ] threshold mix:")
+    print(df["threshold"].value_counts().sort_index().to_string())
+
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+    dest = outdir / "quorum_bylaws.parquet"
+    df.to_parquet(dest, index=False)
+    print(f"\n[out] {dest} ({len(df):,} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/wrds/scripts/scan_covers/profiles/quorum/stage.py
+++ b/skills/wrds/scripts/scan_covers/profiles/quorum/stage.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Stage the DEF 14A filing index for the scan_covers `quorum` profile.
+
+Emits two files, because the scanner and the panel builder need different things:
+
+  quorum_filings.tsv   cik, accession, fdate, meeting_year, path
+                       the metadata index. `meeting_year` is the only field the
+                       scanner CANNOT recover — it sees a filing, not the meeting
+                       the filing is about — so build_panel.py joins it back on
+                       `path`.
+  quorum_files.txt     one path per line, for `scan_covers -files-from`.
+
+Then, on the grid:
+
+    scan_covers -profile quorum -files-from quorum_files.txt \\
+        -root /wrds/sec/wrds_clean_filings > quorum_raw.tsv
+    python build_panel.py --scan quorum_raw.tsv --index quorum_filings.tsv
+
+Usage:
+    python stage.py --start-year 2005 --end-year 2025 --out .
+    python stage.py --ciks-from my_ciks.txt --out .
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import socket
+from pathlib import Path
+
+# WRDS IPv6 is unreliable from some networks; force IPv4 before psycopg2 loads.
+_orig_getaddrinfo = socket.getaddrinfo
+
+
+def _ipv4_only(host, port, family=0, *a, **k):
+    return _orig_getaddrinfo(host, port, socket.AF_INET, *a, **k)
+
+
+socket.getaddrinfo = _ipv4_only
+
+import psycopg2  # noqa: E402
+
+# DEF 14A only. PRE 14A is the preliminary version and a firm that files both
+# would appear twice with possibly different text; the definitive one governs.
+QUERY = """
+SELECT cik, accession, fdate, form, fname
+FROM wrdssec_all.wrds_forms
+WHERE form IN ('DEF 14A', 'DEFM14A')
+  AND fdate BETWEEN %(start)s AND %(end)s
+  {cik_clause}
+"""
+
+
+def fname_to_path(fname: str) -> str:
+    """WRDS `fname` -> path under wrds_clean_filings/.
+
+    'edgar/data/34088/0001193125-25-073986.txt'
+      -> '000034/34088/0001193125-25-073986.txt'
+
+    The first component is the CIK zero-padded to 10 then truncated to 6 — that
+    is the archive's bucketing, not a checksum. Getting it wrong yields a path
+    that does not exist rather than a wrong file, so failures are loud.
+    """
+    parts = fname.split("/")
+    cik_int = parts[2]
+    filename = parts[3]
+    return f"{cik_int.zfill(10)[:6]}/{cik_int}/{filename}"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start-year", type=int, default=2005)
+    ap.add_argument("--end-year", type=int, default=2025)
+    ap.add_argument("--ciks-from", help="file of CIKs, one per line; omit for all filers")
+    ap.add_argument("--out", default=".")
+    ap.add_argument("--host", default=os.environ.get("WRDS_PGHOST", "wrds-pgdata.wharton.upenn.edu"))
+    ap.add_argument("--port", type=int, default=int(os.environ.get("WRDS_PGPORT", "9737")))
+    ap.add_argument("--user", default=os.environ.get("WRDS_USER") or os.environ.get("USER"))
+    args = ap.parse_args()
+
+    params = {"start": f"{args.start_year}-01-01", "end": f"{args.end_year}-12-31"}
+    cik_clause = ""
+    if args.ciks_from:
+        ciks = [c.strip() for c in Path(args.ciks_from).read_text().split() if c.strip()]
+        if not ciks:
+            raise SystemExit(f"{args.ciks_from} is empty")
+        cik_clause = "AND cik IN %(ciks)s"
+        params["ciks"] = tuple(ciks)
+        print(f"[stage] restricted to {len(ciks):,} CIKs")
+
+    conn = psycopg2.connect(host=args.host, port=args.port, dbname="wrds",
+                            user=args.user, sslmode="require")
+    cur = conn.cursor()
+    cur.execute(QUERY.format(cik_clause=cik_clause), params)
+    rows = cur.fetchall()
+    conn.close()
+    print(f"[stage] {len(rows):,} DEF 14A filings {args.start_year}-{args.end_year}")
+
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+    idx_path = outdir / "quorum_filings.tsv"
+    lst_path = outdir / "quorum_files.txt"
+
+    n = 0
+    with idx_path.open("w", newline="") as fh, lst_path.open("w") as lh:
+        w = csv.writer(fh, delimiter="\t", lineterminator="\n")
+        w.writerow(["cik", "accession", "fdate", "meeting_year", "path"])
+        for cik, accession, fdate, _form, fname in rows:
+            if not fname:
+                continue
+            path = fname_to_path(fname)
+            # meeting_year = filing year. A proxy is filed weeks before its
+            # annual meeting and essentially never crosses a year boundary in a
+            # way that matters here; build_panel dedups per (cik, meeting_year)
+            # so a rare December filing for a January meeting collapses into the
+            # same firm-year rather than splitting it.
+            w.writerow([cik, accession, fdate, str(fdate)[:4], path])
+            lh.write(path + "\n")
+            n += 1
+
+    print(f"[out] {idx_path} ({n:,} rows)")
+    print(f"[out] {lst_path}")
+    print(f"\nNext:\n  scan_covers -profile quorum -files-from {lst_path.name} \\\n"
+          f"      -root /wrds/sec/wrds_clean_filings > quorum_raw.tsv\n"
+          f"  python build_panel.py --scan quorum_raw.tsv --index {idx_path.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/wrds/scripts/scan_covers/profiles_quorum.go
+++ b/skills/wrds/scripts/scan_covers/profiles_quorum.go
@@ -1,0 +1,55 @@
+package main
+
+import "regexp"
+
+// quorum — bylaw quorum threshold from DEF 14A proxy statements.
+//
+// FullBody, not a head window. Every other profile in this framework reads a
+// header prefix; this one cannot. The quorum sentence lives in the "Questions
+// and Answers About the Meeting" / "Voting Information" section, which sits
+// anywhere from a few KB to most of the way through a proxy that can run
+// several hundred KB. A head window large enough to be safe would be most of
+// the file anyway, so read the file and say so.
+//
+// HeadBytes stays small because under FullBody it acts only as the form-type
+// pre-filter window — 8 KB always contains the SGML header, so non-DEF-14A
+// filings are rejected after one cheap read.
+//
+// BackFirst is deliberately NOT used. It pays off for 485 prospectuses where
+// the target reliably sits in the back (the SAI); quorum text has no such
+// positional prior, so a back-first pass would just add a seek and re-read.
+//
+// Forms: DEF 14A and DEFM14A carry the meeting mechanics. PRE 14A is the
+// preliminary version — excluded, because a firm that files both would appear
+// twice with possibly different text, and the definitive one is what governs.
+//
+// See profiles/quorum/README.md for the pipeline and the measured coverage.
+func init() {
+	register(&Profile{
+		Name:      "quorum",
+		HeadBytes: 8192,
+		FullBody:  true,
+		Forms:     []string{"DEF 14A", "DEFM14A"},
+		Fields: []Field{
+			{Name: "accession",
+				Pattern: regexp.MustCompile(`ACCESSION NUMBER:[ \t]+([^\s]+)`),
+				Reduce:  First},
+			{Name: "form_type",
+				Pattern: regexp.MustCompile(`CONFORMED SUBMISSION TYPE:[ \t]+([^\r\n]+)`),
+				Reduce:  First},
+			{Name: "filed_date",
+				Pattern: regexp.MustCompile(`FILED AS OF DATE:[ \t]+([0-9]+)`),
+				Reduce:  First},
+			{Name: "cik",
+				Pattern: regexp.MustCompile(`CENTRAL INDEX KEY:[ \t]+([0-9]+)`),
+				Reduce:  First},
+			{Name: "company_name",
+				Pattern: regexp.MustCompile(`COMPANY CONFORMED NAME:[ \t]+([^\r\n]+)`),
+				Reduce:  First},
+			// "threshold|confidence|match_text" — one extraction, three
+			// correlated outputs. See extractQuorum for why it is not three
+			// separate Custom fields.
+			{Name: "quorum", Custom: extractQuorum},
+		},
+	})
+}


### PR DESCRIPTION
quorum: port the DEF 14A bylaw-threshold parser to a scan_covers profile

Mirror had the only quorum-threshold extractor in either repo. ISS Voting
Analytics carries the PASS-vote mechanics but not the quorum threshold, and no
WRDS table has one — iss_va_shareholder.chars, risk.chars and risk.chars_us all
return zero rows for %quorum%. So the capability was worth having upstream.

PORTED, NOT VENDORED, because this skill's own Red Flags section requires it:
"Create a new standalone Go binary for EDGAR extraction -> STOP. scan_covers is
a generic profile-based framework. Add a profiles_*.go file, not a new binary."
Copying parse_quorum_go/ across would have made it the fourth standalone binary
in a skill that says not to have them.

PARITY VERIFIED, not assumed. Built both the port and mirror's standalone and
ran them over fixtures covering every confidence tier — high one-third, high
one-quarter, med majority-outstanding, default, and default-noquorum twice.
Identical threshold and confidence on all six.

(The first parity run showed the standalone dropping a filing the port kept.
That was my harness: the standalone does an unconditional scanner.Scan() to
skip a header line, and I had piped it headerless. Not a behavioural
difference.)

Design notes worth keeping:

- FullBody, not a head window. Quorum text sits in the Q&A-about-the-meeting
  section, anywhere from a few KB in to most of the way through a proxy that can
  run hundreds of KB. HeadBytes is only the form-type pre-filter here. BackFirst
  is deliberately not used — it pays off for 485 prospectuses where the target
  reliably sits in the SAI, and quorum text has no positional prior.
- The quorum column packs threshold|confidence|match_text. One full-body
  proximity scan yields three correlated outputs; three Custom fields would run
  it three times. build_panel.py splits on the first two pipes and the snippet
  is pipe-sanitised in Go.
- default and default-noquorum both return 0.50 and are NOT merged. "We read it
  and found no number" and "there was nothing to read" are different claims
  about the same value, and the dedup ranking prefers the first.

Also fixes the Existing Parsers table, which had two rows pointing into
~/projects/mirror. One of them (state_incorp_go/) was already dead.

merge_v12.py did not come across — it joins to mirror's counterfactuals panel,
which is that paper's analysis rather than general capability.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0193ue9M5okF31PoPetXXBmL
