### PR TITLE
merge_panel: name the zero — items with no fund votes get a block label

### DIFF
--- a/skills/npx-ownership-panel/scripts/merge_panel.sas
+++ b/skills/npx-ownership-panel/scripts/merge_panel.sas
@@ -473,8 +473,31 @@ run;
 
 /* --- The join --------------------------------------------------------------
  * LEFT join from the panel: every panel item is kept, whether or not any fund
- * disclosed a vote on it. Items with no N-PX coverage get a single row with a
- * null block, so their absence is visible rather than silently dropped. */
+ * disclosed a vote on it. Items with no N-PX coverage get a single row labelled
+ * `&NO_FUND_VOTES.`, so their absence is visible rather than silently dropped.
+ *
+ * THE LABEL IS NOT COSMETIC. These rows were previously left with a NULL block,
+ * and a null in a categorical column reads as "missing" — which is the one thing
+ * they are not. Measured on the 2026-07-28 run: 26,924 such items, of which
+ * 26,804 have `votedfor > 0`, 24,392 a `tso`, 26,380 institutional ownership,
+ * mean turnout 65.8%. They are REAL shareholder votes on which no fund in the
+ * N-PX universe voted — a measured zero, and a fact about fund coverage rather
+ * than about the item.
+ *
+ * Blank invited exactly two wrong readings in review: that these were votes by
+ * funds the crosswalk failed to link (they are not — every fundid in the
+ * crosswalk already carries a block), and that they should therefore be netted
+ * against real cells (they should not — they carry NULL n_rows and no votes).
+ *
+ * DO NOT DROP THEM. For a mirror-voting counterfactual an item where no tracked
+ * fund voted is one where the counterfactual is a no-op. Deleting them selects
+ * on the outcome and inflates every pivotal-share statistic, because the deleted
+ * items are precisely those where the block could not have been pivotal.
+ *
+ * They are also NOT cells. n_rows is null, so exclude them from cell-grain
+ * aggregations — `where block ne "&NO_FUND_VOTES."` — and remember that
+ * count(distinct itemonagendaid) over this table is items-in-panel, not
+ * items-with-vote-data. The two differ by exactly this count. */
 proc sql;
     create table out.pass_npx as
         select a.*,
@@ -494,6 +517,8 @@ quit;
  * usable count rather than as a confident-looking split. */
 data out.pass_npx;
     set out.pass_npx;
+    /* Name the zero. See the note above the LEFT JOIN for why this is not blank. */
+    if missing(block) then block = "&NO_FUND_VOTES.";
     n_usable = sum(n_for, n_against, n_abstain);
     if n_usable > 0 then do;
         for_frac     = n_for     / n_usable;
@@ -512,14 +537,14 @@ run;
 proc sql;
     select count(*)                        as n_rows        format=comma14.,
            count(distinct itemonagendaid)  as n_items       format=comma14.,
-           sum(block is null)              as items_no_npx  format=comma14.,
+           sum(block = "&NO_FUND_VOTES.")  as items_no_npx  format=comma14.,
            sum(n_rows)                     as vote_rows     format=comma18.
     from out.pass_npx;
 
     select block,
            count(*)    as cells     format=comma12.,
            sum(n_rows) as vote_rows format=comma18.
-    from out.pass_npx where block is not null
+    from out.pass_npx where block ne "&NO_FUND_VOTES."
     group by block order by vote_rows desc;
 quit;
 

--- a/skills/npx-ownership-panel/scripts/pipeline_config.sas
+++ b/skills/npx-ownership-panel/scripts/pipeline_config.sas
@@ -153,6 +153,34 @@
  */
 %let SHARK_FILE = ;
 
+/* BLOCK SENTINELS. Two, and they mean different things — keeping them distinct is
+ * the point.
+ *
+ *   &UNLINKED.        (build_npx.sas) a FUND whose fundid is not in the crosswalk,
+ *                     so its votes exist but cannot be attributed to a block.
+ *   &NO_FUND_VOTES.   (merge_panel.sas) an ITEM on which no fund in the universe
+ *                     voted at all. There are no votes to attribute.
+ *
+ * The second was previously represented by a NULL block, which reads as "missing"
+ * — the one thing it is not. Measured 2026-07-28: 26,924 such items, 26,804 with
+ * `votedfor > 0`, mean turnout 65.8%. Real shareholder votes, zero fund
+ * participation: a measured zero and a fact about fund coverage, not the item.
+ *
+ * Both are $24-safe (block is `length $24` in every leg).
+ *
+ * CONSEQUENCE FOR ANALYSIS, stated because both readings were got wrong in review:
+ *   - `&NO_FUND_VOTES.` rows carry NULL n_rows. They are NOT cells; exclude them
+ *     from cell-grain aggregation.
+ *   - Do NOT drop them from the item panel. For a mirror-voting counterfactual an
+ *     item nobody tracked voted on is one where the counterfactual is a no-op.
+ *     Deleting them selects on the outcome and inflates every pivotal-share
+ *     statistic, because they are exactly the items where no block could be
+ *     pivotal.
+ *   - count(distinct itemonagendaid) over out.pass_npx is items-in-panel, not
+ *     items-with-vote-data. The two differ by exactly this count.
+ */
+%let NO_FUND_VOTES = __no_fund_votes__;
+
 /* MEASURED EFFECT of these two filters on the item frame, 2005-2025 (2026-07-25):
  *
  *   filters            distinct items   raw rows   fanout


### PR DESCRIPTION
merge_panel: name the zero — items with no fund votes get a block label

out.pass_npx gave items with no N-PX coverage a NULL block. The LEFT JOIN and its
comment were right — keep the item, make the absence visible — but a null in a
categorical column reads as "missing", which is the one thing these are not.

Measured on the 2026-07-28 run: 26,924 such items, of which 26,804 have
votedfor > 0, 24,392 a tso, 26,380 institutional ownership, mean turnout 65.8%.
They are REAL shareholder votes on which no fund in the universe voted — a
measured zero, and a fact about fund coverage rather than about the item.

Blank invited two wrong readings in review, in sequence:
  - that they were votes by funds the crosswalk failed to link. They are not:
    every fundid in the crosswalk already carries a block (21,145 active, 3,892
    index, 1,035 asset_owner, 614 passive = all 26,686), and funds without a
    crsp_fundno are still blocked.
  - that they should therefore be netted against real cells. They should not:
    n_rows is NULL on all 26,924 and the items are disjoint from the named-block
    items (588,203 + 26,924 = 615,127, overlap 0). Netting them halved an
    apparent gap that was correct at -53,555.

So the label is not cosmetic — it is the fix for a column whose null was being
read three different ways.

&NO_FUND_VOTES. is declared in pipeline_config.sas beside &UNLINKED., with the
distinction spelled out: UNLINKED is a FUND that cannot be attributed to a block;
NO_FUND_VOTES is an ITEM with no votes to attribute. Both $24-safe.

The config note also carries the two analysis rules, because both were got wrong:
these rows are not cells (exclude from cell-grain aggregation), and they must NOT
be dropped from the item panel — for a mirror-voting counterfactual an item
nobody tracked voted on is one where the counterfactual is a no-op, so deleting
them selects on the outcome and inflates every pivotal-share statistic.

VERIFIED on the grid, not just compiled: merge_panel re-run clean, orphans=0, 0
ERRORs, 26,924 rows labelled, 0 null blocks remaining, and the four named blocks
unchanged at 564,990 / 578,072 / 526,882 / 298,077 cells.

Note the frozen out.pass_npx digest changes — the block column now carries the
label. Re-freeze deliberately not done here; it is gated on the outstanding
reconciliation residual.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0193ue9M5okF31PoPetXXBmL
