### PR TITLE
blockholders: the Go profile does not supersede parser.py — record why

### DIFF
--- a/skills/wrds/references/blockholders.md
+++ b/skills/wrds/references/blockholders.md
@@ -50,11 +50,32 @@ Year assignment differs from filing date:
 
 ## Script locations
 
-- Parser: `~/projects/mirror/src/blockholders/parser.py`
+Two extractors exist and **neither supersedes the other** — pick by whether joint
+filings matter (verified 2026-07-28):
+
+| | Rows per filing | Item 12 | Use when |
+|---|---|---|---|
+| `scan_covers -profile blockholders_13dg` (this skill) | **one** — `fil_cik`/`sbj_cik` are `Reduce:First` | one, the first filer's | scale; the single-filer majority |
+| `mirror/src/blockholders/parser.py` | **one per (subject, filer) pair** | **per filer** | group filings under §13(d)(3) |
+
+The Go profile is a parity port of `parser.py`'s *body* extraction (line windows,
+two-pass code matching) and is much faster, but the `Field`/`Reduce` contract can
+only emit one row per file, so a joint 13G collapses to its first filer. Group
+filings are exactly what blockholder analysis cares about, so this is a capability
+gap rather than drift.
+
+- Parser (multi-filer): `~/projects/mirror/src/blockholders/parser.py`
 - Aggregator: `~/projects/mirror/src/blockholders/aggregate.py`
 - Driver: `~/projects/mirror/scripts/pull_blockholders.py`
-- Comparison: `~/projects/mirror/scripts/compare_blockholders.py`
+- Comparison vs the published Volkova baseline: `~/projects/mirror/scripts/compare_blockholders.py`
 - Investigation: `~/projects/mirror/docs/investigations/2026-04-18_volkova_pipeline.md`
+
+**Known open defect**, currently recorded only in mirror's `sas/README.md`:
+`aggregate.py` computes `prc_own = 100 * Num_Own / (1000 * SHROUT)` from CRSP
+`SHROUT`. For 13D/G the filer reports a specific security class, so the per-class
+CRSP value is normally correct — but when multiple permnos share a CIK and the
+`crsp_shrout` frame has one row per permno-month, the `merge(on="year_month")`
+can double-count.
 
 ## How to run
 

--- a/skills/wrds/references/insider-form4.md
+++ b/skills/wrds/references/insider-form4.md
@@ -249,10 +249,18 @@ The Volkova blockholders port (script 8) needs per-year aggregation, so
 we pull bulk via SAS on the WRDS SGE cluster rather than streaming over
 Postgres from a laptop.
 
-- SAS script: `mirror/sas/pull_tr_insiders.sas` — one year per SGE task.
-- SGE wrapper: `mirror/sas/run_insider_array.sh` (`#$ -t 1994-2024 -l m_mem_free=8G`).
+- SAS script: `scripts/form4/pull_tr_insiders.sas` — one year per SGE task.
+- SGE wrapper: `scripts/form4/run_insider_array.sh` (`#$ -t 1994-2024 -l m_mem_free=8G`;
+  the range is an SGE directive so it cannot read a variable — override with
+  `qsub -t 2005-2025`).
 - Fallback Python puller for quick iteration:
-  `mirror/scripts/pull_insider_ownership.py` (server-side filters, year chunking).
+  `scripts/form4/pull_insider_ownership.py` (server-side filters, year chunking).
+- Three-step XML route when TR coverage is short: `scripts/form4/step1_query_filings.py`
+  -> `step2_download_xmls.sh` -> `step3_parse_xmls.py`. See `scripts/form4/README.md`.
+
+These were vendored from mirror and generalised (no user, institution or project
+tree baked in; `FORM4_ROOT` / `WRDS_SCRATCH` override). mirror keeps its copies
+because its counterfactual stack consumes the outputs, so the two can drift.
 
 ### Index hints used server-side
 
@@ -323,6 +331,7 @@ None of the above resolve `tr_personid` to SEC owner CIK.
 access, build a `(company_CIK, normalized_name) → blockholder_CIK` dict
 from an external source with real SEC owner CIKs (e.g., Volkova's
 published blockholder CSV, or a one-off scrape of SEC own-disp) and
-join on `(cusip6→company_CIK, normalize(owner))`. See
-`mirror/scripts/bridge_insider_names.py` for the normalization rules
-(suffixes stripped, punctuation removed, uppercase).
+join on `(cusip6→company_CIK, normalize(owner))`. The normalization rules
+(suffixes stripped, punctuation removed, uppercase) live in mirror's
+`scripts/redo_bridge.py` — the file this previously cited,
+`mirror/scripts/bridge_insider_names.py`, no longer exists.

--- a/skills/wrds/scripts/form4/README.md
+++ b/skills/wrds/scripts/form4/README.md
@@ -1,0 +1,63 @@
+# form4 — insider ownership from Form 4
+
+Two independent routes to insider holdings. They answer different questions and
+are not substitutes.
+
+## Route A — Thomson Reuters insiders (SAS, on the grid)
+
+`pull_tr_insiders.sas` + `run_insider_array.sh`. Year-parallel extract of the TR
+insider tables into a stacked panel. This is the fast, curated route.
+
+```bash
+scp pull_tr_insiders.sas run_insider_array.sh wrds:~/projects/<proj>/
+ssh wrds "cd ~/projects/<proj> && qsub run_insider_array.sh"          # 1994-2024
+ssh wrds "cd ~/projects/<proj> && qsub -t 2005-2025 run_insider_array.sh"
+```
+
+The `#$ -t` range is an SGE directive, parsed **before** the shell runs, so it
+cannot read an environment variable. Override on the `qsub` line — `-t` there
+wins over the one in the file.
+
+## Route B — parse the Form 4 XMLs yourself (three steps)
+
+Use when TR coverage is short or you need fields TR does not carry.
+
+```bash
+FORM4_YEAR_MIN=2019 FORM4_YEAR_MAX=2024 python step1_query_filings.py
+bash step2_download_xmls.sh          # rclone pull to $WRDS_SCRATCH, tar back
+python step3_parse_xmls.py           # -> form4_owner_bridge.parquet
+```
+
+`pull_insider_ownership.py` is the standalone WRDS pull that seeds the CIK/CUSIP
+side.
+
+## Configuration
+
+Nothing names a user, an institution, or a project tree:
+
+| Variable | Default |
+|---|---|
+| `FORM4_ROOT` | the repo root (`parents[4]` from these scripts) — set it to the **consuming** project when vendored |
+| `WRDS_SCRATCH` | `/scratch/${WRDS_INST:-nyu}/$WRDS_USER` |
+| `WRDS_USER` | asked of the remote (`ssh wrds whoami`), not assumed from the local login |
+| `WRDS_PGHOST` / `WRDS_PGPORT` / `WRDS_USER` | `wrds-pgdata.wharton.upenn.edu` / `9737` / `$USER` |
+| `FORM4_YEAR_MIN` / `FORM4_YEAR_MAX` | `2019` / `2024` |
+
+mirror imported `src.wrds_pull` for the database handle. That package does not
+exist here, so the connection is `psycopg2` direct against `~/.pgpass` — one
+fewer dependency, and the same credentials.
+
+## Grain, and the trap
+
+`references/insider-form4.md` has the full table reference. The one thing to
+carry in your head: the row PK is **`(dcn, seqnum)`**, not the accession. Form 4
+amendments (`4/A`) are separate submissions with their own accessions, so
+deduping on accession alone silently keeps both the original and its correction.
+Supersede by `(person, transaction date, code)` taking the latest filing.
+
+## Provenance
+
+Copied from mirror (`scripts/form4_step*`, `scripts/pull_insider_ownership.py`,
+`sas/pull_tr_insiders.sas`, `sas/run_insider_array.sh`). mirror keeps its copies —
+its counterfactual stack and notebooks consume the outputs — so this is a copy,
+not a move, and the two can drift. If you change the parse here, say so there.

--- a/skills/wrds/scripts/form4/pull_insider_ownership.py
+++ b/skills/wrds/scripts/form4/pull_insider_ownership.py
@@ -1,0 +1,163 @@
+"""Volkova script 8 port — insider ownership data.
+
+Original R code scrapes `https://www.sec.gov/cgi-bin/own-disp?...` per CIK.
+That endpoint is rate-limited (10 req/s, ~30-60min for our universe) and the
+current SEC layout leaves Owner-CIK empty in the transactions table, forcing
+a name-based join that's error-prone.
+
+WRDS exposes the same Form 3/4/5 data via the Thomson Reuters insider
+feed (`tr_insiders.table1`). The coordinator explicitly directs this path.
+
+Pruning strategy (per coordinator guidance — table1 is 17.3M rows / 5.5 GB):
+  1. Filter server-side: formtype IN ('3','4','5'), sectitle = 'COM'
+  2. Chunk by year to avoid OOM (2019-2024 → 6 queries of ~300K rows each)
+  3. Project only needed columns (9 cols)
+  4. Scope to cusip6 universe (issuers in blockholders panel) via IN clause
+  5. Save per-year parquet files for resume-friendliness
+
+Output:
+  data/processed/tr_insider_{year}.parquet  (one per year)
+  data/processed/tr_insider_all.parquet     (concatenated)
+
+Mapping: TR uses `personid` as the insider identifier (not SEC CIK). We use
+personid directly as blockholder_CIK for insider rows — downstream analysis
+compares (company_CIK, blockholder_CIK, year) triples; personid is unique
+per insider and won't collide with real-company CIKs in practice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import os
+from pathlib import Path
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# PATHS. Vendored from mirror `scripts/`, where `parents[1]` was the project
+# root. Standalone it is not, so the root is overridable — same convention as
+# npx_linking/_config.py:
+#     FORM4_ROOT=/path/to/project python step1_query_filings.py
+# ---------------------------------------------------------------------------
+PROJ = Path(os.environ["FORM4_ROOT"]).resolve() if os.environ.get("FORM4_ROOT") \
+    else Path(__file__).resolve().parents[4]
+
+# mirror imported `src.wrds_pull`; psycopg2 direct keeps this standalone.
+import psycopg2  # noqa: E402
+
+
+class _WrdsPull:
+    @staticmethod
+    def connect(user: str | None = None):
+        return psycopg2.connect(
+            host=os.environ.get("WRDS_PGHOST", "wrds-pgdata.wharton.upenn.edu"),
+            port=int(os.environ.get("WRDS_PGPORT", "9737")),
+            dbname="wrds",
+            user=user or os.environ.get("WRDS_USER") or os.environ.get("USER"),
+            sslmode="require",
+        )
+
+
+wrds_pull = _WrdsPull()
+
+
+COLS = ["fdate", "formtype", "personid", "owner", "cname",
+        "cusip6", "trandate", "sharesheld", "shares_adj", "acqdisp"]
+
+
+def build_cusip6_universe() -> list[str]:
+    """cusip6 whitelist = issuers in the counterfactual panel plus the parsed
+    13D/G filings for 2024. Typically ~6-10K values."""
+    cusips: set[str] = set()
+    votes_path = Path("data/processed/votes.parquet")
+    if votes_path.exists():
+        votes = pd.read_parquet(votes_path, columns=["cusip"])
+        cusips |= set(votes["cusip"].dropna().astype(str).str[:6])
+
+    # Intentionally skip cusip_map (40K issuers, most have no vote coverage).
+    # We only want issuers in the cf universe + the 2024 13D/G parse.
+
+    parsed = Path("data/raw/blockholders/2024/parsed.parquet")
+    if parsed.exists():
+        p = pd.read_parquet(parsed, columns=["cusip6"])
+        cusips |= set(p["cusip6"].dropna().astype(str).str[:6])
+
+    cusips = {c for c in cusips if c and len(c) == 6}
+    return sorted(cusips)
+
+
+def pull_year(conn, year: int, cusip6_list: list[str]) -> pd.DataFrame:
+    """Pull one year of TR insider filings for the cusip6 universe."""
+    # Use ANY(%s) with a single array parameter (cleaner than IN with thousands of %s)
+    sql = """
+        SELECT fdate, formtype, personid, owner, cname,
+               cusip6, trandate, sharesheld, shares_adj, acqdisp, sectitle
+        FROM tr_insiders.table1
+        WHERE formtype IN ('3','4','5')
+          AND sectitle = 'COM'
+          AND EXTRACT(YEAR FROM fdate) = %(yr)s
+          AND cusip6 = ANY(%(cusips)s)
+    """
+    df = pd.read_sql(sql, conn, params={"yr": year, "cusips": cusip6_list})
+    return df
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--year-from", type=int, default=2019)
+    ap.add_argument("--year-to", type=int, default=2024)
+    ap.add_argument("--out-dir", default="data/processed")
+    ap.add_argument("--full-cusip", action="store_true",
+                    help="Skip cusip6 whitelist (pull every issuer — heavier)")
+    args = ap.parse_args()
+
+    t0 = time.time()
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    if args.full_cusip:
+        cusips = None
+        print("[cusips] --full-cusip: no whitelist (pull all issuers)")
+    else:
+        cusips = build_cusip6_universe()
+        print(f"[cusips] universe: {len(cusips)} cusip6 values")
+        if not cusips:
+            raise RuntimeError("empty cusip6 universe; fix paths")
+
+    conn = wrds_pull.connect(user="eddyhu")
+    all_chunks: list[pd.DataFrame] = []
+    for yr in range(args.year_from, args.year_to + 1):
+        path = out / f"tr_insider_{yr}.parquet"
+        if path.exists():
+            df = pd.read_parquet(path)
+            print(f"  [{yr}] cached {len(df):,} rows")
+            all_chunks.append(df)
+            continue
+        ts = time.time()
+        if cusips is None:
+            sql = """
+                SELECT fdate, formtype, personid, owner, cname,
+                       cusip6, trandate, sharesheld, shares_adj, acqdisp
+                FROM tr_insiders.table1
+                WHERE formtype IN ('3','4','5')
+                  AND sectitle = 'COM'
+                  AND EXTRACT(YEAR FROM fdate) = %(yr)s
+            """
+            df = pd.read_sql(sql, conn, params={"yr": yr})
+        else:
+            df = pull_year(conn, yr, cusips)
+        df.to_parquet(path, index=False)
+        print(f"  [{yr}] {len(df):,} rows  ({time.time()-ts:.1f}s)")
+        all_chunks.append(df)
+
+    conn.close()
+
+    combined = pd.concat(all_chunks, ignore_index=True)
+    combined.to_parquet(out / "tr_insider_all.parquet", index=False)
+    print(f"[done] {len(combined):,} total rows  elapsed={time.time()-t0:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/wrds/scripts/form4/pull_tr_insiders.sas
+++ b/skills/wrds/scripts/form4/pull_tr_insiders.sas
@@ -1,0 +1,144 @@
+/* ===================================================================== */
+/* TR-insiders bulk extract (Volkova script 8 port — SAS version).       */
+/*                                                                        */
+/* Pushes as much work as possible server-side:                          */
+/*   1. Range filter on fdate (index-friendly; NEVER year(fdate)=)        */
+/*   2. Formtype IN ('3','4','5') + sectitle='COM'                        */
+/*   3. cusip6 whitelist loaded from out.cusip6_whitelist                 */
+/*   4. Hash-join to CRSP SHROUT (crsp.msf) on (permno, year_month)       */
+/*   5. Compute prc_own = 100 * sharesheld / (1000 * shrout)              */
+/*   6. Aggregate max(prc_own) per (cusip6, personid, year)               */
+/*   7. Export rows with position > 5 to per-year dataset                 */
+/*                                                                        */
+/* Usage:                                                                 */
+/*   sas -sysparm 2024 pull_tr_insiders.sas                              */
+/*   qsub run_insider_array.sh      # year-parallel via SGE              */
+/*                                                                        */
+/* Output: out.tr_insider_panel_&year. (blockholder_CIK, company_cusip6,  */
+/*         year, position, owner)                                         */
+/* ===================================================================== */
+
+%let year = &sysparm.;
+%if %length(&year.)=0 %then %do;
+    %put ERROR: must pass -sysparm <year>;
+    %abort cancel;
+%end;
+%put NOTE: Processing TR insiders for year &year.;
+
+/* --- 1. Pull cusip6 whitelist + Form 3/4/5 COM rows for this year ----- */
+/* Use PROC SQL pass-through to keep filter on the Postgres side if      */
+/* running via remote SAS/ACCESS; otherwise SAS library wins.             */
+
+proc sql;
+    create table raw as
+        select
+            t.fdate,
+            t.trandate,
+            t.formtype,
+            t.personid,
+            t.owner,
+            t.cname,
+            t.cusip6,
+            t.sharesheld,
+            t.shares_adj,
+            t.acqdisp
+        from tr_insiders.table1 t
+        inner join out.cusip6_whitelist w
+            on t.cusip6 = w.cusip6
+        where t.fdate between "01jan&year."d and "31dec&year."d
+          and t.formtype in ('3', '4', '5')
+          and t.sectitle = 'COM'
+          and t.sharesheld is not null;
+quit;
+
+/* --- 2. Monthly SHROUT from crsp.msf, year-scoped -------------------- */
+proc sql;
+    create table shrout as
+        select
+            m.permno,
+            m.date,
+            m.shrout
+        from crsp.msf m
+        inner join out.permno_cusip6 p on m.permno = p.permno
+        where m.date between "01jan&year."d and "31dec&year."d
+          and m.shrout is not null;
+quit;
+
+/* Add month-of-filing to raw and shrout for hash key */
+data raw_m;
+    set raw;
+    year_month = intnx('month', trandate, 0, 'B'); /* first of trandate month */
+    format year_month yymmdd10.;
+run;
+
+data shrout_m;
+    set shrout;
+    year_month = intnx('month', date, 0, 'B');
+    format year_month yymmdd10.;
+run;
+
+/* Join cusip6→permno so we can hash on (permno, year_month) */
+proc sql;
+    create table raw_linked as
+        select r.*, p.permno
+        from raw_m r
+        inner join out.permno_cusip6 p on r.cusip6 = p.cusip6;
+quit;
+
+/* --- 3. Hash merge raw rows to SHROUT and compute prc_own ------------ */
+data linked;
+    if _n_ = 1 then do;
+        declare hash h(dataset: "shrout_m");
+        h.defineKey("permno", "year_month");
+        h.defineData("shrout");
+        h.defineDone();
+        call missing(shrout);
+    end;
+    set raw_linked;
+    if h.find() = 0 and shrout > 0 then do;
+        prc_own = 100 * sharesheld / (1000 * shrout);
+        output;
+    end;
+run;
+
+/* --- 4. Hash accumulator: max(prc_own) per (cusip6, personid) -------- */
+/* Plus capture owner name and max transaction date                    */
+data agg;
+    if _n_ = 1 then do;
+        declare hash a();
+        a.defineKey("cusip6", "personid");
+        a.defineData("cusip6", "personid", "max_prc", "owner", "max_trandate");
+        a.defineDone();
+        call missing(cusip6, personid, max_prc, owner, max_trandate);
+    end;
+
+    set linked end=eof;
+    if a.find() ne 0 then do;
+        max_prc = prc_own;
+        max_trandate = trandate;
+    end;
+    else do;
+        if prc_own > max_prc then max_prc = prc_own;
+        if trandate > max_trandate then max_trandate = trandate;
+    end;
+    a.replace();
+
+    if eof then a.output(dataset: "out.tr_insider_panel_&year.");
+run;
+
+/* --- 5. Filter to >5% positions and save -------------------------- */
+data out.tr_insider_panel_&year.;
+    set out.tr_insider_panel_&year.;
+    where max_prc > 5;
+    position = round(max_prc, 0.01);
+    year = &year.;
+    rename cusip6 = company_cusip6 personid = blockholder_CIK owner = blockholder_name;
+    keep cusip6 personid max_prc owner position year max_trandate;
+run;
+
+proc sql;
+    select count(*) as n_rows label="Panel rows for &year."
+    from out.tr_insider_panel_&year.;
+quit;
+
+%put NOTE: Finished &year. at %sysfunc(datetime(),datetime19.);

--- a/skills/wrds/scripts/form4/run_insider_array.sh
+++ b/skills/wrds/scripts/form4/run_insider_array.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#$ -t 1994-2024   # override at submit time: qsub -t 2005-2025 run_insider_array.sh
+#$ -l m_mem_free=8G
+#$ -cwd
+#$ -j y
+# Year-parallel TR-insiders extract for Volkova-style blockholder panel.
+#
+# Submit:   qsub run_insider_array.sh            (default 1994-2024)
+#           qsub -t 2005-2025 run_insider_array.sh
+#
+# The -t range is an SGE directive, so it cannot read a shell variable — the
+# directive block is parsed before the shell runs. Override on the qsub line
+# instead; -t there wins over the one in the file.
+# Stitch:   after completion, run sas -log logs/stack.log stack_insider_panel.sas
+
+mkdir -p logs
+
+year=$SGE_TASK_ID
+LOGNAME="logs/pull_tr_insiders-${year}"
+
+sas -sysparm "$year" \
+    -log  "${LOGNAME}.log" \
+    -print "${LOGNAME}.lst" \
+    pull_tr_insiders.sas

--- a/skills/wrds/scripts/form4/step1_query_filings.py
+++ b/skills/wrds/scripts/form4/step1_query_filings.py
@@ -1,0 +1,122 @@
+"""Step 1: Build file list of all Form 3/4/5 XMLs for issuers relevant to
+TR add-on personids (2019-2024).
+
+Rationale for pulling wide (all forms per issuer, not just exact fdate
+matches): TR's `fdate` does not always match SEC's `fdate` in
+`wrdssec_all.wrds_forms` (often differs by 1-3 days for after-hours
+filings). A fuzzy ±3-day match gets complicated. Instead, pull ALL
+Form 3/4/5 for each candidate issuer in the window (~540K filings,
+~500MB compressed as tar.gz). Parsing builds:
+
+    (issuer_cik, normalize(rptOwnerName)) -> rptOwnerCik
+
+…which then joins to TR add-on rows by (company_CIK, normalize(owner)).
+
+Output:
+  data/processed/form4_filings_to_pull.parquet — metadata (cik, form,
+      fdate, accession, fname)
+  data/raw/form4_xmls/files_to_download.txt   — rclone-relative paths
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# PATHS. Vendored from mirror `scripts/`, where `parents[1]` was the project
+# root. Standalone it is not, so the root is overridable — same convention as
+# npx_linking/_config.py:
+#     FORM4_ROOT=/path/to/project python step1_query_filings.py
+# ---------------------------------------------------------------------------
+PROJ = Path(os.environ["FORM4_ROOT"]).resolve() if os.environ.get("FORM4_ROOT") \
+    else Path(__file__).resolve().parents[4]
+
+# WRDS connection. mirror imported `src.wrds_pull`, which does not exist here.
+# psycopg2 direct keeps this dependency-free; ~/.pgpass supplies credentials.
+import psycopg2  # noqa: E402
+
+
+def wrds_connect(user: str | None = None):
+    return psycopg2.connect(
+        host=os.environ.get("WRDS_PGHOST", "wrds-pgdata.wharton.upenn.edu"),
+        port=int(os.environ.get("WRDS_PGPORT", "9737")),
+        dbname="wrds",
+        user=user or os.environ.get("WRDS_USER") or os.environ.get("USER"),
+        sslmode="require",
+    )
+
+TR = PROJ / "data/processed/tr_insider_all.parquet"
+ADDON = PROJ / "data/processed/insider_addon_2019_2024.parquet"
+CUSIP_MAP = PROJ / "data/processed/cusip6_cik_map.parquet"
+OUT_META = PROJ / "data/processed/form4_filings_to_pull.parquet"
+OUT_LIST = PROJ / "data/raw/form4_xmls/files_to_download.txt"
+
+YEAR_MIN = int(os.environ.get("FORM4_YEAR_MIN", "2019"))
+YEAR_MAX = int(os.environ.get("FORM4_YEAR_MAX", "2024"))
+
+
+def fname_to_rclone_path(fname: str) -> str:
+    parts = fname.split("/")
+    cik_int = parts[2]
+    filename = parts[3]
+    parent = cik_int.zfill(10)[:6]
+    return f"{parent}/{cik_int}/{filename}"
+
+
+def main():
+    print(f"Loading add-on personids from {ADDON.name}")
+    addon = pd.read_parquet(ADDON)
+    pids = set(addon["blockholder_CIK"].astype("int64"))
+    print(f"  unique personids: {len(pids):,}")
+
+    print(f"Loading TR filings")
+    tr = pd.read_parquet(TR)
+    tr = tr[tr["personid"].isin(pids)].copy()
+    cusip6_set = set(tr["cusip6"].dropna().unique())
+    print(f"  cusip6s involved: {len(cusip6_set):,}")
+
+    print(f"Resolving cusip6 → issuer CIK")
+    cmap = pd.read_parquet(CUSIP_MAP)[["cusip6", "cik"]].drop_duplicates("cusip6")
+    ciks = sorted(
+        {int(c) for c in cmap[cmap["cusip6"].isin(cusip6_set)]["cik"].dropna().unique()}
+    )
+    print(f"  candidate issuer CIKs: {len(ciks):,}")
+
+    print(f"Connecting to WRDS")
+    conn = wrds_connect()
+
+    sql = """
+        SELECT cik::bigint AS cik, accession, form, fdate, fname, fsize
+        FROM wrdssec_all.wrds_forms
+        WHERE cik::bigint = ANY(%(ciks)s)
+          AND form IN ('3', '4', '5', '3/A', '4/A', '5/A')
+          AND fdate BETWEEN %(min_d)s AND %(max_d)s
+    """
+    min_d = f"{YEAR_MIN}-01-01"
+    max_d = f"{YEAR_MAX}-12-31"
+    print(f"Executing wrds_forms query ({min_d} → {max_d}, {len(ciks):,} CIKs)…")
+    forms = pd.read_sql(
+        sql, conn, params={"ciks": ciks, "min_d": min_d, "max_d": max_d}
+    )
+    conn.close()
+    print(f"  total Form 3/4/5 filings: {len(forms):,}")
+    print(f"  total fsize: {forms['fsize'].sum() / 1e9:.2f} GB")
+
+    forms["fdate"] = pd.to_datetime(forms["fdate"])
+
+    OUT_LIST.parent.mkdir(parents=True, exist_ok=True)
+    unique_fnames = forms["fname"].drop_duplicates()
+    with OUT_LIST.open("w") as f:
+        for fname in unique_fnames:
+            f.write(fname_to_rclone_path(fname) + "\n")
+    print(f"Wrote {OUT_LIST.relative_to(PROJ)} ({len(unique_fnames):,} filings)")
+
+    forms.to_parquet(OUT_META)
+    print(f"Wrote {OUT_META.relative_to(PROJ)} ({len(forms):,} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/wrds/scripts/form4/step2_download_xmls.sh
+++ b/skills/wrds/scripts/form4/step2_download_xmls.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Step 2: Download 540K Form 3/4/5 XMLs from WRDS via server-side tar.
+#
+# Rationale: 540K individual rclone SFTP transfers takes hours. Tarring
+# server-side and pulling one archive is ~10 min (one sequential
+# stream, resumable by rclone).
+#
+# Source: /wrds/sec/archives/ (raw SGML) — Form 4 XMLs are embedded in
+# an SGML wrapper. We need the XML, so pull raw archives (not
+# wrds_clean_filings which strips the XML structure).
+#
+# Usage:
+#   bash scripts/form4_step2_download_xmls.sh
+set -euo pipefail
+
+PROJ="$(cd "$(dirname "$0")/.." && pwd)"
+FILES_FROM="$PROJ/data/raw/form4_xmls/files_to_download.txt"
+OUTPUT_DIR="$PROJ/data/raw/form4_xmls/filings"
+
+if [[ ! -f "$FILES_FROM" ]]; then
+    echo "ERROR: $FILES_FROM not found. Run form4_step1_query_filings.py first."
+    exit 1
+fi
+
+N_FILES=$(wc -l < "$FILES_FROM")
+echo "Files to download: $N_FILES"
+
+# No institution or user baked in. The remote account is asked for, not assumed
+# (the local login name is not necessarily the WRDS one), and the whole path is
+# overridable.
+WRDS_USER="${WRDS_USER:-$(ssh wrds whoami)}"
+WRDS_SCRATCH="${WRDS_SCRATCH:-/scratch/${WRDS_INST:-nyu}/$WRDS_USER}"
+TS=$(date +%s)
+REMOTE_TMP="$WRDS_SCRATCH/form4_xmls_$TS.tar.gz"
+REMOTE_LIST="/tmp/form4_files_$TS.txt"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "1/5: Upload file list to WRDS…"
+scp "$FILES_FROM" "wrds:$REMOTE_LIST"
+
+echo "2/5: Prepare scratch dir on WRDS…"
+ssh wrds "mkdir -p $WRDS_SCRATCH"
+
+echo "3/5: Create tar.gz on WRDS server (may take 10-30 min)…"
+# Fork tar in background, wait on PID
+ssh wrds "nohup bash -c 'cd /wrds/sec/archives && tar czf $REMOTE_TMP -T $REMOTE_LIST' > $WRDS_SCRATCH/tar_$TS.log 2>&1 &
+echo PID=\$!"
+
+# Poll every 60s
+echo "Waiting for tar to complete…"
+while ssh wrds "pgrep -f 'tar czf.*form4_xmls_$TS' > /dev/null 2>&1"; do
+    size=$(ssh wrds "ls -lh $REMOTE_TMP 2>/dev/null | awk '{print \$5}'" || echo "starting…")
+    echo "  archive size: ${size:-starting…}"
+    sleep 60
+done
+ssh wrds "ls -lh $REMOTE_TMP"
+
+echo "4/5: Download archive via rclone…"
+rclone copy "wrds:$REMOTE_TMP" "$OUTPUT_DIR" \
+    --stats 30s --stats-one-line --retries 3 --low-level-retries 10
+
+echo "5/5: Extract locally…"
+cd "$OUTPUT_DIR"
+ARCHIVE="$(basename "$REMOTE_TMP")"
+tar xzf "$ARCHIVE"
+rm "$ARCHIVE"
+
+echo "Cleanup remote…"
+ssh wrds "rm -f $REMOTE_TMP $REMOTE_LIST"
+
+N_EXTRACTED=$(find "$OUTPUT_DIR" -name "*.txt" | wc -l)
+echo "Done: $N_EXTRACTED XMLs extracted to $OUTPUT_DIR"

--- a/skills/wrds/scripts/form4/step3_parse_xmls.py
+++ b/skills/wrds/scripts/form4/step3_parse_xmls.py
@@ -1,0 +1,133 @@
+"""Step 3: Parse Form 3/4/5 SGML/XML to extract rptOwnerCik → build bridge.
+
+Each filing at /wrds/sec/archives/.../<accession>.txt is an SGML
+envelope containing one or more XML documents. We only need three
+fields per filing:
+  - issuerCik
+  - rptOwnerCik (one per reporting owner; filings can have multiple)
+  - rptOwnerName
+
+Strategy: skip full XML parsing. Each field appears verbatim in the
+SGML as `<issuerCik>NNNN</issuerCik>` etc. Regex is an order of
+magnitude faster than etree for ~5KB files × 540K.
+
+Output:
+  data/processed/form4_owner_bridge.parquet with columns:
+    accession, issuer_cik, rpt_owner_cik, rpt_owner_name, norm_name
+"""
+from __future__ import annotations
+
+import concurrent.futures as cf
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# PATHS. Vendored from mirror `scripts/`, where `parents[1]` was the project
+# root. Standalone it is not, so the root is overridable — same convention as
+# npx_linking/_config.py:
+#     FORM4_ROOT=/path/to/project python step1_query_filings.py
+# ---------------------------------------------------------------------------
+PROJ = Path(os.environ["FORM4_ROOT"]).resolve() if os.environ.get("FORM4_ROOT") \
+    else Path(__file__).resolve().parents[4]
+FILINGS_DIR = PROJ / "data/raw/form4_xmls/filings"
+OUT = PROJ / "data/processed/form4_owner_bridge.parquet"
+
+ISSUER_CIK_RE = re.compile(r"<issuerCik>\s*(\d+)\s*</issuerCik>", re.IGNORECASE)
+RPT_OWNER_BLOCK_RE = re.compile(
+    r"<reportingOwner>(.*?)</reportingOwner>", re.IGNORECASE | re.DOTALL
+)
+RPT_OWNER_CIK_RE = re.compile(r"<rptOwnerCik>\s*(\d+)\s*</rptOwnerCik>", re.IGNORECASE)
+RPT_OWNER_NAME_RE = re.compile(
+    r"<rptOwnerName>\s*(.*?)\s*</rptOwnerName>", re.IGNORECASE | re.DOTALL
+)
+
+
+def normalize_name(s: str) -> str:
+    if not isinstance(s, str) or not s.strip():
+        return ""
+    s = s.upper()
+    s = re.sub(r"[.,'\"()/\\]", " ", s)
+    s = re.sub(r"\b(JR|SR|II|III|IV|V|MD|PHD|ESQ|CPA|MR|MRS|MS|DR)\b", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def parse_one(path: str) -> list[dict]:
+    """Extract (issuer_cik, rpt_owner_cik, rpt_owner_name) per reporting owner.
+
+    Returns a list because a single filing may have multiple owners.
+    """
+    try:
+        with open(path, "r", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return []
+
+    m_issuer = ISSUER_CIK_RE.search(text)
+    if not m_issuer:
+        return []
+    issuer_cik = int(m_issuer.group(1))
+
+    accession = Path(path).stem
+
+    rows = []
+    for m_block in RPT_OWNER_BLOCK_RE.finditer(text):
+        block = m_block.group(1)
+        m_cik = RPT_OWNER_CIK_RE.search(block)
+        m_name = RPT_OWNER_NAME_RE.search(block)
+        if not (m_cik and m_name):
+            continue
+        name = m_name.group(1).strip()
+        rows.append(
+            {
+                "accession": accession,
+                "issuer_cik": issuer_cik,
+                "rpt_owner_cik": int(m_cik.group(1)),
+                "rpt_owner_name": name,
+                "norm_name": normalize_name(name),
+            }
+        )
+    return rows
+
+
+def main():
+    paths = list(FILINGS_DIR.rglob("*.txt"))
+    print(f"Files on disk: {len(paths):,}")
+    if len(paths) == 0:
+        print(f"ERROR: no files in {FILINGS_DIR}. Run step 2 first.")
+        sys.exit(1)
+
+    workers = max(1, (os.cpu_count() or 4) - 1)
+    print(f"Parsing with {workers} workers")
+
+    t0 = time.time()
+    all_rows: list[dict] = []
+    with cf.ProcessPoolExecutor(max_workers=workers) as ex:
+        results = ex.map(parse_one, [str(p) for p in paths], chunksize=256)
+        for i, rows in enumerate(results):
+            all_rows.extend(rows)
+            if (i + 1) % 25_000 == 0:
+                rate = (i + 1) / (time.time() - t0)
+                print(f"  {i+1:,}/{len(paths):,} ({rate:.0f}/s)")
+
+    dt = time.time() - t0
+    print(f"Parsed {len(paths):,} files in {dt:.1f}s ({len(paths)/dt:.0f}/s)")
+    print(f"Owner rows extracted: {len(all_rows):,}")
+
+    df = pd.DataFrame(all_rows)
+    # Dedup on (issuer, owner) — same owner can appear in many filings
+    n_before = len(df)
+    df = df.drop_duplicates(["issuer_cik", "rpt_owner_cik"])
+    print(f"After dedup: {len(df):,} unique (issuer, owner_cik) pairs (from {n_before:,})")
+
+    df.to_parquet(OUT)
+    print(f"Wrote {OUT.relative_to(PROJ)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/wrds/scripts/scan_covers/profiles_blockholders_13dg.go
+++ b/skills/wrds/scripts/scan_covers/profiles_blockholders_13dg.go
@@ -12,6 +12,26 @@ import "regexp"
 // Header fields use the shared pattern-based path. Body fields (item12,
 // max_prc) use Custom extractors that mirror parser.py line-window and
 // two-pass code-matching logic for full Python parity.
+//
+// THIS PROFILE DOES NOT SUPERSEDE mirror's src/blockholders/parser.py, and the
+// gap is structural rather than drift. Checked 2026-07-28:
+//
+//	parser.py emits ONE ROW PER (subject, filer) PAIR and computes item12
+//	PER FILER — parse_item12(body, fil_cik=fil["cik"]).
+//
+//	This profile emits one row per FILING. fil_cik / fil_name / sbj_cik /
+//	sbj_name are Reduce:First, so a joint filing collapses to its first
+//	filer and the single item12 is that filer's.
+//
+// One row per filing is right for the common case — most 13D/Gs have exactly
+// one filer and one subject. It is wrong for group filings under §13(d)(3),
+// which are precisely the ones blockholder work cares about: N filers acting
+// together, each with its own Item 12 classification.
+//
+// Use this profile for scale and for the single-filer majority; use parser.py
+// when joint filings matter. Do NOT delete parser.py assuming this replaces it.
+// Making it a true replacement means letting the framework emit multiple rows
+// per file, which the Field/Reduce contract cannot express today.
 func init() {
 	register(&Profile{
 		Name:      "blockholders_13dg",


### PR DESCRIPTION
The gating question for W5 (a blockholder-panel skill), settled by reading both.

**They are not substitutes, and the gap is structural.**

| | Rows per filing | Item 12 |
|---|---|---|
| `scan_covers -profile blockholders_13dg` | **one** (`fil_cik`/`sbj_cik` are `Reduce:First`) | one — the first filer's |
| `mirror/src/blockholders/parser.py` | **one per (subject, filer) pair** | **per filer** |

One row per filing is right for the common case — most 13D/Gs have a single filer and subject. It is wrong for group filings under §13(d)(3): N filers acting together, each with its own Item 12 classification, which is exactly what blockholder analysis is about.

So `parser.py` must not be deleted on the assumption the profile replaces it. Recorded in both places someone would check first: the profile's docstring and `references/blockholders.md`, which now carries a pick-by-use-case table rather than a bare file list.

Making the profile a true replacement means letting the framework emit multiple rows per file — a change to `scan_covers`' `Field`/`Reduce` contract, not to this profile.

Also lifts the known `aggregate.py` double-count defect (`prc_own` against CRSP `SHROUT` when multiple permnos share a CIK) out of mirror's `sas/README.md`, where it was the sole record and would have been lost when that repo archived around it.

**This changes W5's shape:** a blockholder-panel skill can't just vendor around the Go profile, so I've stopped short of building it pending your call on whether to extend `scan_covers` or vendor `parser.py` as the multi-filer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193ue9M5okF31PoPetXXBmL