### PR TITLE
scan_covers: opt-in multi-row emit, and use it to fix blockholder joint filings

### DIFF
--- a/skills/wrds/references/blockholders.md
+++ b/skills/wrds/references/blockholders.md
@@ -50,19 +50,25 @@ Year assignment differs from filing date:
 
 ## Script locations
 
-Two extractors exist and **neither supersedes the other** — pick by whether joint
-filings matter (verified 2026-07-28):
+**The multi-filer gap is closed.** `scan_covers -profile blockholders_13dg` now
+emits **one row per (subject, filer) pair**, matching `parser.py`, via the opt-in
+`Profile.Expand` hook added for exactly this (see `expand_blockholders.go`).
 
-| | Rows per filing | Item 12 | Use when |
-|---|---|---|---|
-| `scan_covers -profile blockholders_13dg` (this skill) | **one** — `fil_cik`/`sbj_cik` are `Reduce:First` | one, the first filer's | scale; the single-filer majority |
-| `mirror/src/blockholders/parser.py` | **one per (subject, filer) pair** | **per filer** | group filings under §13(d)(3) |
+It had emitted one row per *filing* with `fil_cik`/`sbj_cik` on `Reduce:First`, so
+a joint filing under §13(d)(3) — N filers acting as a group, each with its own
+Item 12 — collapsed to whichever filer came first. That is the case blockholder
+work is most interested in.
 
-The Go profile is a parity port of `parser.py`'s *body* extraction (line windows,
-two-pass code matching) and is much faster, but the `Field`/`Reduce` contract can
-only emit one row per file, so a joint 13G collapses to its first filer. Group
-filings are exactly what blockholder analysis cares about, so this is a capability
-gap rather than drift.
+Two properties worth knowing:
+
+- **No-op on the common case.** A filing naming one filer and one subject returns
+  the row untouched, so output for the overwhelming majority is byte-identical to
+  before. Verified against the pre-change binary.
+- **Opt-in for everything else.** `Expand` is nil on all five other profiles, so
+  none of them changed. Also verified.
+
+`parser.py` remains the reference implementation and the parity target; the Go
+profile is the one to run at scale.
 
 - Parser (multi-filer): `~/projects/mirror/src/blockholders/parser.py`
 - Aggregator: `~/projects/mirror/src/blockholders/aggregate.py`

--- a/skills/wrds/scripts/scan_covers/expand_blockholders.go
+++ b/skills/wrds/scripts/scan_covers/expand_blockholders.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Multi-filer expansion for blockholders_13dg.
+//
+// Fields/Reduce can carry one value per column per file, so a joint SC 13D/G
+// collapsed to whichever filer `Reduce:First` happened to pick. That is wrong
+// precisely where blockholder work is most interesting: a group filing under
+// §13(d)(3) has N filers acting together, each with its OWN Item 12
+// classification. mirror's src/blockholders/parser.py emits one row per
+// (subject, filer) pair for that reason.
+//
+// This closes the gap without changing what any other profile does — Expand is
+// opt-in and only this profile sets it.
+//
+// NO-OP ON THE COMMON CASE, BY CONSTRUCTION. Most 13D/Gs name exactly one
+// filer and one subject; for those this returns `base` untouched, so output is
+// byte-identical to before the hook existed. Only genuinely joint filings
+// produce extra rows.
+
+var (
+	// Every column-0 SGML role label. Blocks are sliced BETWEEN these positions
+	// rather than matched with a terminator pattern.
+	//
+	// A `FILED BY:(.*?)(?:\n[A-Z...]:\s*\n|\z)` block regex looks right and is
+	// wrong: FindAll resumes at the END of each match, and the match CONSUMES
+	// the next label as its terminator — so on three consecutive FILED BY
+	// blocks it returns the 1st and the 3rd and silently drops the 2nd. Go's
+	// RE2 has no lookahead to hold the delimiter back, so don't try; find the
+	// label offsets and slice.
+	reRoleLabel = regexp.MustCompile(`(?m)^[A-Z][A-Z0-9 /-]*:`)
+	reBlockCIK  = regexp.MustCompile(`CENTRAL INDEX KEY:[ \t]+([0-9]+)`)
+	reBlockName = regexp.MustCompile(`COMPANY CONFORMED NAME:[ \t]+([^\r\n]+)`)
+)
+
+type entity struct{ cik, name string }
+
+// entitiesOf pulls every (cik, name) under the given column-0 role label.
+func entitiesOf(buf []byte, label string) []entity {
+	locs := reRoleLabel.FindAllIndex(buf, -1)
+	var out []entity
+	seen := map[string]bool{}
+	for i, loc := range locs {
+		if string(buf[loc[0]:loc[1]]) != label {
+			continue
+		}
+		end := len(buf)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		body := buf[loc[1]:end]
+
+		c := reBlockCIK.FindSubmatch(body)
+		if c == nil {
+			continue
+		}
+		cik := string(c[1])
+		if seen[cik] {
+			// A filing can name the same CIK twice (a filer that is also the
+			// subject, or a repeated block). Dedupe, or the cartesian product
+			// below squares it.
+			continue
+		}
+		seen[cik] = true
+		name := ""
+		if nm := reBlockName.FindSubmatch(body); nm != nil {
+			name = strings.TrimSpace(string(nm[1]))
+		}
+		out = append(out, entity{cik: cik, name: name})
+	}
+	return out
+}
+
+// Column positions in the blockholders_13dg Fields slice. `base` excludes the
+// leading filepath, which main writes separately.
+const (
+	bhFilCIK  = 3
+	bhFilName = 4
+	bhSbjCIK  = 5
+	bhSbjName = 6
+	bhItem12  = 7
+)
+
+func expandBlockholders(buf []byte, base []string) [][]string {
+	filers := entitiesOf(buf, "FILED BY:")
+	subjects := entitiesOf(buf, "SUBJECT COMPANY:")
+
+	// Single filer AND single subject (or nothing parsed) — the overwhelming
+	// majority. Return base untouched so output is exactly what it was.
+	if len(filers) <= 1 && len(subjects) <= 1 {
+		return [][]string{base}
+	}
+	if len(filers) == 0 {
+		filers = []entity{{cik: base[bhFilCIK], name: base[bhFilName]}}
+	}
+	if len(subjects) == 0 {
+		subjects = []entity{{cik: base[bhSbjCIK], name: base[bhSbjName]}}
+	}
+
+	// Item 12 read once from the body; the only per-filer part is the Fidelity
+	// override, which keys on the filer's own CIK. Matches parser.py, where
+	// parse_item12(body, fil_cik=...) differs across filers in exactly that way.
+	bodyItem12 := base[bhItem12]
+
+	rows := make([][]string, 0, len(filers)*len(subjects))
+	for _, f := range filers {
+		item12 := bodyItem12
+		if f.cik == "315066" { // Fidelity — filings are formatted differently
+			item12 = "hc|in"
+		}
+		for _, s := range subjects {
+			// COPY. Handing the same backing array to several rows would let
+			// the last write win on all of them.
+			r := make([]string, len(base))
+			copy(r, base)
+			r[bhFilCIK], r[bhFilName] = f.cik, f.name
+			r[bhSbjCIK], r[bhSbjName] = s.cik, s.name
+			r[bhItem12] = item12
+			rows = append(rows, r)
+		}
+	}
+	return rows
+}

--- a/skills/wrds/scripts/scan_covers/main.go
+++ b/skills/wrds/scripts/scan_covers/main.go
@@ -123,7 +123,7 @@ func formAllowed(form string, allowed []string) bool {
 	return false
 }
 
-func processFile(path string, prof *Profile) []string {
+func processFile(path string, prof *Profile) [][]string {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil
@@ -169,7 +169,7 @@ func processFile(path string, prof *Profile) []string {
 			// Small file — straight FullBody read.
 			rest, _ := io.ReadAll(f)
 			buf = append(buf, rest...)
-			return extract(buf, prof.Fields)
+			return expand(prof, buf, extract(buf, prof.Fields))
 		}
 		// Read the back half.
 		if _, err := f.Seek(backOff, 0); err != nil {
@@ -182,22 +182,22 @@ func processFile(path string, prof *Profile) []string {
 		backBuf = append(backBuf, back...)
 		result := extract(backBuf, prof.Fields)
 		if hasAnyHit(result, prof.Fields) {
-			return result
+			return expand(prof, backBuf, result)
 		}
 		// Miss — read the gap between head and backOff.
 		if _, err := f.Seek(int64(headLen), 0); err != nil {
-			return result // best-effort; return back-only result if seek fails
+			return expand(prof, backBuf, result) // best-effort; back-only if seek fails
 		}
 		gapLen := backOff - int64(headLen)
 		gap := make([]byte, gapLen)
 		if _, err := io.ReadFull(f, gap); err != nil {
-			return result
+			return expand(prof, backBuf, result)
 		}
 		full := make([]byte, 0, headLen+int(gapLen)+len(back))
 		full = append(full, buf...)
 		full = append(full, gap...)
 		full = append(full, back...)
-		return extract(full, prof.Fields)
+		return expand(prof, full, extract(full, prof.Fields))
 	}
 
 	// FullBody mode: append the rest of the file. Header pre-filter has
@@ -208,7 +208,7 @@ func processFile(path string, prof *Profile) []string {
 		if err == nil && len(rest) > 0 {
 			buf = append(buf, rest...)
 		}
-		return extract(buf, prof.Fields)
+		return expand(prof, buf, extract(buf, prof.Fields))
 	}
 
 	// Head-only mode: truncate at last newline if buffer filled (avoid
@@ -219,7 +219,7 @@ func processFile(path string, prof *Profile) []string {
 		}
 	}
 
-	return extract(buf, prof.Fields)
+	return expand(prof, buf, extract(buf, prof.Fields))
 }
 
 func readFilelist(path string) ([]string, error) {
@@ -307,8 +307,8 @@ func main() {
 				if root != "" && !strings.HasPrefix(p, "/") {
 					full = strings.TrimRight(root, "/") + "/" + p
 				}
-				vals := processFile(full, prof)
-				if vals != nil {
+				rows := processFile(full, prof)
+				for _, vals := range rows {
 					results <- outRow{path: p, vals: vals}
 				}
 			}

--- a/skills/wrds/scripts/scan_covers/profile.go
+++ b/skills/wrds/scripts/scan_covers/profile.go
@@ -70,6 +70,42 @@ type Profile struct {
 	BackMinFileSize int64   // files smaller than this skip BackFirst (default 200 KB)
 	Forms           []string
 	Fields          []Field // determines output TSV column order
+
+	// Expand turns the one extracted row into N rows. OPT-IN: leave it nil and
+	// the profile emits exactly one row per file — what every profile did
+	// before this existed, and what all of them still do today.
+	//
+	// WHY IT EXISTS. Fields/Reduce can describe only ONE value per column per
+	// file, so a filing naming several entities collapses to whichever one the
+	// Reduce picked. For SC 13D/G that is wrong in a way that matters: a joint
+	// filing under §13(d)(3) has N filers acting as a group, each with its own
+	// Item 12 classification, and Reduce:First keeps only the first. mirror's
+	// src/blockholders/parser.py emits one row per (subject, filer) pair for
+	// exactly that reason, which is why the Go port did not supersede it.
+	//
+	// CONTRACT:
+	//   - `base` is the row Fields produced. TREAT IT AS READ-ONLY and copy
+	//     before mutating — hand the same slice back twice and both "rows"
+	//     share one backing array, so the last write wins on every one of them.
+	//   - nil or empty return emits nothing; a one-row return is identical to
+	//     not setting Expand.
+	//   - every returned row must have len(Fields) columns, or the TSV
+	//     desynchronises against the header `-list` advertises.
+	//   - `buf` is the same buffer Fields saw, so Expand can re-scan for the
+	//     per-entity detail the flattened row could not carry.
+	Expand func(buf []byte, base []string) [][]string
+}
+
+// expand applies the profile's opt-in row multiplier. A nil Expand — the case
+// for every profile that has not asked for this — is the identity.
+func expand(p *Profile, buf []byte, row []string) [][]string {
+	if row == nil {
+		return nil
+	}
+	if p.Expand == nil {
+		return [][]string{row}
+	}
+	return p.Expand(buf, row)
 }
 
 // registry holds all compiled profiles; populated via init() calls in

--- a/skills/wrds/scripts/scan_covers/profiles_blockholders_13dg.go
+++ b/skills/wrds/scripts/scan_covers/profiles_blockholders_13dg.go
@@ -28,10 +28,12 @@ import "regexp"
 // which are precisely the ones blockholder work cares about: N filers acting
 // together, each with its own Item 12 classification.
 //
-// Use this profile for scale and for the single-filer majority; use parser.py
-// when joint filings matter. Do NOT delete parser.py assuming this replaces it.
-// Making it a true replacement means letting the framework emit multiple rows
-// per file, which the Field/Reduce contract cannot express today.
+// RESOLVED. The framework now has an opt-in Expand hook (profile.go) and this
+// profile sets it: expandBlockholders emits one row per (subject, filer) pair,
+// with the Fidelity Item 12 override applied per filer, matching parser.py.
+//
+// The expansion is a NO-OP when a filing names one filer and one subject — the
+// overwhelming majority — so output for those is byte-identical to before.
 func init() {
 	register(&Profile{
 		Name:      "blockholders_13dg",
@@ -60,5 +62,7 @@ func init() {
 			// cusip6: pattern-based, first 6 of any 9-char CUSIP token.
 			{Name: "cusip6", Pattern: regexp.MustCompile(`(?i)CUSIP\s*(?:NO\.?|NUMBER)?[^\w]*([0-9A-Z]{6})[0-9A-Z]{3}?`), Reduce: First},
 		},
+		// One row per (subject, filer) pair — see expand_blockholders.go.
+		Expand: expandBlockholders,
 	})
 }


### PR DESCRIPTION
scan_covers: opt-in multi-row emit, and use it to fix blockholder joint filings

Closes the gap recorded in #124. blockholders_13dg emitted one row per FILING
with fil_cik/sbj_cik on Reduce:First, so a joint filing under 13(d)(3) — N
filers acting as a group, each with its own Item 12 classification — collapsed
to whichever filer came first. That is precisely the case blockholder analysis
exists to study, and it is why mirror's parser.py (one row per (subject, filer)
pair) was not superseded by the Go port.

THE FRAMEWORK CHANGE IS OPT-IN. Profile gains an `Expand func(buf, base)
[][]string`. Nil — the state of all five other profiles — is the identity, so
nothing else changed. processFile returns [][]string and the writer iterates;
that is internal.

Verified rather than asserted:
  - quorum profile, before vs after the whole change: byte-identical.
  - single-filer blockholder row, before vs after: byte-identical.
  - joint 3-filer fixture: 3 rows, one per filer, correct CIK and name on each.
  - single-filer fixture: still exactly 1 row.
expandBlockholders returns `base` untouched when a filing names one filer and
one subject, so the no-op on the common case is by construction, not by luck.

THE BUG THIS ALMOST SHIPPED WITH, since it is a trap worth naming: the obvious
block regex

    FILED BY:(.*?)(?:\n[A-Z][A-Z0-9 /-]*:\s*\n|\z)

is wrong. FindAll resumes at the END of each match and the match CONSUMES the
next label as its own terminator, so three consecutive FILED BY blocks yield
the 1st and the 3rd and silently drop the 2nd. Go's RE2 has no lookahead to
hold the delimiter back. Caught only because the fixture had THREE filers — two
would have looked correct. Replaced with: find every column-0 label offset,
slice between them.

Item 12 stays per-filer the way parser.py does it: read once from the body,
with the Fidelity override (CIK 315066) applied per filer rather than once for
the filing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0193ue9M5okF31PoPetXXBmL
